### PR TITLE
Google Bad

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18215,7 +18215,6 @@
         "workbox-cacheable-response": "6.5.0",
         "workbox-core": "6.5.0",
         "workbox-expiration": "6.5.0",
-        "workbox-google-analytics": "6.5.0",
         "workbox-navigation-preload": "6.5.0",
         "workbox-precaching": "6.5.0",
         "workbox-range-requests": "6.5.0",
@@ -18334,17 +18333,6 @@
       "dependencies": {
         "idb": "^6.1.4",
         "workbox-core": "6.5.0"
-      }
-    },
-    "node_modules/workbox-google-analytics": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-6.5.0.tgz",
-      "integrity": "sha512-CHHh55wMNCc/BV1URrzEM2Zjgf6g2CV6QpAAc1pBRqaLY5755PeQZbp3o8KbJEM7YsC9mIBeQVsOkSKkGS30bg==",
-      "dependencies": {
-        "workbox-background-sync": "6.5.0",
-        "workbox-core": "6.5.0",
-        "workbox-routing": "6.5.0",
-        "workbox-strategies": "6.5.0"
       }
     },
     "node_modules/workbox-navigation-preload": {
@@ -31658,7 +31646,6 @@
         "workbox-cacheable-response": "6.5.0",
         "workbox-core": "6.5.0",
         "workbox-expiration": "6.5.0",
-        "workbox-google-analytics": "6.5.0",
         "workbox-navigation-preload": "6.5.0",
         "workbox-precaching": "6.5.0",
         "workbox-range-requests": "6.5.0",
@@ -31760,17 +31747,6 @@
       "requires": {
         "idb": "^6.1.4",
         "workbox-core": "6.5.0"
-      }
-    },
-    "workbox-google-analytics": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-6.5.0.tgz",
-      "integrity": "sha512-CHHh55wMNCc/BV1URrzEM2Zjgf6g2CV6QpAAc1pBRqaLY5755PeQZbp3o8KbJEM7YsC9mIBeQVsOkSKkGS30bg==",
-      "requires": {
-        "workbox-background-sync": "6.5.0",
-        "workbox-core": "6.5.0",
-        "workbox-routing": "6.5.0",
-        "workbox-strategies": "6.5.0"
       }
     },
     "workbox-navigation-preload": {

--- a/public/gtag.js
+++ b/public/gtag.js
@@ -1,5 +1,0 @@
-window.dataLayer = window.dataLayer || [];
-function gtag(){dataLayer.push(arguments);}
-gtag('js', new Date());
-
-gtag('config', 'UA-3953312-31');

--- a/public/index.html
+++ b/public/index.html
@@ -40,22 +40,13 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>Tarkov.dev</title>
-    <!-- <script data-ad-client="ca-pub-7039480870927391" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script> -->
     <meta name="monetization" content="$ilp.uphold.com/aJ7DYdH6Nbpf">
-    <link rel="preconnect" href="https://www.googletagmanager.com">
-    <link rel="preconnect" href="https://www.google-analytics.com">
     <link rel="preconnect" href="https://assets.tarkov.dev" crossorigin>
     <link rel="dns-prefetch" href="https://assets.tarkov.dev" >
   </head>
   <body>
     <div id="root"></div>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script defer src="%PUBLIC_URL%/gtag.js"></script>
-    <script defer src="https://www.googletagmanager.com/gtag/js?id=UA-3953312-31"></script>
-    <!-- //     window.dataLayer = window.dataLayer || [];
-    //     function gtag(){dataLayer.push(arguments);}
-    //     gtag('js', new Date());
-
-    //     gtag('config', 'UA-3953312-31'); -->
+    <!-- Matomo Analytics -->
+    <script defer src="%PUBLIC_URL%/matomo.js"></script>
   </body>
 </html>

--- a/public/matomo.js
+++ b/public/matomo.js
@@ -1,0 +1,12 @@
+
+var _paq = window._paq = window._paq || [];
+/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+_paq.push(['trackPageView']);
+_paq.push(['enableLinkTracking']);
+(function () {
+    var u = "https://wombatstats.com/";
+    _paq.push(['setTrackerUrl', u + 'matomo.php']);
+    _paq.push(['setSiteId', '23']);
+    var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
+    g.async = true; g.src = u + 'matomo.js'; s.parentNode.insertBefore(g, s);
+})();

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,2 @@
-# https://www.robotstxt.org/robotstxt.html
 User-agent: *
+Allow: /


### PR DESCRIPTION
This PR removes Google Analytics and uses a self-hosted instance of Matomo instead. We value the privacy of our users and do not want to use Google at all.