### PR TITLE
Go Direct to GraphCDN

### DIFF
--- a/scripts/build-sitemap.js
+++ b/scripts/build-sitemap.js
@@ -61,7 +61,7 @@ const addPath = (sitemap, url) => {
         sitemap = addPath(sitemap, `/items/${itemType.key}`);
     }
 
-    const allItems = await got('https://api.tarkov.dev/graphql?query={%20itemsByType(type:%20any){%20normalizedName%20}%20}', {
+    const allItems = await got('https://prod-api-tarkov-dev.graphcdn.app/graphql?query={%20itemsByType(type:%20any){%20normalizedName%20}%20}', {
         responseType: 'json',
     });
 

--- a/scripts/test-redirects.js
+++ b/scripts/test-redirects.js
@@ -8,7 +8,7 @@ const redirects = require('../workers-site/redirects.json');
 (async () => {
     let liveNames = [];
     try {
-        const response = await got.post('https://api.tarkov.dev/graphql', {
+        const response = await got.post('https://prod-api-tarkov-dev.graphcdn.app/graphql', {
             body: JSON.stringify({query: `{
                 itemsByType(type: any){
                     normalizedName

--- a/src/components/price-graph/index.js
+++ b/src/components/price-graph/index.js
@@ -16,7 +16,7 @@ function PriceGraph({ itemId, itemChange24 }) {
     const { status, data } = useQuery(
         `historical-price-${itemId}`,
         () =>
-            fetch('https://api.tarkov.dev/graphql', {
+            fetch('https://prod-api-tarkov-dev.graphcdn.app/graphql', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',

--- a/src/components/server-status/index.js
+++ b/src/components/server-status/index.js
@@ -8,7 +8,7 @@ function ServerStatus() {
     const { status, data } = useQuery(
         `server-status`,
         () =>
-            fetch('https://api.tarkov.dev/graphql', {
+            fetch('https://prod-api-tarkov-dev.graphcdn.app/graphql', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',

--- a/src/components/trader-reset-time/index.js
+++ b/src/components/trader-reset-time/index.js
@@ -34,7 +34,7 @@ function TraderResetTime({ trader, center = false }) {
     const { status, data } = useQuery(
         `traderTimer`,
         () =>
-            fetch('https://api.tarkov.dev/graphql', {
+            fetch('https://prod-api-tarkov-dev.graphcdn.app/graphql', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',

--- a/src/features/barters/do-fetch-barters.js
+++ b/src/features/barters/do-fetch-barters.js
@@ -62,7 +62,7 @@ const doFetchBarters = async () => {
         }`,
     });
 
-    const response = await fetch('https://api.tarkov.dev/graphql', {
+    const response = await fetch('https://prod-api-tarkov-dev.graphcdn.app/graphql', {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',

--- a/src/features/crafts/craftsSlice.js
+++ b/src/features/crafts/craftsSlice.js
@@ -78,7 +78,7 @@ export const fetchCrafts = createAsyncThunk('crafts/fetchCrafts', async () => {
     }`,
     });
 
-    const response = await fetch('https://api.tarkov.dev/graphql', {
+    const response = await fetch('https://prod-api-tarkov-dev.graphcdn.app/graphql', {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',

--- a/src/features/hideout/hideoutSlice.js
+++ b/src/features/hideout/hideoutSlice.js
@@ -28,7 +28,7 @@ export const fetchHideout = createAsyncThunk(
     }`,
         });
 
-        const response = await fetch('https://api.tarkov.dev/graphql', {
+        const response = await fetch('https://prod-api-tarkov-dev.graphcdn.app/graphql', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',

--- a/src/features/items/do-fetch-items.js
+++ b/src/features/items/do-fetch-items.js
@@ -63,7 +63,7 @@ const QueryBody = JSON.stringify({
 
 const doFetchItems = async (...a) => {
     const [itemData, itemGrids, itemProps] = await Promise.all([
-        fetch('https://api.tarkov.dev/graphql', {
+        fetch('https://prod-api-tarkov-dev.graphcdn.app/graphql', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',

--- a/src/features/settings/settingsSlice.js
+++ b/src/features/settings/settingsSlice.js
@@ -48,7 +48,7 @@ export const fetchTarkovTrackerProgress = createAsyncThunk(
     }`,
         });
 
-        const apiResponse = await fetch('https://api.tarkov.dev/graphql', {
+        const apiResponse = await fetch('https://prod-api-tarkov-dev.graphcdn.app/graphql', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',

--- a/src/pages/api-docs/index.js
+++ b/src/pages/api-docs/index.js
@@ -16,8 +16,8 @@ function APIDocs() {
             <h2>{t('About')}</h2>
             <div className="section-text-wrapper">
                 {t('The API is available on')}{' '}
-                <a href="https://api.tarkov.dev/graphql">
-                    https://api.tarkov.dev/graphql
+                <a href="https://prod-api-tarkov-dev.graphcdn.app/graphql">
+                    https://prod-api-tarkov-dev.graphcdn.app/graphql
                 </a>{' '}
                 <span>with a playground on</span>{' '}
                 <a href="https://api.tarkov.dev/___graphql">
@@ -100,7 +100,7 @@ function APIDocs() {
             <div className="example-wrapper">
                 <h3 id="browser-js">Browser JS {t('example')}</h3>
                 <SyntaxHighlighter language="javascript" style={atomOneDark}>
-                    {`fetch('https://api.tarkov.dev/graphql', {
+                    {`fetch('https://prod-api-tarkov-dev.graphcdn.app/graphql', {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
@@ -133,7 +133,7 @@ const query = gql\`
 }
 \`
 
-request('https://api.tarkov.dev/graphql', query).then((data) => console.log(data))`}
+request('https://prod-api-tarkov-dev.graphcdn.app/graphql', query).then((data) => console.log(data))`}
                 </SyntaxHighlighter>
             </div>
             <div className="example-wrapper">
@@ -142,7 +142,7 @@ request('https://api.tarkov.dev/graphql', query).then((data) => console.log(data
                     {`import requests
 
 def run_query(query):
-    response = requests.post('https://api.tarkov.dev/graphql', json={'query': query})
+    response = requests.post('https://prod-api-tarkov-dev.graphcdn.app/graphql', json={'query': query})
     if response.status_code == 200:
         return response.json()
     else:
@@ -178,7 +178,7 @@ require 'net/http'
 require 'uri'
 require 'json'
 
-uri = URI.parse("https://api.tarkov.dev/graphql")
+uri = URI.parse("https://prod-api-tarkov-dev.graphcdn.app/graphql")
 
 header = { "Content-Type": "application/json" }
 query = { "query": "{ itemsByName(name: \\"m855a1\\") {id name shortName } }" }
@@ -204,7 +204,7 @@ puts response.body`}
                     {`curl -X POST \
 -H "Content-Type: application/json" \
 -d '{"query": "{ itemsByName(name: \\"m855a1\\") {id name shortName } }"}' \
-https://api.tarkov.dev/graphql`}
+https://prod-api-tarkov-dev.graphcdn.app/graphql`}
                 </SyntaxHighlighter>
             </div>
             <div className="example-wrapper">
@@ -219,7 +219,7 @@ $query = '{
     shortName
   }
 }';
-$data = @file_get_contents('https://api.tarkov.dev/graphql', false, stream_context_create([
+$data = @file_get_contents('https://prod-api-tarkov-dev.graphcdn.app/graphql', false, stream_context_create([
   'http' => [
     'method' => 'POST',
     'header' => $headers,
@@ -251,7 +251,7 @@ class Scratch {
         HttpClient client = HttpClient.newBuilder().build();
         String query = "{\\"query\\": \\"{ itemsByName(name: \\\\\\"m855a1\\\\\\") {id name shortName } }\\"}";
         HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create("https://api.tarkov.dev/graphql"))
+                .uri(URI.create("https://prod-api-tarkov-dev.graphcdn.app/graphql"))
                 .header("Content-Type", "application/json")
                 .header("Accept", "application/json")
                 .POST(HttpRequest.BodyPublishers.ofString(query))
@@ -279,7 +279,7 @@ using (var httpClient = new HttpClient())
 {
 
     //Http response message
-    var httpResponse = await httpClient.PostAsJsonAsync("https://api.tarkov.dev/graphql", data);
+    var httpResponse = await httpClient.PostAsJsonAsync("https://prod-api-tarkov-dev.graphcdn.app/graphql", data);
 
     //Response content
     var responseContent = await httpResponse.Content.ReadAsStringAsync();
@@ -313,7 +313,7 @@ import (
 
 func main() {
     body := strings.NewReader(\`{"query": "{ itemsByName(name: \\"m855a1\\") {id name shortName } }"}\`)
-    req, err := http.NewRequest("POST", "https://api.tarkov.dev/graphql", body)
+    req, err := http.NewRequest("POST", "https://prod-api-tarkov-dev.graphcdn.app/graphql", body)
     if err != nil {
         log.Fatalln(err)
     }


### PR DESCRIPTION
# Go Direct to GraphCDN

In the case that it takes a long time for us to get a custom domain name (have our botched one released from Fastly through graphcdn) we can use this as an alternative.

This PR points all domain **on the website** (tarkov.dev) directly to our graphcdn origin which will cache graphql requests.

This will **not** cache hits directly to the `api.tarkov.dev/graphql` endpoint as that is still being routed through cloudflare. We can experiment with the branch that is deployed in this pull request to see how it works and use it as a potential option if we want to in the mean time while graphcdn releases our domain