### PR TITLE
Wipe length table updates

### DIFF
--- a/src/pages/wipe-length/index.js
+++ b/src/pages/wipe-length/index.js
@@ -9,7 +9,6 @@ import CenterCell from '../../components/center-cell';
 import wipeDetailsJson from '../../data/wipe-details.json';
 
 import './index.css';
-// import { VictoryBar, VictoryChart, VictoryTheme } from 'victory';
 
 // number or wipes to use when calculating the average
 const CountLastNumWipesForAverage = Infinity;
@@ -166,15 +165,7 @@ const WipeLength = (props) => {
                 <h1 className="center-title">
                     {t('Escape from Tarkov Wipe Length')}
                 </h1>
-                <DataTable columns={columns} data={data} disableSortBy={true} />
-                {/* <VictoryChart
-          theme={VictoryTheme.material}
-        >
-          <VictoryBar
-            horizontal={true}
-            data={graphData}
-          />
-        </VictoryChart> */}
+                {}
             </div>
         </React.Fragment>
     );

--- a/src/pages/wipe-length/index.js
+++ b/src/pages/wipe-length/index.js
@@ -49,7 +49,6 @@ for (let i = 0; i < wipeDetails.length; i += 1) {
 }
 
 // calculate average wipe length
-
 const calculateAverage = (wipeDatas) => {
     const endedWipes = wipeDatas.filter(({ ongoing }) => !ongoing);
     endedWipes.sort((a, b) => b.start.getTime() - a.start.getTime());
@@ -69,14 +68,15 @@ const calculateAverage = (wipeDatas) => {
 
 const lengthDaysAverage = calculateAverage(data);
 
-data.push({
-    name: `Average${
-        Number.isFinite(CountLastNumWipesForAverage)
-            ? ` last ${CountLastNumWipesForAverage} wipes`
-            : ''
-    }`,
-    lengthDays: lengthDaysAverage,
-});
+// Add average wipe length to the table
+// data.push({
+//     name: `Average${
+//         Number.isFinite(CountLastNumWipesForAverage)
+//             ? ` last ${CountLastNumWipesForAverage} wipes`
+//             : ''
+//     }`,
+//     lengthDays: lengthDaysAverage,
+// });
 
 data.reverse();
 
@@ -165,6 +165,11 @@ const WipeLength = (props) => {
                 <h1 className="center-title">
                     {t('Escape from Tarkov Wipe Length')}
                 </h1>
+                <div className="center-title">
+                <h3>Average Wipe Length</h3>
+                <p>{t(lengthDaysAverage)} Days 📆</p>
+                </div>
+                <DataTable columns={columns} data={data} disableSortBy={false} />
                 {}
             </div>
         </React.Fragment>


### PR DESCRIPTION
This pull request updates the wipe-length table to pull the average field out and put it at the top of the page. This allows the table to be sorted on different fields without looking all wonky.

## Examples

### Before

<img width="959" alt="image" src="https://user-images.githubusercontent.com/23362539/162637764-dd55a108-cb12-4f86-94f9-60ef9c740857.png">

### After

<img width="943" alt="image" src="https://user-images.githubusercontent.com/23362539/162637747-009272da-52d2-4ec4-b5d9-7fb2a7601754.png">
