### PR TITLE
Site Version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,7 @@ src/data/ammo.json
 src/data/contributors.json
 src/data/quests.json
 src/data/traders.json
+src/data/version.json
 public/sitemap.xml
 workers-site/index.js
 src/pages/guides/*

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "test": "react-scripts test --env=jsdom",
     "prettier": "prettier --write \"src/**/*.{js,jsx,ts,tsx,json,css,scss,md}\"",
     "eject": "react-scripts eject",
-    "prebuild": "node scripts/get-ammo-data.js && node scripts/get-traders.js && node scripts/get-quests.js && node scripts/update-props.js && node scripts/get-contributors.js && node scripts/build-sitemap.js && node scripts/build-guides.js",
+    "prebuild": "node scripts/get-version.js && node scripts/get-ammo-data.js && node scripts/get-traders.js && node scripts/get-quests.js && node scripts/update-props.js && node scripts/get-contributors.js && node scripts/build-sitemap.js && node scripts/build-guides.js",
     "postbuild": "node scripts/build-redirects.js",
     "stage": "npx rimraf build && npm run build && npm run preview",
     "preview": "npx serve build -l 3001 -s",

--- a/scripts/build-sitemap.js
+++ b/scripts/build-sitemap.js
@@ -9,7 +9,7 @@ const ammoData = require('../src/data/ammo.json');
 
 const standardPaths = [
     '',
-    // 'about',
+    'about',
     '/ammo',
     '/api',
     '/api-users',

--- a/scripts/get-version.js
+++ b/scripts/get-version.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+
+const got = require('got');
+
+const COMMIT_URL = 'https://api.github.com/repos/the-hideout/tarkov-dev/commits/main';
+
+const getVersion = async function getVersion(){
+    console.time(`Get version url ${COMMIT_URL}`);
+    try {
+        const response = await got(COMMIT_URL, {
+            responseType: 'json',
+            timeout: 5000,
+        }).json();
+        console.timeEnd(`Get version url ${COMMIT_URL}`);
+
+        return response;
+    } catch (responseError){
+        console.timeEnd(`Get version url ${COMMIT_URL}`);
+        console.error(responseError);
+    }
+
+    return false;
+};
+
+(async () => {
+    let response = false;
+
+    response = await getVersion();
+
+    console.log(response.sha);
+
+    const version = {
+        version: response.sha,
+    }
+
+    console.time('Write new data');
+    fs.writeFileSync(path.join(__dirname, '..', 'src', 'data', 'version.json'), JSON.stringify(version, null, 4));
+    console.timeEnd('Write new data');
+})()

--- a/scripts/get-version.js
+++ b/scripts/get-version.js
@@ -5,7 +5,7 @@ const got = require('got');
 
 const COMMIT_URL = 'https://api.github.com/repos/the-hideout/tarkov-dev/commits/main';
 
-const getVersion = async function getVersion(){
+const getVersion = async function getVersion() {
     console.time(`Get version url ${COMMIT_URL}`);
     try {
         const response = await got(COMMIT_URL, {
@@ -15,7 +15,7 @@ const getVersion = async function getVersion(){
         console.timeEnd(`Get version url ${COMMIT_URL}`);
 
         return response;
-    } catch (responseError){
+    } catch (responseError) {
         console.timeEnd(`Get version url ${COMMIT_URL}`);
         console.error(responseError);
     }
@@ -24,17 +24,26 @@ const getVersion = async function getVersion(){
 };
 
 (async () => {
-    let response = false;
+    try {
+        let response = false;
 
-    response = await getVersion();
+        response = await getVersion();
 
-    console.log(response.sha);
+        console.log(response.sha);
 
-    const version = {
-        version: response.sha,
+        const version = {
+            version: response.sha,
+        }
+
+        console.time('Write new data');
+        fs.writeFileSync(path.join(__dirname, '..', 'src', 'data', 'version.json'), JSON.stringify(version, null, 4));
+        console.timeEnd('Write new data');
+    } catch (error) {
+        console.error(error);
+        fs.writeFileSync(path.join(__dirname, '..', 'src', 'data', 'version.json'), JSON.stringify(
+            {
+                version: 'unknown'
+            }, null, 4
+        ));
     }
-
-    console.time('Write new data');
-    fs.writeFileSync(path.join(__dirname, '..', 'src', 'data', 'version.json'), JSON.stringify(version, null, 4));
-    console.timeEnd('Write new data');
 })()

--- a/src/components/footer/index.js
+++ b/src/components/footer/index.js
@@ -10,6 +10,10 @@ import { ReactComponent as DiscordIcon } from '../supporter/Discord.svg';
 import './index.css';
 import UkraineButton from '../ukraine-button';
 
+import rawVersion from '../../data/version.json';
+
+const version = rawVersion.version.slice(0, 7);
+
 function Footer() {
     const { t } = useTranslation();
 
@@ -131,6 +135,10 @@ function Footer() {
                 {t(
                     'Game content and materials are trademarks and copyrights of Battlestate Games and its licensors. All rights reserved.',
                 )}
+            </div>
+            <div className="copyright-wrapper">
+                {'version: '}
+                <a href="https://github.com/the-hideout/tarkov-dev/commits/main">{version}</a>
             </div>
         </div>
     );


### PR DESCRIPTION
# Site Version 🔢 

This pull request enables a site version based off a `commit sha` in the footer of each page. I personally like seeing what "commit" the version of a page I am viewing is tied into.

## Example 📸 

<img width="1721" alt="Screen Shot 2022-04-13 at 9 58 06 PM" src="https://user-images.githubusercontent.com/23362539/163298927-a0fec7e2-37b5-40f5-8a7c-c44bf63bffd9.png">

The `version: <sha>` at the bottom of the page is associated with the latest commit on GitHub for this repository. It is updated when the site is built and will not change until the site is redeployed. When clicking the commit sha you are linked to the commit history on GitHub.

