### PR TITLE
Fix `/about` path

### DIFF
--- a/scripts/build-sitemap.js
+++ b/scripts/build-sitemap.js
@@ -9,7 +9,7 @@ const ammoData = require('../src/data/ammo.json');
 
 const standardPaths = [
     '',
-    'about',
+    '/about',
     '/ammo',
     '/api',
     '/api-users',


### PR DESCRIPTION
The `/about` path is currently broken in the `sitemap.xml` file because it is missing a leading `/`