### PR TITLE
fix css attributes to properly display monospace fonts for code blocks

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -14,6 +14,7 @@ body {
         'Helvetica Neue', sans-serif;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    font-family: 'bender', Helvetica, sans-serif;
 }
 
 code {
@@ -22,7 +23,6 @@ code {
 }
 
 body * {
-    font-family: 'bender', Helvetica, sans-serif;
     box-sizing: border-box;
 }
 


### PR DESCRIPTION
# Code Monospace Fonts

This PR changes CSS attributes to properly display code blocks in monospace font

## Examples 📸 

**Before**:

![image](https://user-images.githubusercontent.com/23362539/171772075-e912beed-48a6-4509-b718-362e3480ea73.png)

**After**:

![image](https://user-images.githubusercontent.com/23362539/171772052-c2d411e1-9fd3-4f3a-9912-ced7b2a11faf.png)
