### PR TITLE
add a Discord footer to all pages

### DIFF
--- a/src/components/footer/index.css
+++ b/src/components/footer/index.css
@@ -39,3 +39,45 @@
         width: 20%;
     }
 }
+
+@keyframes discord {
+    0% {
+        height: 70px;
+        width: 250px;
+    }
+
+    100% {
+        height: 500px;
+        width: 350px;
+    }
+}
+
+@keyframes discord-c {
+    0% {
+        height: 500px;
+        width: 350px;
+    }
+
+    100% {
+        height: 70px;
+        width: 250px;
+    }
+}
+
+.discord {
+    animation-name: discord-c;
+    animation-duration: 2s;
+    animation-play-state: pause;
+    float: left;
+    height: 70px;
+    width: 250px;
+}
+
+.discord:hover {
+    height: 500px;
+    width: 350px;
+    float: left;
+    animation-name: discord;
+    animation-duration: 2s;
+    animation-play-state: pause;
+}

--- a/src/components/footer/index.js
+++ b/src/components/footer/index.js
@@ -125,6 +125,9 @@ function Footer() {
                         {t('Discord bot for your Discord')}
                     </a>
                 </p>
+                <p>
+                <iframe className='discord' title="discord-iframe" src="https://discord.com/widget?id=956236955815907388&theme=dark" allowtransparency="true" frameborder="0" sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"></iframe>
+                </p>
             </div>
             <div className="copyright-wrapper">
                 {t(


### PR DESCRIPTION
# Discord Footer

This pull request adds a Discord iFrame to the footer of all pages that links back to our development Discord server

## Example 📸 

![image](https://user-images.githubusercontent.com/23362539/171781551-66b85038-23dd-4df2-b403-fdd3812fb334.png)
