### PR TITLE
Tools in crafts profit

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -165,11 +165,6 @@ cite {
     font-size: 14px;
 }
 
-.price-wrapper-tool {
-    color: #0292c0;
-    font-size: 14px;
-}
-
 .page-headline-wrapper {
     display: flex;
     align-items: center;

--- a/src/App.css
+++ b/src/App.css
@@ -165,6 +165,11 @@ cite {
     font-size: 14px;
 }
 
+.price-wrapper-tool {
+    color: #0292c0;
+    font-size: 14px;
+}
+
 .page-headline-wrapper {
     display: flex;
     align-items: center;

--- a/src/components/cost-items-cell/index.css
+++ b/src/components/cost-items-cell/index.css
@@ -28,12 +28,6 @@
     margin-right: 10px;
 }
 
-.cost-item-wrapper img {
-    /* height: 34px;
-    width: 34px; */
-    border: 1px solid #4a5154;
-}
-
 img.barter-icon {
     border: 0;
     position: relative;

--- a/src/components/cost-items-cell/index.js
+++ b/src/components/cost-items-cell/index.js
@@ -14,6 +14,7 @@ function CostItemsCell({ costItems, craftId, barterId }) {
         <div className="cost-wrapper">
             {costItems.map((costItem, itemIndex) => {
 
+                // Check if the item is a tool
                 const isTool = costItem.attributes.type === "tool";
             
                 return (

--- a/src/components/cost-items-cell/index.js
+++ b/src/components/cost-items-cell/index.js
@@ -15,7 +15,7 @@ function CostItemsCell({ costItems, craftId, barterId }) {
             {costItems.map((costItem, itemIndex) => {
 
                 // Check if the item attribute is a tool
-                const isTool = costItem.attributes.type === "tool";
+                const isTool = costItem.attributes.some(element => element.type === "tool");
             
                 return (
                     <div

--- a/src/components/cost-items-cell/index.js
+++ b/src/components/cost-items-cell/index.js
@@ -10,6 +10,8 @@ import { toggleItem as toggleBarterItem } from '../../features/barters/bartersSl
 function CostItemsCell({ costItems, craftId, barterId }) {
     const dispatch = useDispatch();
 
+    const isTool = costItem.attributes.type === "tool";
+
     return (
         <div className="cost-wrapper">
             {costItems.map((costItem, itemIndex) => {
@@ -42,11 +44,12 @@ function CostItemsCell({ costItems, craftId, barterId }) {
                                 iconLink={`https://assets.tarkov.dev/${costItem.id}-icon.jpg`}
                                 height="34"
                                 width="34"
+                                isTool={isTool}
                             />
                         </div>
                         <div className="cost-item-text-wrapper">
                             <Link to={costItem.itemLink}>{costItem.name}</Link>
-                            <div className={`${costItem.attributes.type !== "tool" ? 'price-wrapper' : 'price-wrapper-tool'}`}>
+                            <div className={`${isTool ? 'price-wrapper-tool' : 'price-wrapper'}`}>
                                 <ItemCost
                                     alternatePrice={costItem.alternatePrice}
                                     alternatePriceSource={

--- a/src/components/cost-items-cell/index.js
+++ b/src/components/cost-items-cell/index.js
@@ -14,7 +14,7 @@ function CostItemsCell({ costItems, craftId, barterId }) {
         <div className="cost-wrapper">
             {costItems.map((costItem, itemIndex) => {
 
-                // Check if the item is a tool
+                // Check if the item attribute is a tool
                 const isTool = costItem.attributes.type === "tool";
             
                 return (

--- a/src/components/cost-items-cell/index.js
+++ b/src/components/cost-items-cell/index.js
@@ -10,11 +10,12 @@ import { toggleItem as toggleBarterItem } from '../../features/barters/bartersSl
 function CostItemsCell({ costItems, craftId, barterId }) {
     const dispatch = useDispatch();
 
-    const isTool = costItem.attributes.type === "tool";
-
     return (
         <div className="cost-wrapper">
             {costItems.map((costItem, itemIndex) => {
+
+                const isTool = costItem.attributes.type === "tool";
+            
                 return (
                     <div
                         key={`cost-item-${itemIndex}`}

--- a/src/components/cost-items-cell/index.js
+++ b/src/components/cost-items-cell/index.js
@@ -13,10 +13,6 @@ function CostItemsCell({ costItems, craftId, barterId }) {
     return (
         <div className="cost-wrapper">
             {costItems.map((costItem, itemIndex) => {
-
-                // Check if the item attribute is a tool
-                const isTool = costItem.attributes.some(element => element.type === "tool");
-            
                 return (
                     <div
                         key={`cost-item-${itemIndex}`}
@@ -25,7 +21,7 @@ function CostItemsCell({ costItems, craftId, barterId }) {
                         }`}
                         onClick={(event) => {
                             // Don't allow to toggle/disable tools
-                            if (isTool === true) {
+                            if (costItem.isTool === true) {
                                 return true;
                             }
                             // Don't hook A's
@@ -50,12 +46,12 @@ function CostItemsCell({ costItems, craftId, barterId }) {
                                 iconLink={`https://assets.tarkov.dev/${costItem.id}-icon.jpg`}
                                 height="34"
                                 width="34"
-                                isTool={isTool}
+                                isTool={costItem.isTool}
                             />
                         </div>
                         <div className="cost-item-text-wrapper">
                             <Link to={costItem.itemLink}>{costItem.name}</Link>
-                            <div className={`${isTool ? 'price-wrapper-tool' : 'price-wrapper'}`}>
+                            <div className={`${costItem.isTool ? 'price-wrapper-tool' : 'price-wrapper'}`}>
                                 <ItemCost
                                     alternatePrice={costItem.alternatePrice}
                                     alternatePriceSource={

--- a/src/components/cost-items-cell/index.js
+++ b/src/components/cost-items-cell/index.js
@@ -24,6 +24,10 @@ function CostItemsCell({ costItems, craftId, barterId }) {
                             costItem.count === 0 ? 'disabled' : ''
                         }`}
                         onClick={(event) => {
+                            // Don't allow to toggle/disable tools
+                            if (isTool === true) {
+                                return true;
+                            }
                             // Don't hook A's
                             if (event.target.nodeName === 'A') {
                                 return true;

--- a/src/components/cost-items-cell/index.js
+++ b/src/components/cost-items-cell/index.js
@@ -46,7 +46,7 @@ function CostItemsCell({ costItems, craftId, barterId }) {
                         </div>
                         <div className="cost-item-text-wrapper">
                             <Link to={costItem.itemLink}>{costItem.name}</Link>
-                            <div className={`${costItem.isTool === false ? 'price-wrapper' : 'price-wrapper-tool'}`}>
+                            <div className={`${costItem.attributes.type !== "tool" ? 'price-wrapper' : 'price-wrapper-tool'}`}>
                                 <ItemCost
                                     alternatePrice={costItem.alternatePrice}
                                     alternatePriceSource={

--- a/src/components/cost-items-cell/index.js
+++ b/src/components/cost-items-cell/index.js
@@ -46,7 +46,7 @@ function CostItemsCell({ costItems, craftId, barterId }) {
                         </div>
                         <div className="cost-item-text-wrapper">
                             <Link to={costItem.itemLink}>{costItem.name}</Link>
-                            <div className="price-wrapper">
+                            <div className={`${costItem.isTool === false ? 'price-wrapper' : 'price-wrapper-tool'}`}>
                                 <ItemCost
                                     alternatePrice={costItem.alternatePrice}
                                     alternatePriceSource={

--- a/src/components/crafts-table/index.css
+++ b/src/components/crafts-table/index.css
@@ -2,3 +2,12 @@
     color: #636363;
     font-size: 14px;
 }
+
+.price-wrapper-tool {
+    color: #0292c0;
+    font-size: 14px;
+}
+
+.table-image-tool {
+    border: 1px solid #0292c0;
+}

--- a/src/components/crafts-table/index.js
+++ b/src/components/crafts-table/index.js
@@ -236,7 +236,7 @@ function CraftTable(props) {
                         (craftRow.duration * (skills.crafting * 0.75)) / 100,
                 );
 
-                var costItemsWithoutTools = costItems.filter(costItem => costItem.isTool === false)
+                var costItemsWithoutTools = costItems.filter(costItem => costItem.attributes.type !== "tool")
                 costItemsWithoutTools.map(
                     (costItem) =>
                         (totalCost =

--- a/src/components/crafts-table/index.js
+++ b/src/components/crafts-table/index.js
@@ -236,7 +236,8 @@ function CraftTable(props) {
                         (craftRow.duration * (skills.crafting * 0.75)) / 100,
                 );
 
-                costItems.map(
+                var costItemsWithoutTools = costItems.filter(costItem => costItem.isTool === false)
+                costItemsWithoutTools.map(
                     (costItem) =>
                         (totalCost =
                             totalCost + costItem.price * costItem.count),

--- a/src/components/crafts-table/index.js
+++ b/src/components/crafts-table/index.js
@@ -236,7 +236,7 @@ function CraftTable(props) {
                         (craftRow.duration * (skills.crafting * 0.75)) / 100,
                 );
 
-                var costItemsWithoutTools = costItems.filter(costItem => costItem.attributes.type !== "tool")
+                var costItemsWithoutTools = costItems.filter(costItem => !costItem.attributes.some(element => element.type === "tool"))
                 costItemsWithoutTools.map(
                     (costItem) =>
                         (totalCost =

--- a/src/components/crafts-table/index.js
+++ b/src/components/crafts-table/index.js
@@ -236,7 +236,7 @@ function CraftTable(props) {
                         (craftRow.duration * (skills.crafting * 0.75)) / 100,
                 );
 
-                var costItemsWithoutTools = costItems.filter(costItem => !costItem.attributes.some(element => element.type === "tool"))
+                var costItemsWithoutTools = costItems.filter(costItem => costItem.isTool === false)
                 costItemsWithoutTools.map(
                     (costItem) =>
                         (totalCost =

--- a/src/components/reward-image/index.js
+++ b/src/components/reward-image/index.js
@@ -1,12 +1,12 @@
 import './index.css';
 
-function RewardImage({ count, iconLink, height = '64', width = '64' }) {
+function RewardImage({ count, iconLink, height = '64', width = '64', isTool = false }) {
     return (
         <div className="reward-image-wrapper">
             {count && <span className="reward-count-wrapper">{count}</span>}
             <img
                 alt=""
-                className="table-image"
+                className={isTool === false ? "table-image" : "table-image-tool"}
                 loading="lazy"
                 height={height}
                 width={width}

--- a/src/features/crafts/craftsSlice.js
+++ b/src/features/crafts/craftsSlice.js
@@ -119,6 +119,12 @@ const craftsSlice = createSlice({
             newCrafts = newCrafts.map((craft) => {
                 craft.requiredItems = craft.requiredItems.map(
                     (requiredItem) => {
+                        // Filter an item only if it's not a tool
+                        const isTool = costItem.attributes.some(element => element.type === "tool");
+                        if (isTool === true) {
+                            return requiredItem;
+                        }
+
                         if (requiredItem.item.id === action.payload.itemId) {
                             if (requiredItem.count === 0) {
                                 requiredItem.count = requiredItem.originalCount;

--- a/src/features/crafts/craftsSlice.js
+++ b/src/features/crafts/craftsSlice.js
@@ -23,12 +23,12 @@ export const fetchCrafts = createAsyncThunk('crafts/fetchCrafts', async () => {
               avg24hPrice
               lastLowPrice
               traderPrices {
-                  price
-                  currency
-                  priceRUB
-                  trader {
-                      name
-                  }
+                price
+                currency
+                priceRUB
+                trader {
+                  name
+                }
               }
               buyFor {
                 source
@@ -62,7 +62,7 @@ export const fetchCrafts = createAsyncThunk('crafts/fetchCrafts', async () => {
                 currency
                 priceRUB
                 trader {
-                    name
+                  name
                 }
               }
               buyFor {
@@ -77,7 +77,11 @@ export const fetchCrafts = createAsyncThunk('crafts/fetchCrafts', async () => {
                 priceRUB
                 currency
               }
-              isTool
+              attributes {
+                type
+                name
+                value
+              }
             }
             count
           }

--- a/src/features/crafts/craftsSlice.js
+++ b/src/features/crafts/craftsSlice.js
@@ -120,7 +120,7 @@ const craftsSlice = createSlice({
                 craft.requiredItems = craft.requiredItems.map(
                     (requiredItem) => {
                         // Filter an item only if it's not a tool
-                        const isTool = costItem.attributes.some(element => element.type === "tool");
+                        const isTool = requiredItem.attributes.some(element => element.type === "tool");
                         if (isTool === true) {
                             return requiredItem;
                         }

--- a/src/features/crafts/craftsSlice.js
+++ b/src/features/crafts/craftsSlice.js
@@ -77,13 +77,13 @@ export const fetchCrafts = createAsyncThunk('crafts/fetchCrafts', async () => {
                 priceRUB
                 currency
               }
-              attributes {
-                type
-                name
-                value
-              }
             }
             count
+            attributes {
+              type
+              name
+              value
+            }
           }
           source
           duration

--- a/src/features/crafts/craftsSlice.js
+++ b/src/features/crafts/craftsSlice.js
@@ -77,6 +77,7 @@ export const fetchCrafts = createAsyncThunk('crafts/fetchCrafts', async () => {
                 priceRUB
                 currency
               }
+              isTool
             }
             count
           }

--- a/src/modules/format-cost-items.js
+++ b/src/modules/format-cost-items.js
@@ -146,6 +146,10 @@ const formatCostItems = (
         if (freeFuel && fuelIds.includes(requiredItem.item.id)) {
             calculationPrice = 0;
         }
+        
+        let isTool = false;
+        if (requiredItem.attributes)
+            isTool = requiredItem.attributes.some(element => element.type === "tool");
 
         const returnData = {
             id: requiredItem.item.id,
@@ -167,6 +171,7 @@ const formatCostItems = (
                 'https://tarkov.dev/images/unknown-item-icon.jpg',
             wikiLink: requiredItem.item.wikiLink,
             itemLink: `/item/${requiredItem.item.normalizedName}`,
+            isTool: isTool,
         };
 
         return returnData;


### PR DESCRIPTION
This pull request removes tools from craft cost calculation but leaves them in the table so that the user can buy them for the best price available. Also colors with blue the tool image border and tool price.

p.s. I didn't test it as I don't have a debug environment right now.