### PR TITLE
Improve dogtag barter display

### DIFF
--- a/src/components/barters-table/index.js
+++ b/src/components/barters-table/index.js
@@ -15,6 +15,7 @@ import CostItemsCell from '../cost-items-cell';
 import formatCostItems from '../../modules/format-cost-items';
 import RewardCell from '../reward-cell';
 import capitalizeFirst from '../../modules/capitalize-first';
+import { isAnyDogtag, isBothDogtags } from '../../modules/dogtags';
 
 import './index.css';
 
@@ -135,6 +136,12 @@ function BartersTable(props) {
                     }
 
                     if (requiredItem.item.id === itemFilter) {
+                        return true;
+                    }
+                    if (isBothDogtags(itemFilter) && isAnyDogtag(requiredItem.item.id)) {
+                        return true;
+                    }
+                    if (isBothDogtags(requiredItem.item.id) && isAnyDogtag(itemFilter)) {
                         return true;
                     }
                 }

--- a/src/features/barters/do-fetch-barters.js
+++ b/src/features/barters/do-fetch-barters.js
@@ -37,36 +37,40 @@ const doFetchBarters = async () => {
             }
             requiredItems {
                 item {
-                id
-                name
-                normalizedName
-                iconLink
-                imageLink
-                wikiLink
-                avg24hPrice
-                lastLowPrice
-                traderPrices {
-                    priceRUB
-                    price
-                    currency
-                    trader {
-                        name
+                    id
+                    name
+                    normalizedName
+                    iconLink
+                    imageLink
+                    wikiLink
+                    avg24hPrice
+                    lastLowPrice
+                    traderPrices {
+                        priceRUB
+                        price
+                        currency
+                        trader {
+                            name
+                        }
+                    }
+                    buyFor {
+                        source
+                        priceRUB
+                        price
+                        currency
+                    }
+                    sellFor {
+                        source
+                        priceRUB
+                        price
+                        currency
                     }
                 }
-                buyFor {
-                    source
-                    priceRUB
-                    price
-                    currency
-                }
-                sellFor {
-                    source
-                    priceRUB
-                    price
-                    currency
-                }
-                }
                 count
+                attributes {
+                    name
+                    value
+                }
             }
             source
             }

--- a/src/modules/dogtags.js
+++ b/src/modules/dogtags.js
@@ -1,0 +1,11 @@
+export function isAnyDogtag(id) {
+    return id === '59f32bb586f774757e1e8442' || id === '59f32c3b86f77472a31742f0' || id === '5b9b9020e7ef6f5716480215';
+};
+
+export function isBothDogtags(id) {
+    return id === '5b9b9020e7ef6f5716480215';
+};
+
+/*export default {
+    isAnyDogtag, isBothDogtags
+};*/

--- a/src/modules/format-cost-items.js
+++ b/src/modules/format-cost-items.js
@@ -143,6 +143,14 @@ const formatCostItems = (
         );
         let calculationPrice = bestPrice.price;
 
+        let itemName = requiredItem.item.name;
+        const isDogTag = requiredItem.attributes && requiredItem.attributes.some(att => att.name === 'minLevel');
+        if (isDogTag) {
+            const minLevel = requiredItem.attributes.find(att => att.name === 'minLevel').value;
+            calculationPrice = calculationPrice * minLevel;
+            itemName = `${itemName} ≥ ${minLevel}`;
+        }
+
         if (freeFuel && fuelIds.includes(requiredItem.item.id)) {
             calculationPrice = 0;
         }
@@ -162,7 +170,7 @@ const formatCostItems = (
                               100
                       ).toFixed(2)
                     : requiredItem.count,
-            name: requiredItem.item.name,
+            name: itemName,
             price: calculationPrice,
             priceSource: bestPrice.source,
             alternatePriceSource: bestPrice.barter,


### PR DESCRIPTION
- Shows required tag level for each barter
- Shows required tag is BEAR, USEC, or either
- Shows correct sell-to-Therapist value as the cost of each tag, according to required tag level
- The item pages for all dog tag items show all items that tag can be used for