### PR TITLE
/loot-tier page improvements

### DIFF
--- a/src/components/filter/index.js
+++ b/src/components/filter/index.js
@@ -164,6 +164,11 @@ function ToggleFilter({ label, onChange, checked, tooltipContent, disabled }) {
 }
 
 const selectFilterStyle = {
+    multiValueLabel: (provided) => ({
+        ...provided,
+        color: '#E0DFD6',
+        padding: '0.1rem'
+    }),
     menu: (provided) => ({
         ...provided,
         backgroundColor: '#2d2d2f',
@@ -199,7 +204,7 @@ const selectFilterStyle = {
     }),
     multiValue: (provided) => ({
         ...provided,
-        backgroundColor: '#E5E5E5',
+        backgroundColor: '#998A65',
         color: '#E5E5E5',
     }),
 };

--- a/src/components/filter/index.js
+++ b/src/components/filter/index.js
@@ -204,7 +204,7 @@ const selectFilterStyle = {
     }),
     multiValue: (provided) => ({
         ...provided,
-        backgroundColor: '#998A65',
+        backgroundColor: '#5F553B',
         color: '#E5E5E5',
     }),
 };

--- a/src/pages/loot-tiers/index.js
+++ b/src/pages/loot-tiers/index.js
@@ -49,10 +49,9 @@ const filterOptions = [
         label: 'Wearable',
         default: true,
     },
-
     {
         value: 'gun',
-        label: 'Weapon',
+        label: 'Gun',
         default: true,
     },
 ];

--- a/src/pages/loot-tiers/index.js
+++ b/src/pages/loot-tiers/index.js
@@ -333,7 +333,7 @@ function LootTier(props) {
         >
             <div style={{ flexDirection: 'column', display: 'flex', flexWrap:'wrap', justifyContent: 'center', alignItems: 'center' }}>
                 <h1 style={{margin: '0.75rem', textAlign: 'center'}}>Loot Tiers</h1>
-                <p style={{margin: '0.75rem', textAlign: 'center'}}>Escape from Tarkov "loot tiers" - Ranking items in the game from most valuable, to least</p>
+                <p style={{margin: '0.75rem', textAlign: 'center'}}>Escape from Tarkov "loot tiers" - Ranking the most valuable items in the game</p>
             </div>
             <Filter fullWidth>
                 <ToggleFilter

--- a/src/pages/loot-tiers/index.js
+++ b/src/pages/loot-tiers/index.js
@@ -332,6 +332,10 @@ function LootTier(props) {
             }}
             key={'display-wrapper'}
         >
+            <div style={{ flexDirection: 'column', display: 'flex', flexWrap:'wrap', justifyContent: 'center', alignItems: 'center' }}>
+                <h1 style={{margin: '0.5em'}}>Loot Tiers</h1>
+                <p style={{margin: '0.5em'}}>Escape from Tarkov "loot tiers" - Ranking items in the game from most valuable, to least</p>
+            </div>
             <Filter fullWidth>
                 <ToggleFilter
                     label={t('Include Marked')}

--- a/src/pages/loot-tiers/index.js
+++ b/src/pages/loot-tiers/index.js
@@ -332,8 +332,8 @@ function LootTier(props) {
             key={'display-wrapper'}
         >
             <div style={{ flexDirection: 'column', display: 'flex', flexWrap:'wrap', justifyContent: 'center', alignItems: 'center' }}>
-                <h1 style={{margin: '0.5em'}}>Loot Tiers</h1>
-                <p style={{margin: '0.5em'}}>Escape from Tarkov "loot tiers" - Ranking items in the game from most valuable, to least</p>
+                <h1 style={{margin: '0.75rem', textAlign: 'center'}}>Loot Tiers</h1>
+                <p style={{margin: '0.75rem', textAlign: 'center'}}>Escape from Tarkov "loot tiers" - Ranking items in the game from most valuable, to least</p>
             </div>
             <Filter fullWidth>
                 <ToggleFilter


### PR DESCRIPTION
# `/loot-tier` page improvement

This pull request adds header and paragraph elements to the `/loot-tier` page. It also makes the labels more "color themed" to the site

## Examples 📸 

**Before**:

<img width="1792" alt="Screen Shot 2022-06-28 at 12 09 34 AM" src="https://user-images.githubusercontent.com/23362539/176105736-ace20395-ab90-4edd-b454-8c22e848253c.png">

**After**:

<img width="1792" alt="Screen Shot 2022-06-28 at 12 13 53 AM" src="https://user-images.githubusercontent.com/23362539/176106338-6148acd5-520f-4c30-8e19-83a8a26dbc48.png">

---

related: https://github.com/the-hideout/tarkov-dev/issues/81 - Adding `<h1>` and `<p>` tags should improve SEO for this page as well