### PR TITLE
add default language placeholder

### DIFF
--- a/src/pages/settings/index.js
+++ b/src/pages/settings/index.js
@@ -131,7 +131,7 @@ function Settings() {
             <div className="language-toggle-wrapper settings-group-wrapper">
                 <h2>{t('Language')}</h2>
                 <Select
-                    defaultValue='en'
+                    placeholder={i18n.language}
                     options={langOptions}
                     className="basic-multi-select"
                     classNamePrefix="select"


### PR DESCRIPTION
This PR adds a default label to the language switcher so it is not blank when you first load the page.

Resolves: https://github.com/the-hideout/tarkov-dev/issues/93