### PR TITLE
Add option to use lastLowPrices for calculating crafting profits

### DIFF
--- a/src/components/crafts-table/index.js
+++ b/src/components/crafts-table/index.js
@@ -31,7 +31,7 @@ import {
 } from '../../modules/format-duration';
 
 function CraftTable(props) {
-    const { selectedStation, freeFuel, nameFilter, itemFilter, showAll } =
+    const { selectedStation, freeFuel, nameFilter, itemFilter, showAll, averagePrices } =
         props;
     const dispatch = useDispatch();
     const { t } = useTranslation();
@@ -256,7 +256,7 @@ function CraftTable(props) {
                             craftRow.rewardItems[0].item.iconLink ||
                             'https://tarkov.dev/images/unknown-item-icon.jpg',
                         count: craftRow.rewardItems[0].count,
-                        value: 0,
+                        value: 0, 
                     },
                 };
 
@@ -274,17 +274,19 @@ function CraftTable(props) {
                     (bestTrade && bestTrade.priceRUB > tradeData.reward.value) ||
                     (bestTrade && !includeFlea)
                 ) {
-                    // console.log(barterRow.rewardItems[0].item.traderPrices);
                     tradeData.reward.value = bestTrade.priceRUB;
                     tradeData.reward.sellTo = bestTrade.trader.name;
                 }
 
+                const priceToUse = averagePrices === true ? 'avg24hPrice' : 'lastLowPrice';
+
                 if (!craftRow.rewardItems[0].item.types.includes('noFlea')) {
-                    tradeData.reward.value =
-                        craftRow.rewardItems[0].item.avg24hPrice;
+                        tradeData.reward.value =
+                        craftRow.rewardItems[0].item[priceToUse];
+                    
                     tradeData.reward.sellTo = t('Flea Market');
                     tradeData.fleaThroughput = Math.floor(
-                        (craftRow.rewardItems[0].item.avg24hPrice *
+                        (craftRow.rewardItems[0].item[priceToUse] *
                             craftRow.rewardItems[0].count) /
                             (craftDuration / 3600),
                     );
@@ -298,7 +300,7 @@ function CraftTable(props) {
                         tradeData.profit -
                         fleaMarketFee(
                             craftRow.rewardItems[0].item.basePrice,
-                            craftRow.rewardItems[0].item.avg24hPrice,
+                            craftRow.rewardItems[0].item[priceToUse],
                             craftRow.rewardItems[0].count,
                         ) *
                             feeReduction;
@@ -367,6 +369,7 @@ function CraftTable(props) {
         feeReduction,
         t,
         showAll,
+        averagePrices,
     ]);
 
     const columns = useMemo(

--- a/src/pages/crafts/index.js
+++ b/src/pages/crafts/index.js
@@ -35,6 +35,10 @@ function Crafts() {
     );
     const [nameFilter, setNameFilter] = useState(defaultQuery || '');
     const [freeFuel, setFreeFuel] = useState(false);
+    const [averagePrices, setAveragePrices] = useStateWithLocalStorage(
+        'averageCraftingPrices',
+        true,
+    );
     const [selectedStation, setSelectedStation] = useStateWithLocalStorage(
         'selectedStation',
         'top',
@@ -69,6 +73,18 @@ function Crafts() {
                         <div>
                             {t(
                                 'Shows all crafts regardless of what you have set in your settings',
+                            )}
+                        </div>
+                    }
+                />
+                <ToggleFilter
+                    checked={averagePrices}
+                    label={t('Average Prices')}
+                    onChange={(e) => setAveragePrices(!averagePrices)}
+                    tooltipContent={
+                        <div>
+                            {t(
+                                'Use average prices from the past 24 hours for profit calculations',
                             )}
                         </div>
                     }
@@ -137,6 +153,7 @@ function Crafts() {
             nameFilter={nameFilter}
             freeFuel={freeFuel}
             showAll={showAll}
+            averagePrices={averagePrices}
             selectedStation={selectedStation}
             key="crafts-page-crafts-table"
         />,


### PR DESCRIPTION
Adds a slider to allow for using lastLowPrice for profit calculations when looking at hideout profits. This is valuable earlier in the wipe when prices are more rapidly changing. 
![image](https://user-images.githubusercontent.com/1557581/177222148-0d2f3aaf-0305-410e-ab46-a5a7fbfc7e31.png)
