### PR TITLE
remove sentry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,15 +70,16 @@ jobs:
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
           command: pages publish build/ --project-name=tarkov-dev --branch=main
 
-      - name: Create Sentry release
-        uses: getsentry/action-release@744e4b262278339b79fb39c8922efcae71e98e39 # pin@v1.1.6
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: tarkov-dev
-          SENTRY_PROJECT: tarkovdev
-        with:
-          environment: production
-          sourcemaps: ./build/static/
+      # Uncomment to enable Sentry releases via CI
+      # - name: Create Sentry release
+      #   uses: getsentry/action-release@744e4b262278339b79fb39c8922efcae71e98e39 # pin@v1.1.6
+      #   env:
+      #     SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      #     SENTRY_ORG: tarkov-dev
+      #     SENTRY_PROJECT: tarkovdev
+      #   with:
+      #     environment: production
+      #     sourcemaps: ./build/static/
 
       - name: CDN Purge
         uses: jakejarvis/cloudflare-purge-action@eee6dba0236093358f25bb1581bd615dc8b3d8e3 # pin@v0.3.0

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import ReactDOM from 'react-dom';
 // import * as serviceWorker from './serviceWorker';
-import * as Sentry from '@sentry/react';
-import { BrowserTracing } from '@sentry/tracing';
+// import * as Sentry from '@sentry/react';
+// import { BrowserTracing } from '@sentry/tracing';
 import App from './App';
 import store from './store';
 import { Provider } from 'react-redux';
@@ -12,17 +12,18 @@ import ScrollToTop from './components/scroll-to-top';
 
 const queryClient = new QueryClient();
 
-if (
-    window.location.hostname !== 'localhost' &&
-    window.location.protocol !== 'file:'
-) {
-    Sentry.init({
-        dsn: 'https://4850423d8b93481d90de92ea48af9497@o1189140.ingest.sentry.io/6309411',
-        integrations: [new BrowserTracing()],
-        tracesSampleRate: 1.0,
-        release: process.env.npm_package_version,
-    });
-}
+// Uncomment to enable Sentry
+// if (
+//     window.location.hostname !== 'localhost' &&
+//     window.location.protocol !== 'file:'
+// ) {
+//     Sentry.init({
+//         dsn: 'https://4850423d8b93481d90de92ea48af9497@o1189140.ingest.sentry.io/6309411',
+//         integrations: [new BrowserTracing()],
+//         tracesSampleRate: 1.0,
+//         release: process.env.npm_package_version,
+//     });
+// }
 
 ReactDOM.render(
     <Provider store={store}>


### PR DESCRIPTION
# Remove Sentry 🔭 

This pull request removes Sentry from the main website. We are on the free tier of Sentry and I just discovered that the "transactions" that web clients send via Sentry, destroys our free tier limit. We almost never look at these metrics, and most of the errors are just noise any ways. Our free tier limits with Sentry would be better served on our other services.

Our free tier limit resets August 4th