### PR TITLE
fix langCode not formatting non US lang codes

### DIFF
--- a/src/modules/lang-helpers.js
+++ b/src/modules/lang-helpers.js
@@ -2,13 +2,6 @@
 import i18n from '../i18n';
 
 export async function langCode() {
-    // Get the user selected language
-    var language = i18n.language;
-
     // Convert to two digit language code
-    if (language === 'en-US') {
-        language = 'en';
-    }
-
-    return language;
+    return i18n.language.replace(/-[a-zA-Z]{2}/, "");
 };


### PR DESCRIPTION
Upon the introduction of #118 which allowed for user defined languages upon item fetch, did not account for language codes which were not exactly ``en-US``. This could lead to an unaccepted language argument being passed to the GraphQL API resulting in no items loading upon initial page load (i.e. if ``en-GB`` is returned by the user). 53c1f475c947e10bc02c1d11ee53364760c20955 resolves the aforementioned issue via regular expressions to replace any two characters followed by a hyphen.

Note that this has been tested only locally however as long as the API supports the user defined language there should be no concern.