### PR TITLE
add lua (luvit) example to api-docs

### DIFF
--- a/src/pages/api-docs/index.js
+++ b/src/pages/api-docs/index.js
@@ -132,6 +132,9 @@ function APIDocs() {
                 <li>
                     <HashLink to="#go">Golang</HashLink>
                 </li>
+                <li>
+                    <HashLink to="#luvit">Lua (Luvit)</HashLink>
+                </li>
             </ul>
             <div className="example-wrapper">
                 <h3 id="browser-js">Browser JS {t('example')}</h3>
@@ -363,6 +366,32 @@ func main() {
 
     defer resp.Body.Close()
 }`}
+                </SyntaxHighlighter>
+            </div>
+            <div className="example-wrapper">
+                <h3 id="luvit">
+                    <span>Lua (Luvit) {t('example')}</span>
+                    <cite>
+                        <span>Contributed by </span>
+                        <a href="https://github.com/AntwanR942">AntwanR942</a>
+                    </cite>
+                </h3>
+                <SyntaxHighlighter language="lua" style={atomOneDark}>
+                    {`local http = require "coro-http"
+
+coroutine.wrap(function()
+    local query = [[{"query": "{ items(name: "m855a1") {id name shortName } }"}]]
+    local headers = {
+        { "Content-Type", "application/json" },
+        { "Accept", "application/json" }
+    }
+    local res, body = http.request("POST", "https://api.tarkov.dev/graphql", headers, query)
+    if res.code ~= 200 then
+        error(res.message)
+    end
+
+    print(body)
+end)()`}
                 </SyntaxHighlighter>
             </div>
         </div>,


### PR DESCRIPTION
<!-- 

⚠️ IMPORTANT ⚠️

- Please fill in all sections [in brackets]
- Please read the collapsible sections if you need help
- All comments in fenced brackets like this one are comments and will not be displayed

Please delete any sections below which you do not need to fill out. You may keep the collapsibe "help" section

-->

# add lua (luvit) example to api-docs

Adds a lua example to the API page. Luvit is a combination of libuv and JIT for Lua similar to NodeJS for Javascript. I use it often personally and thought the odd person may appreciate an example. Of course the example code works and has been tested.

## Examples 📸

![Screenshot_1](https://user-images.githubusercontent.com/46630572/178376142-b13880c4-aa6f-44a3-8ba9-c593ca060f28.png)
![Screenshot_2](https://user-images.githubusercontent.com/46630572/178376145-4a7b4295-8a0a-4326-9643-3ced5c24edad.png)