### PR TITLE
Fix incorrect backpack sort by weight list

### DIFF
--- a/src/pages/items/backpacks/index.js
+++ b/src/pages/items/backpacks/index.js
@@ -135,7 +135,7 @@ function Backpacks(props) {
                         ).toFixed(2),
                         size: item.itemProperties.grid?.totalSize,
                         slots: item.slots,
-                        weight: `${item.itemProperties.Weight} kg`,
+                        weight: `${parseFloat(item.itemProperties.Weight).toFixed(2)} kg`,
                         wikiLink: item.wikiLink,
                         itemLink: `/item/${item.normalizedName}`,
                         notes: item.notes,


### PR DESCRIPTION

# Fix incorrect backpack sort by weight list

Fixing sorting backpacks by weight via formatting with a fixed length. 

## Description 🗒️

Sorting backpacks by weight were incorrect due to differing length of values. 

## Examples 📸

    1.4
    1.5
    1.45
    1.56
    1.57


## Related Issues 🔗

https://github.com/the-hideout/tarkov-dev/issues/153

---


