### PR TITLE
Fetch optimization

### DIFF
--- a/src/components/small-item-table/index.js
+++ b/src/components/small-item-table/index.js
@@ -169,6 +169,9 @@ function SmallItemTable(props) {
     });
 
     useEffect(() => {
+        if (!barterPrice)
+            return;
+        
         let timer = false;
         if (bartersStatus === 'idle') {
             dispatch(fetchBarters());
@@ -183,7 +186,7 @@ function SmallItemTable(props) {
         return () => {
             clearInterval(timer);
         };
-    }, [bartersStatus, dispatch]);
+    }, [bartersStatus, barterPrice, dispatch]);
 
     const data = useMemo(() => {
         let returnData = items
@@ -609,8 +612,7 @@ function SmallItemTable(props) {
                                         props.row.original.barters[0]?.source
                                     }
                                     requiredItems={
-                                        props.row.original.barters[0]
-                                            ?.requiredItems
+                                        props.row.original.barters[0]?.requiredItems
                                     }
                                 />
                             }


### PR DESCRIPTION
# Optimization of the homepage

Avoid `do_fetch_barters` when not needed

## Description 🗒️

With this, we will not do `do_fetch_barters` if the _fields/columns_ in `SmallItemTable` don't require them, like on the home page and other pages. Currently, only _containers_ and _armor_ use `barterPrice`.