### PR TITLE
Added weight column to items/armor

### DIFF
--- a/src/components/small-item-table/index.js
+++ b/src/components/small-item-table/index.js
@@ -145,6 +145,7 @@ function SmallItemTable(props) {
         maxPrice,
         bsgCategoryFilter,
         showContainedItems,
+        weight
     } = props;
     const dispatch = useDispatch();
     const { t } = useTranslation();
@@ -326,6 +327,7 @@ function SmallItemTable(props) {
                     repairability: `${materialRepairabilityMap[itemData.itemProperties.ArmorMaterial]}/6`,
                     stats: `${itemData.itemProperties.speedPenaltyPercent}% / ${itemData.itemProperties.mousePenalty}% / ${itemData.itemProperties.weaponErgonomicPenalty}`,
                     canHoldItems: itemData.canHoldItems,
+                    weight: itemData.weight
                 };
 
                 if (formattedItem.buyOnFleaPrice && formattedItem.buyOnFleaPrice.price > 0) {
@@ -747,6 +749,14 @@ function SmallItemTable(props) {
             });
         }
 
+        if (weight) {
+          useColumns.push({
+            Header: t('Weight (kg)'),
+            accessor: 'weight',
+            Cell: CenterCell,
+          });
+        }
+
         if (stats) {
             useColumns.push({
                 Header: (
@@ -783,6 +793,7 @@ function SmallItemTable(props) {
         repairability,
         stats,
         showContainedItems,
+        weight
     ]);
 
     let extraRow = false;

--- a/src/pages/items/armor/index.js
+++ b/src/pages/items/armor/index.js
@@ -109,6 +109,7 @@ function Armor(props) {
                 maxDurability
                 effectiveDurability
                 repairability
+                weight
                 stats
             />
         </div>,


### PR DESCRIPTION
<!-- 

⚠️ IMPORTANT ⚠️

- Please fill in all sections [in brackets]
- Please read the collapsible sections if you need help
- All comments in fenced brackets like this one are comments and will not be displayed

Please delete any sections below which you do not need to fill out. You may keep the collapsible "help" section

-->

# Added weight column to items/armor

Small addition to `components\small-item-table` and `pages\items\armor`.

## Description 🗒️

Modified the Small Item Table component, adding a weight column header and accessor along with a definition.
There is now a weight column in the armor listings, displaying the weight in kilograms for each armor (or armored rig).

In the future other this column can be added to a small item table's props by using the 'weight' accessor.

## Examples 📸
![Capture1](https://user-images.githubusercontent.com/46886675/181631086-00d77406-39f4-4db1-aaaf-7fb9461fbd60.PNG)

## Related Issues 🔗

<!-- OPTIONAL: If this PR fixes, closes, or resolves an issue; please link that issue here -->

resolves: #164

---

<details>
<summary> Expand for Help </summary>

- Have questions about the review or deployment process? View our [contributing docs](https://github.com/the-hideout/tarkov-dev/blob/main/CONTRIBUTING.md)
- Need additional help and want to chat in real time? Join our [community Discord](https://discord.gg/XPAsKGHSzH)

> By submitting this pull request, you agree to our [code of conduct](https://github.com/the-hideout/tarkov-dev/blob/main/CODE_OF_CONDUCT.md)

</details>
