### PR TITLE
Cleanup CI

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -30,14 +30,6 @@ jobs:
         with:
           ref: ${{ steps.branch-deploy.outputs.ref }}
 
-      - name: Install
-        if: ${{ steps.branch-deploy.outputs.continue == 'true' }}
-        run: npm ci
-
-      - name: Build
-        if: ${{ steps.branch-deploy.outputs.continue == 'true' }}
-        run: npm run build
-
       - name: deploy - dev
         id: dev-deploy
         if: ${{ steps.branch-deploy.outputs.continue == 'true' && steps.branch-deploy.outputs.noop != 'true' && steps.branch-deploy.outputs.environment == 'development' }}


### PR DESCRIPTION
# Cleanup CI 🧹 

This pull request removes redundant `npm install` and `npm build` jobs in the branch-deploy stage of CI. This is redundant because both these steps are run on each commit which has to pass before a `.deploy` can begin

Note: This should significantly speed up deployments

> Due to the way CI works, these changes will only take affect once this PR is merged