### PR TITLE
Fixed weapon price-per-slot calculation

### DIFF
--- a/src/pages/loot-tiers/index.js
+++ b/src/pages/loot-tiers/index.js
@@ -127,6 +127,17 @@ function LootTier(props) {
     const itemData = useMemo(() => {
         return items
             .map((item) => {
+                if (item.types.includes('gun')) {
+                  // Overrides guns' dimensions using their default height and width.
+                  // Fixes a bug where PPS was calculated using just a weapon receiver.
+                  item.height = item.properties.defaultHeight;
+                  item.width = item.properties.defaultWidth;
+                  item.slots = item.height * item.width;
+
+                  item.types = item.types.filter(
+                    (type) => type !== 'wearable');
+                }
+                
                 if (!hasFlea) {
                     return {
                         ...item,
@@ -141,11 +152,6 @@ function LootTier(props) {
                 if (fleaPrice <= item.traderPriceRUB) {
                     sellTo = item.traderName;
                 }
-
-                if (item.types.includes('gun'))
-                    item.types = item.types.filter(
-                        (type) => type !== 'wearable',
-                    );
 
                 return {
                     ...item,

--- a/src/pages/loot-tiers/index.js
+++ b/src/pages/loot-tiers/index.js
@@ -128,15 +128,15 @@ function LootTier(props) {
         return items
             .map((item) => {
                 if (item.types.includes('gun')) {
-                  // Overrides guns' dimensions using their default height and width.
-                  // Fixes a bug where PPS was calculated using just a weapon receiver.
-                  item.height = item.properties.defaultHeight;
-                  item.width = item.properties.defaultWidth;
-                  item.slots = item.height * item.width;
+                    // Overrides guns' dimensions using their default height and width.
+                    // Fixes a bug where PPS was calculated using just a weapon receiver.
+                    item.height = item.properties.defaultHeight;
+                    item.width = item.properties.defaultWidth;
+                    item.slots = item.height * item.width;
 
-                  item.types = item.types.filter(
-                    (type) => type !== 'wearable');
-                }
+                    item.types = item.types.filter(
+                      (type) => type !== 'wearable');
+                  }
                 
                 if (!hasFlea) {
                     return {

--- a/src/pages/loot-tiers/index.js
+++ b/src/pages/loot-tiers/index.js
@@ -135,7 +135,7 @@ function LootTier(props) {
                     item.slots = item.height * item.width;
 
                     item.types = item.types.filter(
-                      (type) => type !== 'wearable');
+                        (type) => type !== 'wearable');
                 }
                 
                 if (!hasFlea) {

--- a/src/pages/loot-tiers/index.js
+++ b/src/pages/loot-tiers/index.js
@@ -136,7 +136,7 @@ function LootTier(props) {
 
                     item.types = item.types.filter(
                       (type) => type !== 'wearable');
-                  }
+                }
                 
                 if (!hasFlea) {
                     return {


### PR DESCRIPTION
<!-- 

⚠️ IMPORTANT ⚠️

- Please fill in all sections [in brackets]
- Please read the collapsible sections if you need help
- All comments in fenced brackets like this one are comments and will not be displayed

Please delete any sections below which you do not need to fill out. You may keep the collapsibe "help" section

-->

# Loot Tier Weapon PPS Fix

Fixed a bug in `pages\loot-tiers` that caused price-per-slot calculations to be run on weapon receivers.

## Description 🗒️

When PPS calculations were run for the loot tiers, it was based just the weapon's receiver. 
This fix overrides weapon dimension values by using `defaultHeight` and `defaultWeight` properties from item-props.json.
For example, an M4A1 will be now treated as a 5x2 item instead of a 2x1 item.

As a side effect, some weapon icons look alot nicer and not as viscously squonched. 🙂

## Examples 📸

![Capture](https://user-images.githubusercontent.com/46886675/181970976-29d7eaad-60ea-492b-ae35-0f02b9753221.PNG)

## Related Issues 🔗

resolves: #80 

---

<details>
<summary> Expand for Help </summary>

- Have questions about the review or deployment process? View our [contributing docs](https://github.com/the-hideout/tarkov-dev/blob/main/CONTRIBUTING.md)
- Need additional help and want to chat in real time? Join our [community Discord](https://discord.gg/XPAsKGHSzH)

> By submitting this pull request, you agree to our [code of conduct](https://github.com/the-hideout/tarkov-dev/blob/main/CODE_OF_CONDUCT.md)

</details>
