### PR TITLE
Fix css of Tippy

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -182,12 +182,31 @@ cite {
 }
 
 div.tippy-box {
+    background-color: #2d2c2e;
     color: #c7c5b3;
     border-color: #4f4f4f;
     border-radius: 4px;
     border-style: solid;
     border-width: 3px;
     box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
+}
+
+div.tippy-box[data-placement^='top'] > .tippy-arrow::before {
+    border-top-color: #4f4f4f;
+    bottom: -10px;
+}
+
+div.tippy-box[data-placement^='bottom'] > .tippy-arrow::before {
+    border-bottom-color: #4f4f4f;
+    top: -10px;
+}
+
+div.tippy-box[data-placement^='left'] > .tippy-arrow::before {
+    border-left-color: #4f4f4f;
+}
+
+div.tippy-box[data-placement^='right'] > .tippy-arrow::before {
+    border-right-color: #4f4f4f;
 }
 
 @media screen and (min-width: 710px) {


### PR DESCRIPTION
# Fix css of Tippy

Now the arrow colour matches the border and the background colour matches the fileds

## Examples 📸

Before:
<img width="196" alt="Screenshot 2022-08-03 at 12 53 55" src="https://user-images.githubusercontent.com/10927011/182591996-edddffff-e5f0-4495-850b-353b6a6f6e80.png">

After:
<img width="198" alt="Screenshot 2022-08-03 at 12 54 02" src="https://user-images.githubusercontent.com/10927011/182592011-ba63b0fd-5ccf-42d9-a815-ca1140acbf2d.png">

---

<details>
<summary> Expand for Help </summary>

- Have questions about the review or deployment process? View our [contributing docs](https://github.com/the-hideout/tarkov-dev/blob/main/CONTRIBUTING.md)
- Need additional help and want to chat in real time? Join our [community Discord](https://discord.gg/XPAsKGHSzH)

> By submitting this pull request, you agree to our [code of conduct](https://github.com/the-hideout/tarkov-dev/blob/main/CODE_OF_CONDUCT.md)

</details>
