### PR TITLE
Load More Button

### DIFF
--- a/src/pages/start/index.css
+++ b/src/pages/start/index.css
@@ -65,6 +65,25 @@
     display: flex;
 }
 
+.load-more-wrapper {
+    margin-top: 1.25rem;
+    margin-bottom: .5rem;
+    display: block;
+    text-align: center;
+}
+
+.load-more-button {
+    padding-left: 1rem;
+    padding-right: 1rem;
+    border-radius: 5px;
+}
+
+.load-more-button:hover {
+    background-color: #6e5f43;
+    color: white;
+    cursor: pointer;
+  }
+
 @media screen and (min-width: 1220px) {
     .start-section-wrapper img {
         max-width: 256px;

--- a/src/pages/start/index.js
+++ b/src/pages/start/index.js
@@ -58,6 +58,10 @@ function Start() {
         [setNameFilter],
     );
 
+    const loadMore = event => {
+        console.log('clicked')
+    };
+
     return [
         <Helmet key={'loot-tier-helmet'}>
             <meta charSet="utf-8" />
@@ -83,12 +87,19 @@ function Start() {
                         maxItems={20}
                         nameFilter={nameFilter}
                         defaultRandom={true}
+                        autoScroll={false}
                         fleaValue
                         traderValue
                         instaProfit
                         hideBorders
                     />
                 </Suspense>
+
+                {/* Load More Button */}
+                <div className="load-more-wrapper">
+                    <button className="load-more-button" onClick={loadMore}>Load More</button>
+                </div>
+
             </div>
             <div className="start-section-wrapper">
                 <Suspense fallback={renderLoader()}>

--- a/src/pages/start/index.js
+++ b/src/pages/start/index.js
@@ -58,8 +58,9 @@ function Start() {
         [setNameFilter],
     );
 
+    const [loadMoreState, setLoadMoreState] = useState(false);
     const loadMore = event => {
-        console.log('clicked')
+        setLoadMoreState(current => !current);
     };
 
     return [
@@ -83,7 +84,7 @@ function Start() {
                     />
                 </Suspense>
                 <Suspense fallback={renderLoader()}>
-                    <SmallItemTable
+                    {!loadMoreState && [<SmallItemTable
                         maxItems={20}
                         nameFilter={nameFilter}
                         defaultRandom={true}
@@ -92,14 +93,25 @@ function Start() {
                         traderValue
                         instaProfit
                         hideBorders
-                    />
+                    />,
+                    <div className="load-more-wrapper">
+                        <button id="load-more-button" className="load-more-button" onClick={loadMore}>Load More</button>
+                    </div>
+                    ]}
+
+                    {loadMoreState && (
+                        <SmallItemTable
+                            maxItems={20}
+                            nameFilter={nameFilter}
+                            defaultRandom={true}
+                            autoScroll={true}
+                            fleaValue
+                            traderValue
+                            instaProfit
+                            hideBorders
+                        />
+                    )}
                 </Suspense>
-
-                {/* Load More Button */}
-                <div className="load-more-wrapper">
-                    <button className="load-more-button" onClick={loadMore}>Load More</button>
-                </div>
-
             </div>
             <div className="start-section-wrapper">
                 <Suspense fallback={renderLoader()}>


### PR DESCRIPTION
# Load More Button

This pull request adds a `Load More` button to the home page. This gives users an option to toggle infinity load of items rather than just having that option enabled by default

## Example 📸

<img width="1055" alt="Screen Shot 2022-08-15 at 10 15 25 AM" src="https://user-images.githubusercontent.com/23362539/184673472-4b2bd1a5-7037-41aa-84ab-b3be9505e78a.png">
 