### PR TITLE
Fix expanded rows

### DIFF
--- a/src/components/data-table/index.css
+++ b/src/components/data-table/index.css
@@ -67,7 +67,7 @@ td.data-cell:last-child {
 }
 
 .data-table tbody tr.expanded td {
-    background-color: #1b1919;
+    background-color: #242324;
 }
 
 .arrow-icon,

--- a/src/components/data-table/index.js
+++ b/src/components/data-table/index.js
@@ -99,10 +99,10 @@ function DataTable({
             const tableProps = row.getRowProps();
 
             tableProps.className = `${
-                row.isExpanded || row.depth === 1 ? 'expanded' : ''
+                row.depth >= 1 ? 'expanded' : ''
             }`;
             return (
-                <tr key={i} {...tableProps}>
+                <tr key={row.original.id} {...tableProps}>
                     {row.cells.map((cell) => {
                         return (
                             <td

--- a/src/pages/items/pistol-grips/index.js
+++ b/src/pages/items/pistol-grips/index.js
@@ -224,7 +224,6 @@ function PistolGrips(props) {
                 columns={columns}
                 items={displayItems}
                 traderPrice
-                maxItems={50}
                 autoScroll
             />
 


### PR DESCRIPTION
# Fix expanded rows

Now expanded rows have good visibility.
Removed limit of 50 pistol grips.

## Examples 📸

From:
<img width="1211" alt="Screenshot 2022-08-23 at 18 49 59" src="https://user-images.githubusercontent.com/10927011/186216595-a18f6bfe-d3a3-4107-9815-35167c2fa03f.png">

To:
<img width="1207" alt="Screenshot 2022-08-23 at 18 49 28" src="https://user-images.githubusercontent.com/10927011/186216648-2e7bdeca-6460-4f7e-82d7-f082d810978d.png">
