### PR TITLE
fix display of craft ingredients items cost

### DIFF
--- a/src/components/crafts-table/index.css
+++ b/src/components/crafts-table/index.css
@@ -1,6 +1,10 @@
-.duration-wrapper {
+.duration-wrapper, .finish-wrapper {
     color: #636363;
     font-size: 14px;
+}
+
+.finish-wrapper {
+    cursor: pointer;
 }
 
 .price-wrapper-tool {

--- a/src/components/crafts-table/index.js
+++ b/src/components/crafts-table/index.js
@@ -375,7 +375,9 @@ function CraftTable(props) {
                             <div className="duration-wrapper">
                                 {getDurationDisplay(value * 1000)}
                             </div>
-                            <div className="duration-wrapper">
+                            <div className="finish-wrapper" title={t('Start now')} onClick={((e) => {
+                                e.target.innerText = getFinishDisplay(value * 1000);
+                            })}>
                                 {getFinishDisplay(value * 1000)}
                             </div>
                         </CenterCell>

--- a/src/modules/format-cost-items.js
+++ b/src/modules/format-cost-items.js
@@ -199,6 +199,7 @@ const formatCostItems = (
                     : requiredItem.count,
             name: itemName,
             price: calculationPrice,
+            priceRUB: calculationPrice,
             priceType: bestPrice.type,
             vendor: bestPrice.vendor,
             priceDetails: bestPrice.barter,


### PR DESCRIPTION
Fixes the display of the cost of ingredient items for crafts.

Also adds the ability to click on the finish time of a craft to refresh it as if the craft started at the moment clicked.