### PR TITLE
Hide built hideout modules and completed quests

### DIFF
--- a/src/components/items-for-hideout/index.js
+++ b/src/components/items-for-hideout/index.js
@@ -1,13 +1,16 @@
 import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
 import { useHideoutQuery } from '../../features/hideout/queries';
 
 import './index.css';
 
 function ItemsForHideout(props) {
-    const { itemFilter } = props;
+    const { itemFilter, showAll } = props;
     const { t } = useTranslation();
     const { data: hideout } = useHideoutQuery();
+    const settings = useSelector((state) => state.settings);
 
     // Data manipulation section
     const data = useMemo(() => {
@@ -45,11 +48,24 @@ function ItemsForHideout(props) {
     //     </div>
     // }
 
+    const unbuilt = useMemo(() => {
+        return data.filter(module => settings[module.normalizedName] < module.level);
+    }, [data, settings]);
+
     let extraRow = false;
 
     if (data.length <= 0) {
         extraRow = t('No hideout modules requires this item');
+    } else if (unbuilt.length !== data.length && !showAll) {
+        extraRow = (
+            <>
+                {t('No unbuilt hideout moduels for selected filters but some were hidden by ')}<Link to="/settings/">{t('your settings')}</Link>
+            </>
+        );
     }
+
+    let displayList = unbuilt;
+    if (showAll) displayList = data;
 
     return (
         <div className="table-wrapper">
@@ -71,7 +87,7 @@ function ItemsForHideout(props) {
                             </td>
                         </tr>
                     )}
-                    {data.map((item, k) => {
+                    {displayList.map((item, k) => {
                         return (
                             <tr key={k} className="hideout-item-list-row">
                                 <td className="hideout-item-list-column">

--- a/src/components/items-for-hideout/index.js
+++ b/src/components/items-for-hideout/index.js
@@ -65,7 +65,8 @@ function ItemsForHideout(props) {
     }
 
     let displayList = unbuilt;
-    if (showAll) displayList = data;
+    if (showAll)
+        displayList = data;
 
     return (
         <div className="table-wrapper">

--- a/src/components/quests-list/index.css
+++ b/src/components/quests-list/index.css
@@ -59,4 +59,5 @@
 .item-quest-headline-wrapper h2 {
     flex-grow: 1;
     margin: 0;
+    padding: 20px 0;
 }

--- a/src/components/quests-list/index.css
+++ b/src/components/quests-list/index.css
@@ -49,3 +49,14 @@
 .quest-link-wrapper a {
     display: flex;
 }
+
+.item-quest-headline-wrapper {
+    margin-top: 20px;
+    align-items: center;
+    display: flex;
+}
+
+.item-quest-headline-wrapper h2 {
+    flex-grow: 1;
+    margin: 0;
+}

--- a/src/components/quests-list/index.js
+++ b/src/components/quests-list/index.js
@@ -10,8 +10,6 @@ import './index.css';
 const getQuestList = (questList, t, showAll, settings) => {
     let extraRow = false;
 
-    console.log(questList);
-    console.log(settings);
     const shownQuests = questList.filter(quest => showAll || !settings.completedQuests.some(stringId => parseInt(stringId) === quest.tarkovDataId));
     console.log(shownQuests);
     if (questList.length <= 0) {

--- a/src/components/quests-list/index.js
+++ b/src/components/quests-list/index.js
@@ -1,14 +1,27 @@
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
+import { useSelector } from 'react-redux';
 
+import { Filter, ToggleFilter } from '../../components/filter';
 import QuestItemsCell from '../quest-items-cell';
 import './index.css';
 
-const getQuestList = (questList, t) => {
+const getQuestList = (questList, t, showAll, settings) => {
     let extraRow = false;
 
+    console.log(questList);
+    console.log(settings);
+    const shownQuests = questList.filter(quest => showAll || !settings.completedQuests.some(stringId => parseInt(stringId) === quest.tarkovDataId));
+    console.log(shownQuests);
     if (questList.length <= 0) {
         extraRow = t('No quest requires this item');
+    } else if (questList.length !== shownQuests.length) {
+        extraRow = (
+            <>
+                {t('Some completed quests hidden by ')}<Link to="/settings/">{t('your settings')}</Link>
+            </>
+        );
     }
 
     return (
@@ -26,7 +39,7 @@ const getQuestList = (questList, t) => {
                             <td colSpan={2}>{extraRow}</td>
                         </tr>
                     )}
-                    {questList.map((questData) => {
+                    {shownQuests.map((questData) => {
                         return (
                             <tr key={`quest-list-${questData.id}`}>
                                 <td>
@@ -68,12 +81,38 @@ const getQuestList = (questList, t) => {
 function QuestsList(props) {
     const { itemQuests } = props;
     const { t } = useTranslation();
+    const [showAllQuests, setShowAllQuests] = useState(false);
+    const settings = useSelector((state) => state.settings);
     let title = t('Quests Requiring');
     if (itemQuests.length > 0 && itemQuests[0].rewardItems) title = t('Quests Providing');
+    let toggleFilter = '';
+    if (settings.completedQuests?.length > 0) toggleFilter = (
+        <Filter>
+            <ToggleFilter
+                checked={showAllQuests}
+                label={t('Show completed')}
+                onChange={(e) =>
+                    setShowAllQuests(!showAllQuests)
+                }
+                tooltipContent={
+                    <div>
+                        {t(
+                            'Shows all quests regardless of if you\'ve completed them',
+                        )}
+                    </div>
+                }
+            />
+        </Filter>
+    );
     return (
         <div>
-            <h2>{title}</h2>
-            {getQuestList(itemQuests, t)}
+            <div className="item-quest-headline-wrapper">
+                <h2>
+                    {title}
+                </h2>
+                {toggleFilter}
+            </div>
+            {getQuestList(itemQuests, t, showAllQuests, settings)}
         </div>
     );
 }

--- a/src/components/quests-list/index.js
+++ b/src/components/quests-list/index.js
@@ -11,7 +11,6 @@ const getQuestList = (questList, t, showAll, settings) => {
     let extraRow = false;
 
     const shownQuests = questList.filter(quest => showAll || !settings.completedQuests.some(stringId => parseInt(stringId) === quest.tarkovDataId));
-    console.log(shownQuests);
     if (questList.length <= 0) {
         extraRow = t('No quest requires this item');
     } else if (questList.length !== shownQuests.length) {

--- a/src/modules/format-cost-items.js
+++ b/src/modules/format-cost-items.js
@@ -117,6 +117,7 @@ function getCheapestItemPriceWithBarters(item, barters, settings, allowAllSource
  
     if (bestBarter && (!bestPrice.price || barterTotalCost < bestPrice.price)) {
         bestPrice.price = barterTotalCost;
+        bestPrice.priceRUB = barterTotalCost;
         bestPrice.type = 'barter';
         bestPrice.barter = bestBarter;
         bestPrice.vendor = {

--- a/src/pages/item/index.css
+++ b/src/pages/item/index.css
@@ -172,7 +172,8 @@
 
 .item-crafts-headline-wrapper,
 .item-barters-headline-wrapper,
-.item-contents-headline-wrapper {
+.item-contents-headline-wrapper,
+.item-hideout-headline-wrapper {
     margin-top: 20px;
     align-items: center;
     display: flex;
@@ -180,7 +181,8 @@
 
 .item-crafts-headline-wrapper h2,
 .item-barters-headline-wrapper h2,
-.item-contents-headline-wrapper h2 {
+.item-contents-headline-wrapper h2,
+.item-hideout-headline-wrapper h2 {
     flex-grow: 1;
     margin: 0;
 }

--- a/src/pages/item/index.css
+++ b/src/pages/item/index.css
@@ -173,7 +173,8 @@
 .item-crafts-headline-wrapper,
 .item-barters-headline-wrapper,
 .item-contents-headline-wrapper,
-.item-hideout-headline-wrapper {
+.item-hideout-headline-wrapper,
+.item-quest-headline-wrapper {
     margin-top: 20px;
     align-items: center;
     display: flex;
@@ -182,7 +183,8 @@
 .item-crafts-headline-wrapper h2,
 .item-barters-headline-wrapper h2,
 .item-contents-headline-wrapper h2,
-.item-hideout-headline-wrapper h2 {
+.item-hideout-headline-wrapper h2,
+.item-quest-headline-wrapper h2 {
     flex-grow: 1;
     margin: 0;
 }

--- a/src/pages/item/index.js
+++ b/src/pages/item/index.js
@@ -82,6 +82,7 @@ function Item() {
     const [showAllCrafts, setShowAllCrafts] = useState(false);
     const [showAllBarters, setShowAllBarters] = useState(false);
     const [showAllContainedItemSources, setShowAllContainedItemSources] = useState(false);
+    const [showAllHideoutStations, setShowAllHideoutStations] = useState(false);
 
     const { data: currentItemByNameData, status: itemStatus } =
         useItemByNameQuery(itemName);
@@ -932,11 +933,29 @@ function Item() {
                 )}
                 {usedInHideout && (
                     <div>
-                        <h2>
-                            {t('Hideout modules needing')} {currentItemData.name}
-                        </h2>
+                        <div className="item-crafts-headline-wrapper">
+                            <h2>
+                                {t('Hideout modules needing')} {currentItemData.name}
+                            </h2>
+                            <Filter>
+                                <ToggleFilter
+                                    checked={showAllHideoutStations}
+                                    label={t('Show built')}
+                                    onChange={(e) =>
+                                        setShowAllHideoutStations(!showAllHideoutStations)
+                                    }
+                                    tooltipContent={
+                                        <div>
+                                            {t(
+                                                'Shows all modules regardless of what you have set in your settings',
+                                            )}
+                                        </div>
+                                    }
+                                />
+                            </Filter>
+                        </div>
                         <Suspense fallback={<div>{t('Loading...')}</div>}>
-                            <ItemsForHideout itemFilter={currentItemData.id} />
+                            <ItemsForHideout itemFilter={currentItemData.id} showAll={showAllHideoutStations} />
                         </Suspense>
                     </div>
                 )}


### PR DESCRIPTION
Item detail pages currently show all hideout modules regardless of whether the user has already built the module. This changes it so that built modules are hidden by default, but the user can display them with the toggle similar to how the crafts and barters tables work:
![image](https://user-images.githubusercontent.com/35779878/186683653-675381ec-93f6-4383-886c-b5cdc6aef810.png)
![image](https://user-images.githubusercontent.com/35779878/186683701-29bb96f1-d975-4988-8bfc-2f2822b3a133.png)

Also allows for showing and hiding of quests requiring or providing items, depending on quest completion:
![image](https://user-images.githubusercontent.com/35779878/186704627-7a4a1223-2ad2-4447-acdb-39409657a6df.png)
