### PR TITLE
Loot tier item real size

### DIFF
--- a/src/components/item-grid/Item.jsx
+++ b/src/components/item-grid/Item.jsx
@@ -30,18 +30,19 @@ function Item(props) {
 
     let imgSrc = props.src;
 
-    const gridSize = `${props.width}x${props.height}`;
-
-    if (props.width > props.height && !sizesNotToRotate.includes(gridSize)) {
-        imgSrc = `//images.weserv.nl/?url=${encodeURIComponent(imgSrc)}&ro=-90`;
-    } else if (sizesToAlwaysRotate.includes(gridSize)) {
-        imgSrc = `//images.weserv.nl/?url=${encodeURIComponent(imgSrc)}&ro=-90`;
-    }
+    //const gridSize = `${props.width}x${props.height}`;
+    //
+    // if (props.width > props.height && !sizesNotToRotate.includes(gridSize)) {
+    //     imgSrc = `//images.weserv.nl/?url=${encodeURIComponent(imgSrc)}&ro=-90`;
+    // } else if (sizesToAlwaysRotate.includes(gridSize)) {
+    //     imgSrc = `//images.weserv.nl/?url=${encodeURIComponent(imgSrc)}&ro=-90`;
+    // }
 
     return (
         <a
             href={props.itemLink}
-            className={`grid-item grid-item-${props.width}x${props.height}`}
+            className={`grid-item`}
+            style={{gridRowEnd: `span ${props.height}`, gridColumnEnd: `span ${props.width}`}}
             onClick={handleClick}
         >
             <ItemTooltip

--- a/src/components/item-grid/Item.jsx
+++ b/src/components/item-grid/Item.jsx
@@ -3,18 +3,18 @@ import { useCallback } from 'react';
 import ItemTooltip from './ItemTooltip';
 import ItemIcon from './ItemIcon';
 
-const sizesNotToRotate = [
-    '3x2',
-    '4x2',
-    '4x1',
-    '5x1',
-    '5x2',
-    '5x3',
-    '6x1',
-    '7x1',
-];
+// const sizesNotToRotate = [
+//     '3x2',
+//     '4x2',
+//     '4x1',
+//     '5x1',
+//     '5x2',
+//     '5x3',
+//     '6x1',
+//     '7x1',
+// ];
 
-const sizesToAlwaysRotate = ['2x3'];
+// const sizesToAlwaysRotate = ['2x3'];
 
 function Item(props) {
     const { item, onClick } = props;

--- a/src/features/items/do-fetch-items.js
+++ b/src/features/items/do-fetch-items.js
@@ -500,25 +500,30 @@ const doFetchItems = async () => {
     for (const item of allItems) {
         if (item.types.includes('gun') && item.containsItems) {
             item.traderPrices = item.traderPrices.map((localTraderPrice) => {
-                if (localTraderPrice.source === 'fleaMarket') {
+                if (localTraderPrice.trader.normalizedName === 'flea-market') {
                     return localTraderPrice;
                 }
 
                 localTraderPrice.price = item.containsItems.reduce(
                     (previousValue, currentValue) => {
-                        const partPrice = allItems.find(it => it.id === currentValue.item.id).traderPrices.find(
-                            (innerTraderPrice) =>
-                                innerTraderPrice.name === localTraderPrice.name,
-                        );
+                        const part = allItems.find(innerItem => innerItem.id === currentValue.item.id);
+                        const partFromSameTrader = part.traderPrices.find(innerTraderPrice => innerTraderPrice.trader.normalizedName === localTraderPrice.trader.normalizedName);
 
-                        if (!partPrice) {
+                        if (!partFromSameTrader) {
                             return previousValue;
                         }
 
-                        return partPrice.price + previousValue;
+                        return partFromSameTrader.price + previousValue;
                     },
                     localTraderPrice.price,
                 );
+                
+                if (localTraderPrice.currency === "USD") {
+                    localTraderPrice.priceRUB = localTraderPrice.price * 99.77;
+                }
+                else {
+                    localTraderPrice.priceRUB = localTraderPrice.price;
+                }
 
                 return localTraderPrice;
             });
@@ -530,19 +535,24 @@ const doFetchItems = async () => {
 
                 sellFor.price = item.containsItems.reduce(
                     (previousValue, currentValue) => {
-                        const partPrice = allItems.find(it => it.id === currentValue.item.id).sellFor.find(
-                            (innerSellFor) =>
-                                innerSellFor.source === sellFor.source,
-                        );
+                        const part = allItems.find(innerItem => innerItem.id === currentValue.item.id);
+                        const partFromSellFor = part.sellFor.find(innerSellFor => innerSellFor.vendor.normalizedName === sellFor.vendor.normalizedName);
 
-                        if (!partPrice) {
+                        if (!partFromSellFor) {
                             return previousValue;
                         }
 
-                        return partPrice.price + previousValue;
+                        return partFromSellFor.price + previousValue;
                     },
                     sellFor.price,
                 );
+                
+                if (sellFor.currency === "USD") {
+                    sellFor.priceRUB = sellFor.price * 99.77;
+                }
+                else {
+                    sellFor.priceRUB = sellFor.price;
+                }
 
                 return sellFor;
             });

--- a/src/features/items/do-fetch-items.js
+++ b/src/features/items/do-fetch-items.js
@@ -504,7 +504,7 @@ const doFetchItems = async () => {
                     return localTraderPrice;
                 }
 
-                localTraderPrice.price = item.containsItems.reduce(
+                const totalPrices = item.containsItems.reduce(
                     (previousValue, currentValue) => {
                         const part = allItems.find(innerItem => innerItem.id === currentValue.item.id);
                         const partFromSameTrader = part.traderPrices.find(innerTraderPrice => innerTraderPrice.trader.normalizedName === localTraderPrice.trader.normalizedName);
@@ -513,17 +513,16 @@ const doFetchItems = async () => {
                             return previousValue;
                         }
 
-                        return partFromSameTrader.price + previousValue;
+                        previousValue.price += partFromSameTrader.price;
+                        previousValue.priceRUB += partFromSameTrader.priceRUB;
+
+                        return previousValue;
                     },
-                    localTraderPrice.price,
+                    {price: localTraderPrice.price, priceRUB: localTraderPrice.priceRUB}
                 );
-                
-                if (localTraderPrice.currency === "USD") {
-                    localTraderPrice.priceRUB = localTraderPrice.price * 99.77;
-                }
-                else {
-                    localTraderPrice.priceRUB = localTraderPrice.price;
-                }
+
+                localTraderPrice.price = totalPrices.price;
+                localTraderPrice.priceRUB = totalPrices.priceRUB;
 
                 return localTraderPrice;
             });
@@ -533,7 +532,7 @@ const doFetchItems = async () => {
                     return sellFor;
                 }
 
-                sellFor.price = item.containsItems.reduce(
+                const totalPrices = item.containsItems.reduce(
                     (previousValue, currentValue) => {
                         const part = allItems.find(innerItem => innerItem.id === currentValue.item.id);
                         const partFromSellFor = part.sellFor.find(innerSellFor => innerSellFor.vendor.normalizedName === sellFor.vendor.normalizedName);
@@ -542,17 +541,16 @@ const doFetchItems = async () => {
                             return previousValue;
                         }
 
-                        return partFromSellFor.price + previousValue;
+                        previousValue.price += partFromSellFor.price;
+                        previousValue.priceRUB += partFromSellFor.priceRUB;
+
+                        return previousValue;
                     },
-                    sellFor.price,
+                    {price: sellFor.price, priceRUB: sellFor.priceRUB}
                 );
                 
-                if (sellFor.currency === "USD") {
-                    sellFor.priceRUB = sellFor.price * 99.77;
-                }
-                else {
-                    sellFor.priceRUB = sellFor.price;
-                }
+                sellFor.price = totalPrices.price;
+                sellFor.priceRUB = totalPrices.priceRUB;
 
                 return sellFor;
             });

--- a/src/pages/loot-tiers/index.js
+++ b/src/pages/loot-tiers/index.js
@@ -286,22 +286,20 @@ function LootTier(props) {
 
         for (let i = 0; i < innerItemChunks.length; i = i + 1) {
             innerItemChunks[i] = innerItemChunks[i]?.sort((itemA, itemB) => {
-                if (itemA.slots > itemB.slots) {
-                    return -1;
-                }
-
-                if (itemA.slots < itemB.slots) {
-                    return 1;
-                }
-
-                return 0;
-            });
-        }
-
-        for (let i = 0; i < innerItemChunks.length; i = i + 1) {
-            innerItemChunks[i] = innerItemChunks[i]?.sort((itemA, itemB) => {
                 if (itemA.height > itemB.height) {
                     return -1;
+                }
+
+                if (itemA.height === itemB.height) {
+                    if (itemA.slots > itemB.slots) {
+                        return -1;
+                    }
+                    else if (itemA.slots === itemB.slots) {
+                        return 0;
+                    }
+                    else if (itemA.slots < itemB.slots) {
+                        return 1;
+                    }
                 }
                 
                 if (itemA.height < itemB.height) {

--- a/src/pages/loot-tiers/index.js
+++ b/src/pages/loot-tiers/index.js
@@ -298,6 +298,20 @@ function LootTier(props) {
             });
         }
 
+        for (let i = 0; i < innerItemChunks.length; i = i + 1) {
+            innerItemChunks[i] = innerItemChunks[i]?.sort((itemA, itemB) => {
+                if (itemA.height > itemB.height) {
+                    return -1;
+                }
+                
+                if (itemA.height < itemB.height) {
+                    return 1;
+                }
+
+                return 0;
+            });
+        }
+
         return {
             groupNames: innerGroupNames,
             itemChunks: innerItemChunks,

--- a/src/pages/loot-tiers/index.js
+++ b/src/pages/loot-tiers/index.js
@@ -145,7 +145,7 @@ function LootTier(props) {
 
                 if (hasFlea && !item.types.includes('noFlea')) {
                     const fleaPrice = item.avg24hPrice - item.fee;
-                    if (fleaPrice <= item.traderPriceRUB) {
+                    if (fleaPrice >= item.traderPriceRUB) {
                         sellTo = 'Flea Market';
                         sellToNormalized = 'flea-market';
                         priceRUB = fleaPrice;


### PR DESCRIPTION
# Loot tier item real size

In this PR the loot items are given back their original size

## Description 🗒️

* For grid to look good we need to sort again and place highest items first
* Do not rotate items, so now we do not need to use `images.weserv.nl` service for item image rotation

## Examples 📸

For not wearable/weapon nothing really changes, they are quite small and only rotation of 2x1 changes:
before:
![Screenshot 2022-08-26 at 12 34 18 Large](https://user-images.githubusercontent.com/10927011/186893154-19904fd0-9603-45b9-82d9-97d6ff5ccbea.jpeg)
after:
![Screenshot 2022-08-26 at 12 36 22 Large](https://user-images.githubusercontent.com/10927011/186893162-3a3435f5-3b19-401a-93f3-496cb66e094b.jpeg)

Weapons look much nicer:
before:
![Screenshot 2022-08-26 at 12 32 16 Large](https://user-images.githubusercontent.com/10927011/186893663-d30b98d3-db8d-4309-8951-dbec324a9b80.jpeg)
after:
![Screenshot 2022-08-26 at 12 32 28 Large](https://user-images.githubusercontent.com/10927011/186893667-1a0a2bdb-559d-4605-93d4-ce7657a87938.jpeg)

Wearables look chunkier, but they are and in this way you have clear understanding of real size of the item:
before:
![Screenshot 2022-08-26 at 12 33 07 Large](https://user-images.githubusercontent.com/10927011/186893797-bcb35ad9-80ba-4f66-821f-342b6b77642a.jpeg)
after:
![Screenshot 2022-08-26 at 12 33 16 Large](https://user-images.githubusercontent.com/10927011/186893804-70410340-3b44-4743-8935-19a7005e745e.jpeg)

