### PR TITLE
Store total item sell to trader value separately from sell to trader value of the base item

### DIFF
--- a/src/components/trader-price-cell/index.js
+++ b/src/components/trader-price-cell/index.js
@@ -29,14 +29,13 @@ function TraderPriceCell(props) {
     }
 
     const trader = props.row.original.buyFor
-        ?.map((buyFor) => {
-            if (buyFor.source === 'flea-market') {
-                return false;
+        ?.reduce((previous, current) => {
+            if (current.vendor.normalizedName === 'flea-market') {
+                return previous;
             }
-
-            return buyFor;
-        })
-        .filter(Boolean)[0];
+            if (!previous || current.priceRUB < previous.priceRUB) return current;
+            return previous;
+        }, false);
 
     if (!trader) {
         return null;

--- a/src/features/items/do-fetch-items.js
+++ b/src/features/items/do-fetch-items.js
@@ -550,7 +550,7 @@ const doFetchItems = async () => {
             });
         }
 
-        const traderOnlySellFor = item.sellFor.filter(sellFor => sellFor.vendor.traderNormalizedName !== 'flea-market');
+        const traderOnlySellFor = item.sellFor.filter(sellFor => sellFor.vendor.normalizedName !== 'flea-market');
 
         item.traderPrices = traderOnlySellFor.map(sellFor => {
             return {

--- a/src/features/items/do-fetch-items.js
+++ b/src/features/items/do-fetch-items.js
@@ -505,7 +505,7 @@ const doFetchItems = async () => {
     });
 
     for (const item of allItems) {
-        if ((item.types.includes('gun') || item.types.includes('preset')) && item.containsItems?.length > 0) {
+        if (item.types.includes('gun') && item.containsItems?.length > 0) {
             item.sellFor = item.sellFor.map((sellFor) => {
                 if (sellFor.vendor.normalizedName === 'flea-market') {
                     return {
@@ -515,13 +515,8 @@ const doFetchItems = async () => {
                     };
                 }
                 const trader = itemData.data.traders.find(t => t.normalizedName === sellFor.vendor.normalizedName);
-                const baseId = item.types.includes('preset') ? item.properties.baseItem.id : false;
                 const totalPrices = item.containsItems.reduce(
                     (previousValue, currentValue) => {
-                        if (baseId === currentValue.item.id) {
-                            // don't double-count the value of the base item
-                            return previousValue;
-                        }
                         const part = allItems.find(innerItem => innerItem.id === currentValue.item.id);
                         const partFromSellFor = part.sellFor.find(innerSellFor => innerSellFor.vendor.normalizedName === sellFor.vendor.normalizedName);
 

--- a/src/features/items/do-fetch-items.js
+++ b/src/features/items/do-fetch-items.js
@@ -548,6 +548,14 @@ const doFetchItems = async () => {
                     totalPriceRUB: totalPrices.priceRUB
                 };
             });
+        } else {
+            item.sellFor = item.sellFor.map((sellFor) => {
+                return {
+                    ...sellFor,
+                    totalPrice: sellFor.price,
+                    totalPriceRUB: sellFor.priceRUB
+                };
+            });
         }
 
         const traderOnlySellFor = item.sellFor.filter(sellFor => sellFor.vendor.normalizedName !== 'flea-market');

--- a/src/pages/ammo/index.js
+++ b/src/pages/ammo/index.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-restricted-globals */
 import React, { useState, useMemo, useCallback, useEffect } from 'react';
+import { useSelector } from 'react-redux';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import 'tippy.js/dist/tippy.css'; // optional
@@ -7,6 +8,7 @@ import 'tippy.js/dist/tippy.css'; // optional
 import Icon from '@mdi/react';
 import { mdiAmmunition } from '@mdi/js';
 
+import { Filter, ToggleFilter } from '../../components/filter';
 import Graph from '../../components/Graph.jsx';
 import useKeyPress from '../../hooks/useKeyPress';
 import DataTable from '../../components/data-table';
@@ -39,9 +41,11 @@ function Ammo() {
     const navigate = useNavigate();
     const [selectedLegendName, setSelectedLegendName] =
         useState(currentAmmoList);
+    const [showAllTraderPrices, setShowAllTraderPrices] = useState(false);
     const shiftPress = useKeyPress('Shift');
     const { t } = useTranslation();
     const { data: items } = useItemsQuery();
+    const settings = useSelector((state) => state.settings);
 
     useEffect(() => {
         if (currentAmmo === []) {
@@ -99,6 +103,18 @@ function Ammo() {
         if(!symbol) {
             console.log(`Missing symbol for ${returnData.type}, the graph will crash. Add more symbols to src/symbols.json`);
             process.exit(1);
+        }
+
+        if (!showAllTraderPrices) {
+            returnData.buyFor = returnData.buyFor.filter(buyFor => {
+                if (buyFor.vendor.normalizedName === 'flea-market') {
+                    return true;
+                }
+                if (buyFor.vendor.minTraderLevel <= settings[buyFor.vendor.normalizedName]) {
+                    return true;
+                }
+                return false;
+            });
         }
 
         return returnData;
@@ -295,11 +311,23 @@ function Ammo() {
                     {"This page contains a list of every type of ammo in Escape from Tarkov. To filter the complete list of available cartridges, click the name of a caliber."}
                 </p>
             </div>
-
+            <Filter>
+                <ToggleFilter
+                    checked={showAllTraderPrices}
+                    label={t('Ignore settings')}
+                    onChange={(e) =>
+                        setShowAllTraderPrices(!showAllTraderPrices)
+                    }
+                    tooltipContent={
+                        <>
+                            {t('Shows all trader prices regardless of your settings')}
+                        </>
+                    }
+                />
+            </Filter>
             <h2 className="center-title">
                 {t('Ammo Statistics Table')}
             </h2>
-
             <DataTable columns={columns} data={listState} />
         </React.Fragment>
     );

--- a/src/pages/ammo/index.js
+++ b/src/pages/ammo/index.js
@@ -78,8 +78,8 @@ function Ammo() {
             returnData.displayDamage = MAX_DAMAGE;
         }
 
-        if (returnData.penetration > MAX_PENETRATION) {
-            returnData.name = `${ammoData.name} (${returnData.penetration})`;
+        if (returnData.penetrationPower > MAX_PENETRATION) {
+            returnData.name = `${ammoData.name} (${returnData.penetrationPower})`;
             returnData.displayPenetration = MAX_PENETRATION;
         }
         let symbol = symbols[typeCache.length];

--- a/src/pages/barters/index.js
+++ b/src/pages/barters/index.js
@@ -37,9 +37,13 @@ function Barters() {
         'selectedTrader',
         'all',
     );
+    const [showAll, setShowAll] = useStateWithLocalStorage(
+        'showAllBarters',
+        false,
+    );
     const [hideDogtags, setHideDogtags] = useStateWithLocalStorage(
         'hideDogtagBarters',
-        true,
+        false,
     );
     const { t } = useTranslation();
 
@@ -56,6 +60,16 @@ function Barters() {
                     {t('Barter Profits')}
                 </h1>
                 <Filter>
+                    <ToggleFilter
+                        checked={showAll}
+                        label={t('Ignore settings')}
+                        onChange={(e) => setShowAll(!showAll)}
+                        tooltipContent={
+                            <>
+                                {t('Shows all barters regardless of what you have set in your settings')}
+                            </>
+                        }
+                    />
                     <ToggleFilter
                         checked={hideDogtags}
                         label={t('Hide dogtags')}
@@ -117,6 +131,7 @@ function Barters() {
                 selectedTrader={selectedTrader}
                 key="barters-page-barters-table"
                 removeDogtags={hideDogtags}
+                showAll={showAll}
             />
 
             <div className="page-wrapper barters-page-wrapper">

--- a/src/pages/item/index.js
+++ b/src/pages/item/index.js
@@ -359,7 +359,7 @@ function Item() {
 
     const itemFleaFee = fleaFee(currentItemData.basePrice, currentItemData.lastLowPrice, 1, meta?.flea?.sellOfferFeeRate, meta?.flea?.sellRequirementFeeRate);
 
-    const traderIsBest = currentItemData.traderPriceRUB > currentItemData.lastLowPrice - itemFleaFee;
+    const traderIsBest = currentItemData.traderTotalPriceRUB > currentItemData.lastLowPrice - itemFleaFee;
     const useFleaPrice = currentItemData.lastLowPrice <= currentItemData.bestPrice;
 
     let fleaTooltip;

--- a/src/pages/item/index.js
+++ b/src/pages/item/index.js
@@ -549,14 +549,14 @@ function Item() {
                                                 condition={currentItemData.traderCurrency !== 'RUB'}
                                                 wrapper={(children) => 
                                                     <Tippy
-                                                        content={formatPrice(currentItemData.traderPriceRUB)}
+                                                        content={formatPrice(currentItemData.traderTotalPriceRUB)}
                                                         placement="bottom"
                                                     >
                                                         <div>{children}</div>
                                                     </Tippy>
                                                 }
                                             >
-                                                {formatPrice(currentItemData.traderPrice, currentItemData.traderCurrency)}
+                                                {formatPrice(currentItemData.traderTotalPrice, currentItemData.traderCurrency)}
                                             </ConditionalWrapper>
                                         </div>
                                     </div>
@@ -592,14 +592,14 @@ function Item() {
                                                         condition={traderPrice.currency !== 'RUB'}
                                                         wrapper={(children) => 
                                                             <Tippy
-                                                                content={formatPrice(traderPrice.priceRUB)}
+                                                                content={formatPrice(traderPrice.totalPriceRUB)}
                                                                 placement="bottom"
                                                             >
                                                                 <div>{children}</div>
                                                             </Tippy>
                                                         }
                                                     >
-                                                        {formatPrice(traderPrice.price, traderPrice.currency)}
+                                                        {formatPrice(traderPrice.totalPrice, traderPrice.currency)}
                                                     </ConditionalWrapper>
                                                 </div>
                                             </div>

--- a/src/pages/items/guns/index.js
+++ b/src/pages/items/guns/index.js
@@ -58,6 +58,7 @@ function Guns() {
 
             <SmallItemTable
                 nameFilter={nameFilter}
+                totalTraderPrice={true}
                 typeFilter="gun"
                 fleaValue
                 traderValue

--- a/src/pages/loot-tiers/index.js
+++ b/src/pages/loot-tiers/index.js
@@ -141,11 +141,11 @@ function LootTier(props) {
 
                 let sellTo = item.traderName;
                 let sellToNormalized = item.traderNormalizedName;
-                let priceRUB = item.traderPriceRUB;
+                let priceRUB = item.traderTotalPriceRUB;
 
                 if (hasFlea && !item.types.includes('noFlea')) {
                     const fleaPrice = item.avg24hPrice - item.fee;
-                    if (fleaPrice >= item.traderPriceRUB) {
+                    if (fleaPrice >= item.traderTotalPriceRUB) {
                         sellTo = 'Flea Market';
                         sellToNormalized = 'flea-market';
                         priceRUB = fleaPrice;

--- a/src/pages/start/index.js
+++ b/src/pages/start/index.js
@@ -93,6 +93,7 @@ function Start() {
                         nameFilter={nameFilter}
                         defaultRandom={true}
                         autoScroll={loadMoreState}
+                        totalTraderPrice={true}
                         fleaValue
                         traderValue
                         instaProfit

--- a/src/pages/traders/trader/index.js
+++ b/src/pages/traders/trader/index.js
@@ -162,6 +162,7 @@ function Trader() {
                 traderBuyback={selectedTable === 'level' ? true : false}
                 traderBuybackFilter={selectedTable === 'level' ? true : false}
                 maxItems={selectedTable === 'level' ? 50 : false}
+                totalTraderPrice={true}
 
                 // instaProfit = {selectedTable === 'instaProfit' ? true : false}
                 // maxItems = {selectedTable === 'instaProfit' ? 50 : false}


### PR DESCRIPTION
Currently, the website replaces the sell-to-trader price of weapon receivers with the sell-to-trader price of all items in that weapon's default configuration. This generally works fine enough, but then it messes up sell calculations for presets because presets contain those base items and the total value of the preset will count the total value of the base item's default configuration even though it may not contain all the same parts as the default. This is most pronounced with the G28 which has a large default configuration sale value because it has so many parts. Looking at the G28 Patrol preset, it has a huge calculated sell to trader value because it counts the value of all the items from the G28 default configuration:
![image](https://user-images.githubusercontent.com/35779878/187078759-f99b6003-a91b-4d54-9c16-4526ca2dbd02.png)

This PR starts sorting out the issue by adding totalPrice and totalPriceRUB fields to the sellFor and traderPrice values. Those values can be used to get the total value of a weapon while leaving the values of just the receive intact. This appears to work well on item pages, but needs testing elsewhere (particularly on the loot tier page).