### PR TITLE
Fix item css on mobile and co

### DIFF
--- a/src/components/boss-list/index.js
+++ b/src/components/boss-list/index.js
@@ -1,8 +1,10 @@
 import { useQuery } from 'react-query';
+import { Link } from 'react-router-dom';
+
 import doFetchBosses from '../../features/bosses/do-fetch-bosses';
 import formatBossData from '../../modules/format-boss-data';
-import { Link } from 'react-router-dom';
 import MenuItem from '../menu/MenuItem';
+import LoadingSmall from '../loading-small';
 
 import './index.css';
 
@@ -26,7 +28,7 @@ export function BossPageList() {
 
     // If no bosses have been returned yet, return 'loading'
     if (!bosses || bosses.length === 0) {
-        return 'Loading...';
+        return <LoadingSmall />;
     }
 
     // Format the boss data
@@ -97,7 +99,7 @@ function BossList() {
 
     // If no bosses have been returned yet, return 'loading'
     if (!bosses || bosses.length === 0) {
-        return 'Loading...';
+        return <LoadingSmall />;
     }
 
     // Format the boss data

--- a/src/components/loading-small/index.css
+++ b/src/components/loading-small/index.css
@@ -1,0 +1,21 @@
+.loading-wipe {
+    background: linear-gradient(to left, #c7c5b3 20%, #9a8866 40%, #9a8866 60%, #c7c5b3 80%);
+    background-size: 200% auto;
+
+    color: #000;
+    background-clip: text;
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    -webkit-animation: shine 1s linear infinite;
+    animation: shine 1s linear infinite;
+}
+@-webkit-keyframes shine {
+    to {
+        background-position: -200% center;
+    }
+}
+@keyframes shine {
+    to {
+        background-position: -200% center;
+    }
+}

--- a/src/components/loading-small/index.js
+++ b/src/components/loading-small/index.js
@@ -1,0 +1,15 @@
+import { useTranslation } from 'react-i18next';
+
+import './index.css';
+
+function LoadingSmall() {
+    const { t } = useTranslation();
+
+    return (
+        <div className={`loading-wipe`}>
+            {t('Loading...')}
+        </div>
+    );
+}
+
+export default LoadingSmall;

--- a/src/components/menu/index.js
+++ b/src/components/menu/index.js
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Suspense } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Icon from '@mdi/react';
@@ -13,24 +14,15 @@ import {
 import MenuItem from './MenuItem';
 // import PatreonButton from '../patreon-button';
 import UkraineButton from '../ukraine-button';
+import LoadingSmall from '../loading-small';
+import { BossListNav } from '../boss-list';
 
 import { caliberMap } from '../../modules/format-ammo';
 import rawMapData from '../../data/maps.json';
 import itemsData from '../../data/category-pages.json';
 
-import { BossListNav } from '../../components/boss-list';
 
 import './index.css';
-import { Suspense } from 'react';
-
-// Comment / uncomment for banner alert
-// import MuiAlert from '@material-ui/lab/Alert';
-// function Alert(props) {
-//     return <MuiAlert elevation={6} variant="filled" {...props} />;
-// }
-// End of banner alert toggle
-
-const renderLoader = () => <p>Loading...</p>;
 
 const ammoTypes = Object.values(caliberMap).sort();
 
@@ -216,7 +208,7 @@ const Menu = () => {
                     </li>
                     <li className="submenu-wrapper" key="menu-bosses">
                         <Link to="/bosses/">{t('Bosses')}</Link>
-                        <Suspense fallback={renderLoader()}>
+                        <Suspense fallback={<LoadingSmall />}>
                             <BossListNav onClick={setIsOpen.bind(this, false)} />
                         </Suspense>
                     </li>

--- a/src/components/quests-list/index.css
+++ b/src/components/quests-list/index.css
@@ -49,15 +49,3 @@
 .quest-link-wrapper a {
     display: flex;
 }
-
-.item-quest-headline-wrapper {
-    margin-top: 20px;
-    align-items: center;
-    display: flex;
-}
-
-.item-quest-headline-wrapper h2 {
-    flex-grow: 1;
-    margin: 0;
-    padding: 20px 0;
-}

--- a/src/components/quests-list/index.js
+++ b/src/components/quests-list/index.js
@@ -32,7 +32,7 @@ const getQuestList = (questList, t, showAll, settings) => {
                 </thead>
                 <tbody>
                     {extraRow && (
-                        <tr className="quest-list-extra-row">
+                        <tr className="quest-list-extra-row" key="quest-list-extra-row">
                             <td colSpan={2}>{extraRow}</td>
                         </tr>
                     )}
@@ -84,20 +84,21 @@ function QuestsList(props) {
     let title = (itemQuests.length > 0 && itemQuests[0].rewardItems) ? t('Quests Providing') : t('Quests Requiring');
 
     let toggleFilter = '';
-    if (settings.completedQuests?.length > 0) toggleFilter = (
-        <ToggleFilter
-            checked={showAllQuests}
-            label={t('Show completed')}
-            onChange={(e) =>
-                setShowAllQuests(!showAllQuests)
-            }
-            tooltipContent={
-                <>
-                    {t('Shows all quests regardless of if you\'ve completed them')}
-                </>
-            }
-        />
-    );
+    if (settings.completedQuests?.length > 0) 
+        toggleFilter = (
+            <ToggleFilter
+                checked={showAllQuests}
+                label={t('Show completed')}
+                onChange={(e) =>
+                    setShowAllQuests(!showAllQuests)
+                }
+                tooltipContent={
+                    <>
+                        {t('Shows all quests regardless of if you\'ve completed them')}
+                    </>
+                }
+            />
+        );
     return (
         <div>
             <div className="item-quest-headline-wrapper">

--- a/src/components/quests-list/index.js
+++ b/src/components/quests-list/index.js
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 
-import { Filter, ToggleFilter } from '../../components/filter';
+import { ToggleFilter } from '../../components/filter';
 import QuestItemsCell from '../quest-items-cell';
 import './index.css';
 

--- a/src/components/quests-list/index.js
+++ b/src/components/quests-list/index.js
@@ -85,20 +85,18 @@ function QuestsList(props) {
 
     let toggleFilter = '';
     if (settings.completedQuests?.length > 0) toggleFilter = (
-        <Filter>
-            <ToggleFilter
-                checked={showAllQuests}
-                label={t('Show completed')}
-                onChange={(e) =>
-                    setShowAllQuests(!showAllQuests)
-                }
-                tooltipContent={
-                    <>
-                        {t('Shows all quests regardless of if you\'ve completed them')}
-                    </>
-                }
-            />
-        </Filter>
+        <ToggleFilter
+            checked={showAllQuests}
+            label={t('Show completed')}
+            onChange={(e) =>
+                setShowAllQuests(!showAllQuests)
+            }
+            tooltipContent={
+                <>
+                    {t('Shows all quests regardless of if you\'ve completed them')}
+                </>
+            }
+        />
     );
     return (
         <div>

--- a/src/components/small-item-table/index.js
+++ b/src/components/small-item-table/index.js
@@ -12,19 +12,21 @@ import CenterCell from '../center-cell';
 import ItemNameCell from '../item-name-cell';
 import FleaPriceCell from '../flea-price-cell';
 import BarterToolTip from '../barter-tooltip';
-
 import DataTable from '../data-table';
+import LoadingSmall from '../loading-small';
+
 import formatPrice from '../../modules/format-price';
 import itemSearch from '../../modules/item-search';
+import { getCheapestBarter } from '../../modules/format-cost-items';
+
 import {
     selectAllBarters,
     fetchBarters,
 } from '../../features/barters/bartersSlice';
-import { getCheapestBarter } from '../../modules/format-cost-items';
-
-import './index.css';
 import { useItemsQuery } from '../../features/items/queries';
 import { useMetaQuery } from '../../features/meta/queries';
+
+import './index.css';
 
 function getItemCountPrice(item) {
     if (item.count < 2) return '';
@@ -882,7 +884,7 @@ function SmallItemTable(props) {
     if (data.length <= 0) {
         // If the API query has not yet completed
         if (result.isFetched === false) {
-            extraRow = t('Loading...');
+            extraRow = <LoadingSmall />;
             // If the API query has completed, but no items were found
         } else {
             extraRow = t('No items');

--- a/src/pages/item/index.css
+++ b/src/pages/item/index.css
@@ -40,22 +40,9 @@
 }
 
 .information-grid {
-    justify-content: space-between;
     display: flex;
     flex-flow: wrap;
     gap: 10px;
-}
-
-.single-line-grid.sell {
-    justify-content: flex-start;
-}
-
-.single-line-grid.buy {
-    justify-content: flex-end;
-}
-
-.information-outer-grid {
-    justify-content: space-between;
 }
 
 .information-grid h2 {
@@ -141,19 +128,6 @@
     color: #c7c5b3;
 }
 
-.flea-wrapper {
-    display: block;
-}
-
-.flea-wrapper img {
-    height: 86px;
-    width: 86px;
-}
-
-.flea-wrapper .price-wrapper {
-    text-align: center;
-}
-
 .text-and-image-information-wrapper.price-info-wrapper {
     align-items: center;
     display: flex;
@@ -185,8 +159,8 @@
 .item-hideout-headline-wrapper,
 .item-quest-headline-wrapper {
     margin-top: 20px;
+    margin-bottom: 20px;
     align-items: center;
-    display: flex;
 }
 
 .item-crafts-headline-wrapper h2,
@@ -199,7 +173,7 @@
 }
 
 .item-h2 {
-    margin-top: 10;
+    margin-top: 10px;
 }
 
 @media screen and (min-width: 700px) {
@@ -209,6 +183,14 @@
 
     .item-page-wrapper h2 {
         /* margin-top: 70px; */
+    }
+
+    .item-crafts-headline-wrapper,
+    .item-barters-headline-wrapper,
+    .item-contents-headline-wrapper,
+    .item-hideout-headline-wrapper,
+    .item-quest-headline-wrapper {
+        display: flex;
     }
 
     .icon-and-link-wrapper {
@@ -233,16 +215,20 @@
         text-align: center;
     }
 
+    .single-line-grid.sell {
+        justify-content: flex-start;
+    }
+    
+    .single-line-grid.buy {
+        justify-content: flex-end;
+    }
+
     .icon-and-link-wrapper img {
         max-height: 200px;
     }
 
     .main-information-grid {
         display: flex;
-    }
-
-    .information-grid {
-        flex-wrap: nowrap;
     }
 
     .main-information-grid h1 img {

--- a/src/pages/item/index.js
+++ b/src/pages/item/index.js
@@ -505,7 +505,7 @@ function Item() {
                                         placement="bottom"
                                         content={fleaTooltip}
                                     >
-                                        <div className={`text-and-image-information-wrapper flea-wrapper ${traderIsBest ? '' : 'best-profit'}`}>
+                                        <div className={`text-and-image-information-wrapper ${traderIsBest ? '' : 'best-profit'}`}>
                                             <img
                                                 alt="Flea market"
                                                 height="86"
@@ -523,9 +523,7 @@ function Item() {
                                                         src={warningIcon}
                                                     />
                                                 )}
-                                                <span>
-                                                    {formatPrice(useFleaPrice ? currentItemData.lastLowPrice : currentItemData.bestPrice)}
-                                                </span>
+                                                {formatPrice(useFleaPrice ? currentItemData.lastLowPrice : currentItemData.bestPrice)}
                                             </div>
                                         </div>
                                     </Tippy>
@@ -683,10 +681,14 @@ function Item() {
                 {!currentItemData.types.includes('noFlea') && (
                     <div>
                         <h2>{t('Flea price last 7 days')}</h2>
-                        <PriceGraph
-                            itemId={currentItemData.id}
-                            itemChange24={currentItemData.changeLast48h}
-                        />
+                        {currentItemData.id && (
+                            <Suspense fallback={<>{t('Loading...')}</>}>
+                                <PriceGraph
+                                    itemId={currentItemData.id}
+                                    itemChange24={currentItemData.changeLast48h}
+                                />
+                            </Suspense>
+                        )}
                         <br />
                         <div className={`text-and-image-information-wrapper price-info-wrapper`}>
                             <div className="price-wrapper price-wrapper-bright">
@@ -718,20 +720,18 @@ function Item() {
                             <h2>
                                 {t('Items contained in')} {currentItemData.name}
                             </h2>
-                            <Filter>
-                                <ToggleFilter
-                                    checked={showAllContainedItemSources}
-                                    label={t('Ignore settings')}
-                                    onChange={(e) =>
-                                        setShowAllContainedItemSources(!showAllContainedItemSources)
-                                    }
-                                    tooltipContent={
-                                        <>
-                                            {t('Shows all sources of items regardless of what you have set in your settings')}
-                                        </>
-                                    }
-                                />
-                            </Filter>
+                            <ToggleFilter
+                                checked={showAllContainedItemSources}
+                                label={t('Ignore settings')}
+                                onChange={(e) =>
+                                    setShowAllContainedItemSources(!showAllContainedItemSources)
+                                }
+                                tooltipContent={
+                                    <>
+                                        {t('Shows all sources of items regardless of what you have set in your settings')}
+                                    </>
+                                }
+                            />
                         </div>
                         <Suspense fallback={<>{t('Loading...')}</>}>
                             <SmallItemTable
@@ -753,20 +753,18 @@ function Item() {
                             <h2>
                                 {t('Barters with')} {currentItemData.name}
                             </h2>
-                            <Filter>
-                                <ToggleFilter
-                                    checked={showAllBarters}
-                                    label={t('Ignore settings')}
-                                    onChange={(e) =>
-                                        setShowAllBarters(!showAllBarters)
-                                    }
-                                    tooltipContent={
-                                        <>
-                                            {t('Shows all crafts regardless of what you have set in your settings')}
-                                        </>
-                                    }
-                                />
-                            </Filter>
+                            <ToggleFilter
+                                checked={showAllBarters}
+                                label={t('Ignore settings')}
+                                onChange={(e) =>
+                                    setShowAllBarters(!showAllBarters)
+                                }
+                                tooltipContent={
+                                    <>
+                                        {t('Shows all crafts regardless of what you have set in your settings')}
+                                    </>
+                                }
+                            />
                         </div>
                         <Suspense fallback={<div>{t('Loading...')}</div>}>
                             <BartersTable
@@ -782,20 +780,18 @@ function Item() {
                             <h2>
                                 {t('Crafts with')} {currentItemData.name}
                             </h2>
-                            <Filter>
-                                <ToggleFilter
-                                    checked={showAllCrafts}
-                                    label={t('Ignore settings')}
-                                    onChange={(e) =>
-                                        setShowAllCrafts(!showAllCrafts)
-                                    }
-                                    tooltipContent={
-                                        <>
-                                            {t('Shows all crafts regardless of what you have set in your settings')}
-                                        </>
-                                    }
-                                />
-                            </Filter>
+                            <ToggleFilter
+                                checked={showAllCrafts}
+                                label={t('Ignore settings')}
+                                onChange={(e) =>
+                                    setShowAllCrafts(!showAllCrafts)
+                                }
+                                tooltipContent={
+                                    <>
+                                        {t('Shows all crafts regardless of what you have set in your settings')}
+                                    </>
+                                }
+                            />
                         </div>
                         <Suspense fallback={<div>{t('Loading...')}</div>}>
                             <CraftsTable
@@ -811,20 +807,18 @@ function Item() {
                             <h2>
                                 {t('Hideout modules needing')} {currentItemData.name}
                             </h2>
-                            <Filter>
-                                <ToggleFilter
-                                    checked={showAllHideoutStations}
-                                    label={t('Show built')}
-                                    onChange={(e) =>
-                                        setShowAllHideoutStations(!showAllHideoutStations)
-                                    }
-                                    tooltipContent={
-                                        <>
-                                            {t('Shows all modules regardless of what you have set in your settings')}
-                                        </>
-                                    }
-                                />
-                            </Filter>
+                            <ToggleFilter
+                                checked={showAllHideoutStations}
+                                label={t('Show built')}
+                                onChange={(e) =>
+                                    setShowAllHideoutStations(!showAllHideoutStations)
+                                }
+                                tooltipContent={
+                                    <>
+                                        {t('Shows all modules regardless of what you have set in your settings')}
+                                    </>
+                                }
+                            />
                         </div>
                         <Suspense fallback={<div>{t('Loading...')}</div>}>
                             <ItemsForHideout itemFilter={currentItemData.id} showAll={showAllHideoutStations} />

--- a/src/pages/item/index.js
+++ b/src/pages/item/index.js
@@ -24,22 +24,23 @@ import PriceGraph from '../../components/price-graph';
 import ItemSearch from '../../components/item-search';
 import { ToggleFilter } from '../../components/filter';
 import ContainedItemsList from '../../components/contained-items-list';
+import LoadingSmall from '../../components/loading-small';
 
 import { useMetaQuery } from '../../features/meta/queries';
 import { selectAllBarters, fetchBarters, } from '../../features/barters/bartersSlice';
 import { selectAllHideoutModules, fetchHideout } from '../../features/hideout/hideoutSlice';
 import { selectAllCrafts, fetchCrafts } from '../../features/crafts/craftsSlice';
 import { selectQuests, fetchQuests } from '../../features/quests/questsSlice';
+import {
+    useItemByNameQuery,
+    useItemByIdQuery,
+} from '../../features/items/queries';
 
 import formatPrice from '../../modules/format-price';
 import fleaFee from '../../modules/flea-market-fee';
 import bestPrice from '../../modules/best-price';
 
 import './index.css';
-import {
-    useItemByNameQuery,
-    useItemByIdQuery,
-} from '../../features/items/queries';
 
 dayjs.extend(relativeTime);
 
@@ -71,6 +72,7 @@ function Item() {
         name: t('Loading...'),
         types: ['loading'],
         iconLink: `${process.env.PUBLIC_URL}/images/unknown-item-icon.jpg`,
+        gridImageLink: `${process.env.PUBLIC_URL}/images/unknown-item-icon.jpg`,
         sellFor: [
             {
                 source: 'fleaMarket',
@@ -450,7 +452,10 @@ function Item() {
                     <div className="item-information-wrapper">
                         <h1>
                             <div className={'item-font'}>
-                                {currentItemData.name}
+                                {!currentItemData.types.includes('loading')
+                                    ? (currentItemData.name)
+                                    : (<LoadingSmall />)
+                                }
                             </div>
                             <img
                                 alt={currentItemData.name}
@@ -710,7 +715,7 @@ function Item() {
                     </h2>
                     {hasProperties
                         ? (<PropertyList properties={{...currentItemData.properties, categories: currentItemData.categories}} />)
-                        : (<>{t('Loading...')}</>)
+                        : (<LoadingSmall />)
                     }
                 </div>
                 {containsItems && (

--- a/src/pages/item/index.js
+++ b/src/pages/item/index.js
@@ -1,4 +1,4 @@
-import React, { Suspense, useMemo, useState, useEffect } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 import { useParams, Navigate, Link } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';

--- a/src/pages/start/index.js
+++ b/src/pages/start/index.js
@@ -27,18 +27,14 @@ import {
 import './index.css';
 
 import categoryPages from '../../data/category-pages.json';
-import BossList from '../../components/boss-list';
 
 const DISCORD_STASH_INVITE_LINK = 'https://discord.com/api/oauth2/authorize?client_id=955521336904667227&permissions=309237664832&scope=bot%20applications.commands'
-
-// Lazy loading React component text (fallback)
-// https://web.dev/code-splitting-suspense/?utm_source=lighthouse&utm_medium=wpt
-const renderLoader = () => <p>Loading...</p>;
 
 // Use Lazy and Suspense to load these components
 const ServerStatus = lazy(() => import('../../components/server-status'));
 const SmallItemTable = lazy(() => import('../../components/small-item-table'));
 const ItemSearch = lazy(() => import('../../components/item-search'));
+const BossList = lazy(() => import('../../components/boss-list'));
 
 function Start() {
     const defaultQuery = new URLSearchParams(window.location.search).get(
@@ -80,14 +76,14 @@ function Start() {
             key={'display-wrapper-start-page'}
         >
             <div className="start-section-wrapper item-section" key={'item-section-div'}>
-                <Suspense fallback={renderLoader()} key={'item-search'}>
+                <Suspense fallback={<div>{t('Loading...')}</div>} key={'item-search'}>
                     <ItemSearch
                         onChange={handleNameFilterChange}
                         autoFocus={true}
                         key={'item-search-box'}
                     />
                 </Suspense>
-                <Suspense fallback={renderLoader()}>
+                <Suspense fallback={<div>{t('Loading...')}</div>}>
                     <SmallItemTable
                         maxItems={20}
                         nameFilter={nameFilter}
@@ -107,7 +103,7 @@ function Start() {
                 </Suspense>
             </div>
             <div className="start-section-wrapper" key={'server-status-div'}>
-                <Suspense fallback={renderLoader()} key={'server-status'}>
+                <Suspense fallback={<div>{t('Loading...')}</div>} key={'server-status'}>
                     <ServerStatus key={"server-status"} />
                 </Suspense>
                 <h3>
@@ -339,7 +335,7 @@ function Start() {
                     </Link>
                 </h3>
                 <ul className="traders-list">
-                    <Suspense fallback={renderLoader()}>
+                    <Suspense fallback={<div>{t('Loading...')}</div>}>
                         <BossList />
                     </Suspense>
                 </ul>

--- a/src/pages/start/index.js
+++ b/src/pages/start/index.js
@@ -5,8 +5,12 @@ import { useTranslation } from 'react-i18next';
 import React, { lazy, Suspense } from 'react';
 
 import QueueBrowserTask from '../../modules/queue-browser-task';
+
 import rawMapData from '../../data/maps.json';
+import categoryPages from '../../data/category-pages.json';
+
 import ItemIconList from '../../components/item-icon-list';
+import LoadingSmall from '../../components/loading-small';
 
 import Icon from '@mdi/react';
 import {
@@ -25,8 +29,6 @@ import {
 } from '@mdi/js';
 
 import './index.css';
-
-import categoryPages from '../../data/category-pages.json';
 
 const DISCORD_STASH_INVITE_LINK = 'https://discord.com/api/oauth2/authorize?client_id=955521336904667227&permissions=309237664832&scope=bot%20applications.commands'
 
@@ -76,14 +78,14 @@ function Start() {
             key={'display-wrapper-start-page'}
         >
             <div className="start-section-wrapper item-section" key={'item-section-div'}>
-                <Suspense fallback={<div>{t('Loading...')}</div>} key={'item-search'}>
+                <Suspense fallback={<LoadingSmall />} key={'item-search'}>
                     <ItemSearch
                         onChange={handleNameFilterChange}
                         autoFocus={true}
                         key={'item-search-box'}
                     />
                 </Suspense>
-                <Suspense fallback={<div>{t('Loading...')}</div>}>
+                <Suspense fallback={<LoadingSmall />}>
                     <SmallItemTable
                         maxItems={20}
                         nameFilter={nameFilter}
@@ -104,7 +106,7 @@ function Start() {
                 </Suspense>
             </div>
             <div className="start-section-wrapper" key={'server-status-div'}>
-                <Suspense fallback={<div>{t('Loading...')}</div>} key={'server-status'}>
+                <Suspense fallback={<LoadingSmall />} key={'server-status'}>
                     <ServerStatus key={"server-status"} />
                 </Suspense>
                 <h3>
@@ -336,7 +338,7 @@ function Start() {
                     </Link>
                 </h3>
                 <ul className="traders-list">
-                    <Suspense fallback={<div>{t('Loading...')}</div>}>
+                    <Suspense fallback={<LoadingSmall />}>
                         <BossList />
                     </Suspense>
                 </ul>

--- a/src/pages/traders/index.js
+++ b/src/pages/traders/index.js
@@ -7,6 +7,8 @@ import { mdiAccountGroup } from '@mdi/js';
 import { useTranslation } from 'react-i18next';
 
 import TraderResetTime from '../../components/trader-reset-time';
+import LoadingSmall from '../../components/loading-small';
+
 import { selectAllTraders, fetchTraders } from '../../features/traders/tradersSlice';
 
 import './index.css';
@@ -100,7 +102,7 @@ const showLoadingPage = (t) => {
                 {t('Traders')}
             </h1>
             <div className="traders-list-wrapper">
-                Loading...
+                <LoadingSmall />
             </div>
 
             <div className="page-wrapper trader-page-wrapper">


### PR DESCRIPTION
# Fix item css on mobile and co

This PR fixes some wrongdoings on item page:
 on mobile screens like:
- flea trader icon
- trader icons alignment
- switches for ignore settings

 on normal screens:
- add unknown image during item loading
- overflow of trader icons where there are many trader options (now they go multiline)

 other:
- removes flea price graph during loading
- replaces static loading text with `animated` one
- adds _loading_ div to stats
- Removes `Suspens` from components where it's not needed


## Examples 📸

<img width="493" alt="Screenshot 2022-08-29 at 16 22 25" src="https://user-images.githubusercontent.com/10927011/187225940-e4fc86d2-d50f-4a1a-b222-9dd0a639b762.png">
<img width="758" alt="Screenshot 2022-08-29 at 16 21 53" src="https://user-images.githubusercontent.com/10927011/187225944-7222adff-8934-4b44-85e9-56c4088dd4f9.png">
<img width="495" alt="Screenshot 2022-08-29 at 16 23 05" src="https://user-images.githubusercontent.com/10927011/187225946-1a2e8dba-335a-43cc-a90f-d09d08c070f7.png">
<img width="499" alt="Screenshot 2022-08-29 at 16 34 06" src="https://user-images.githubusercontent.com/10927011/187226260-e975e418-9808-4bbb-adb3-14c0645e8bc6.png">
