### PR TITLE
show warning when no flea prices scanned

### DIFF
--- a/src/pages/item/index.js
+++ b/src/pages/item/index.js
@@ -365,7 +365,7 @@ function Item() {
     const useFleaPrice = currentItemData.lastLowPrice <= currentItemData.bestPrice;
 
     let fleaTooltip;
-    
+    console.log(currentItemData)
     if (!useFleaPrice && currentItemData.bestPrice) {
         fleaTooltip = (
             <div>
@@ -397,8 +397,9 @@ function Item() {
                 {formatPrice(currentItemData.bestPrice)}
             </div>
         );
-    }
-    else {
+    } else if (!currentItemData.lastLowPrice) {
+        fleaTooltip = t('No flea price seen');
+    } else {
         fleaTooltip = (
             <div>
                 <div className="tooltip-calculation">
@@ -520,7 +521,7 @@ function Item() {
                                                 // title = {`Sell ${currentItemData.name} on the Flea market`}
                                             />
                                             <div className="price-wrapper">
-                                                {!useFleaPrice && (
+                                                {(!useFleaPrice || !currentItemData.lastLowPrice) && (
                                                     <img
                                                         alt="Warning"
                                                         loading="lazy"
@@ -528,7 +529,7 @@ function Item() {
                                                         src={warningIcon}
                                                     />
                                                 )}
-                                                {formatPrice(useFleaPrice ? currentItemData.lastLowPrice : currentItemData.bestPrice)}
+                                                {(!useFleaPrice || currentItemData.lastLowPrice) && formatPrice(useFleaPrice? currentItemData.bestPrice : currentItemData.bestPrice)}
                                             </div>
                                         </div>
                                     </Tippy>

--- a/src/pages/item/index.js
+++ b/src/pages/item/index.js
@@ -365,7 +365,7 @@ function Item() {
     const useFleaPrice = currentItemData.lastLowPrice <= currentItemData.bestPrice;
 
     let fleaTooltip;
-    console.log(currentItemData)
+
     if (!useFleaPrice && currentItemData.bestPrice) {
         fleaTooltip = (
             <div>

--- a/src/pages/item/index.js
+++ b/src/pages/item/index.js
@@ -365,7 +365,7 @@ function Item() {
     const useFleaPrice = currentItemData.lastLowPrice <= currentItemData.bestPrice;
 
     let fleaTooltip;
-
+    
     if (!useFleaPrice && currentItemData.bestPrice) {
         fleaTooltip = (
             <div>

--- a/src/pages/item/index.js
+++ b/src/pages/item/index.js
@@ -365,7 +365,7 @@ function Item() {
     const useFleaPrice = currentItemData.lastLowPrice <= currentItemData.bestPrice;
 
     let fleaTooltip;
-    
+
     if (!useFleaPrice && currentItemData.bestPrice) {
         fleaTooltip = (
             <div>
@@ -529,7 +529,7 @@ function Item() {
                                                         src={warningIcon}
                                                     />
                                                 )}
-                                                {(!useFleaPrice || currentItemData.lastLowPrice) && formatPrice(useFleaPrice? currentItemData.bestPrice : currentItemData.bestPrice)}
+                                                {(!useFleaPrice || currentItemData.lastLowPrice) && formatPrice(useFleaPrice ? currentItemData.lastLowPrice : currentItemData.bestPrice)}
                                             </div>
                                         </div>
                                     </Tippy>


### PR DESCRIPTION
Show a warning instead of a price of 0 when no prices have been scanned for an item:
![image](https://user-images.githubusercontent.com/35779878/187927574-199732b0-c50a-4d04-9109-d72e4471b3ac.png)
