### PR TITLE
show max profit tooltip on no prices scanned

### DIFF
--- a/src/modules/best-price.js
+++ b/src/modules/best-price.js
@@ -7,12 +7,13 @@ export default function bestPrice(itemData, Ti = false, Tr = false) {
             bestPriceFee: 0,
         };
     }
-    let currentFee = calculateFee(itemData.basePrice, itemData.lastLowPrice, 1, Ti, Tr);
-    let bestProfit = itemData.lastLowPrice - currentFee;
-    let bestPrice = itemData.lastLowPrice;
+    let testPrice = itemData.lastLowPrice || (itemData.basePrice * 100);
+    let currentFee = calculateFee(itemData.basePrice, testPrice, 1, Ti, Tr);
+    let bestProfit = testPrice - currentFee;
+    let bestPrice = testPrice;
     let bestPriceFee = currentFee;
 
-    for (let i = itemData.lastLowPrice - 1000; i > 0; i = i - 1000) {
+    for (let i = testPrice - 1000; i > 0; i = i - 1000) {
         const newFee = calculateFee(itemData.basePrice, i, 1, Ti, Tr);
 
         const newProfit = i - newFee;

--- a/src/pages/item/index.js
+++ b/src/pages/item/index.js
@@ -418,7 +418,8 @@ function Item() {
                 {t('This item has not been observed on the Flea Market.')}
                 {t(" The maximum profitable price  is")}{' '}
                 {formatPrice(currentItemData.bestPrice)}
-                {t(', but the item may or may not sell at that price.')}
+                {t(', but the item may or may not sell at that price.')}{' '}
+                {t('The max profitable price is impacted by your intel center and hideout management skill levels in your settings.')}
             </div>
         )
         //fleaTooltip = t('No flea price seen');

--- a/src/pages/item/index.js
+++ b/src/pages/item/index.js
@@ -387,18 +387,41 @@ function Item() {
                         {formatPrice(currentItemData.bestPrice - currentItemData.bestPriceFee)}
                     </div>
                 </div>
-                <div className="tooltip-calculation">
-                    {t('Calculated over the average for the last 24 hours')}
-                </div>
-                {t('This item was sold for')}{' '}
-                {formatPrice(currentItemData.avg24hPrice)}{' '}
-                {t('on average in the last 24h on the Flea Market.')}
+                {t('This item was listed for')}{' '}
+                {formatPrice(currentItemData.lastLowPrice)}{' '}
+                {t('minimum last observed on the Flea Market.')}
                 {t(" However, due to how fees are calculated you're better off selling for")}{' '}
                 {formatPrice(currentItemData.bestPrice)}
             </div>
         );
     } else if (!currentItemData.lastLowPrice) {
-        fleaTooltip = t('No flea price seen');
+        fleaTooltip = (
+            <div>
+                <div className="tooltip-calculation">
+                    {t('Max price to sell for')}{' '}
+                    <div className="tooltip-price-wrapper">
+                        {formatPrice(currentItemData.bestPrice)}
+                    </div>
+                </div>
+                <div className="tooltip-calculation">
+                    {t('Fee')}{' '}
+                    <div className="tooltip-price-wrapper">
+                        {formatPrice(currentItemData.bestPriceFee)}
+                    </div>
+                </div>
+                <div className="tooltip-calculation">
+                    {t('Profit')}{' '}
+                    <div className="tooltip-price-wrapper">
+                        {formatPrice(currentItemData.bestPrice - currentItemData.bestPriceFee)}
+                    </div>
+                </div>
+                {t('This item has not been observed on the Flea Market.')}
+                {t(" The maximum profitable price  is")}{' '}
+                {formatPrice(currentItemData.bestPrice)}
+                {t(', but the item may or may not sell at that price.')}
+            </div>
+        )
+        //fleaTooltip = t('No flea price seen');
     } else {
         fleaTooltip = (
             <div>


### PR DESCRIPTION
Instead of providing no information when an item's price hasn't been scanned, the website can provide a tooltip showing the maximum profitable price:
![image](https://user-images.githubusercontent.com/35779878/187947928-69af2cb1-5eba-4ed6-b820-4218f1f3eff4.png)
We could also show this price in the usual price location, but we may want to keep it in the tooltip only to make sure the warning about the item possibly not selling at that price is seen.