### PR TITLE
Use API item data for boss loot, add new rig layouts

### DIFF
--- a/src/components/boss-list/index.js
+++ b/src/components/boss-list/index.js
@@ -1,16 +1,16 @@
 import { useQuery } from 'react-query';
 import { Link } from 'react-router-dom';
 
-import doFetchBosses from '../../features/bosses/do-fetch-bosses';
+import doFetchMaps from '../../features/maps/do-fetch-maps';
 import formatBossData from '../../modules/format-boss-data';
 import MenuItem from '../menu/MenuItem';
 import LoadingSmall from '../loading-small';
 
 import './index.css';
 
-// Query for bosses
-export const useBossesQuery = (queryOptions) => {
-    const bossesQuery = useQuery('bosses', () => doFetchBosses(), {
+// Query for maps
+export const useMapsQuery = (queryOptions) => {
+    const mapsQuery = useQuery('maps', () => doFetchMaps(), {
         refetchInterval: 600000,
         placeholderData: [],
         refetchOnMount: false,
@@ -18,21 +18,21 @@ export const useBossesQuery = (queryOptions) => {
         ...queryOptions,
     });
 
-    return bossesQuery;
+    return mapsQuery;
 };
 
 // BossPageList component for the main boss page
 export function BossPageList() {
-    // Fetch bosses
-    const { data: bosses } = useBossesQuery();
+    // Fetch maps
+    const { data: maps } = useMapsQuery();
 
-    // If no bosses have been returned yet, return 'loading'
-    if (!bosses || bosses.length === 0) {
+    // If no maps have been returned yet, return 'loading'
+    if (!maps || maps.length === 0) {
         return <LoadingSmall />;
     }
 
     // Format the boss data
-    const bossArray = formatBossData(bosses);
+    const bossArray = formatBossData(maps);
 
     // Return the home page boss React component
     return (
@@ -40,7 +40,7 @@ export function BossPageList() {
             {bossArray.map((boss) => {
 
                 // Format the boss name for links
-                var key = boss.normalizedName.toLowerCase().replace(/ /g, '-');
+                var key = boss.normalizedName;
 
                 return (
                     <Link to={`/boss/${key}`} className="screen-link" key={`boss-${key}`}>
@@ -59,16 +59,16 @@ export function BossPageList() {
 
 // BossListNav component for homepage nav bar
 export function BossListNav(onClick) {
-    // Fetch bosses
-    const { data: bosses } = useBossesQuery();
+    // Fetch maps
+    const { data: maps } = useMapsQuery();
 
-    // If no bosses have been returned yet, return 'loading'
-    if (!bosses || bosses.length === 0) {
+    // If no maps have been returned yet, return 'loading'
+    if (!maps || maps.length === 0) {
         return null;
     }
 
     // Format the boss data
-    const bossArray = formatBossData(bosses);
+    const bossArray = formatBossData(maps);
 
     // Return the home page nav boss React component
     return (
@@ -76,7 +76,7 @@ export function BossListNav(onClick) {
             <ul>
                 {bossArray.map((boss) => {
                     // Format the boss name for links
-                    var key = boss.normalizedName.toLowerCase().replace(/ /g, '-');
+                    var key = boss.normalizedName;
 
                     return (
                         <MenuItem
@@ -94,16 +94,16 @@ export function BossListNav(onClick) {
 
 // BossList component for homepage
 function BossList() {
-    // Fetch bosses
-    const { data: bosses } = useBossesQuery();
+    // Fetch maps
+    const { data: maps } = useMapsQuery();
 
-    // If no bosses have been returned yet, return 'loading'
-    if (!bosses || bosses.length === 0) {
+    // If no maps have been returned yet, return 'loading'
+    if (!maps || maps.length === 0) {
         return <LoadingSmall />;
     }
 
     // Format the boss data
-    const bossArray = formatBossData(bosses);
+    const bossArray = formatBossData(maps);
 
     // Return the home page boss React component
     return (
@@ -111,7 +111,7 @@ function BossList() {
             {bossArray.map((boss) => {
 
                 // Format the boss name for links
-                var key = boss.normalizedName.toLowerCase().replace(/ /g, '-');
+                var key = boss.normalizedName;
 
                 return (
                     <li key={`boss-link-${key}`}>

--- a/src/components/contained-items-list/index.js
+++ b/src/components/contained-items-list/index.js
@@ -18,7 +18,7 @@ const ContainedItemsList = ({ item }) => {
         return null;
     }
 
-    const sortedItems = items.filter(linkedItem => {
+    let sortedItems = items.filter(linkedItem => {
         for (const slot of containers) {
             /*const included = slot.filters.allowedItems.includes(linkedItem.id) ||
                 linkedItem.categoryIds.some(catId => slot.filters.allowedCategories.includes(catId));
@@ -38,7 +38,15 @@ const ContainedItemsList = ({ item }) => {
             }
         }
     });
-    
+console.log(sortedItems);
+    sortedItems = sortedItems.reduce((allItems, current) => {
+        if (!allItems.some(item => item.id === current.id))
+            allItems.push(current);
+        return allItems;
+    }, []);
+    if (sortedItems.length === 1 && sortedItems[0].id === '54009119af1c881c07000029') {
+        return null;
+    }
     sortedItems.sort((a,b) => {
         const textA = a.normalizedName;
         const textB = b.normalizedName;

--- a/src/components/contained-items-list/index.js
+++ b/src/components/contained-items-list/index.js
@@ -38,7 +38,7 @@ const ContainedItemsList = ({ item }) => {
             }
         }
     });
-console.log(sortedItems);
+
     sortedItems = sortedItems.reduce((allItems, current) => {
         if (!allItems.some(item => item.id === current.id))
             allItems.push(current);

--- a/src/components/reward-cell/index.js
+++ b/src/components/reward-cell/index.js
@@ -28,9 +28,10 @@ function RewardCell(props) {
                         {name}
                     </Link>
                 </div>
-                <div className="source-wrapper">{source}{barterOnly && <span> ({t('Barter only')})</span>}</div>
+                <div className="source-wrapper">{source}</div>{barterOnly && <span> ({t('Barter only')})</span>}
                 <div className="price-wrapper">
                     {formatPrice(sellValue)} <span>@</span> {sellTo}
+                    {barterOnly && <span> ({t('Barter only')})</span>}
                 </div>
             </div>
         </div>

--- a/src/components/reward-cell/index.js
+++ b/src/components/reward-cell/index.js
@@ -28,7 +28,7 @@ function RewardCell(props) {
                         {name}
                     </Link>
                 </div>
-                <div className="source-wrapper">{source}</div>{barterOnly && <span> ({t('Barter only')})</span>}
+                <div className="source-wrapper">{source}</div>
                 <div className="price-wrapper">
                     {formatPrice(sellValue)} <span>@</span> {sellTo}
                     {barterOnly && <span> ({t('Barter only')})</span>}

--- a/src/components/reward-cell/index.js
+++ b/src/components/reward-cell/index.js
@@ -28,10 +28,9 @@ function RewardCell(props) {
                         {name}
                     </Link>
                 </div>
-                <div className="source-wrapper">{source}</div>
+                <div className="source-wrapper">{source}{barterOnly && <span> ({t('Barter only')})</span>}</div>
                 <div className="price-wrapper">
                     {formatPrice(sellValue)} <span>@</span> {sellTo}
-                    {barterOnly && <span> ({t('Barter only')})</span>}
                 </div>
             </div>
         </div>

--- a/src/components/reward-cell/index.js
+++ b/src/components/reward-cell/index.js
@@ -13,7 +13,7 @@ function RewardCell(props) {
         itemLink,
         name,
         source,
-        value,
+        sellValue,
         sellTo,
         barterOnly = false,
     } = props;
@@ -30,7 +30,7 @@ function RewardCell(props) {
                 </div>
                 <div className="source-wrapper">{source}</div>
                 <div className="price-wrapper">
-                    {formatPrice(value)} <span>@</span> {sellTo}
+                    {formatPrice(sellValue)} <span>@</span> {sellTo}
                     {barterOnly && <span> ({t('Barter only')})</span>}
                 </div>
             </div>

--- a/src/components/small-item-table/index.js
+++ b/src/components/small-item-table/index.js
@@ -155,6 +155,7 @@ function SmallItemTable(props) {
         cheapestPrice,
         sumColumns,
         totalTraderPrice,
+        idFilter,
     } = props;
     const dispatch = useDispatch();
     const { t } = useTranslation();
@@ -466,6 +467,13 @@ function SmallItemTable(props) {
 
         if (defaultRandom && !nameFilter) {
             shuffleArray(returnData);
+        }
+
+        if (idFilter) {
+            if (!Array.isArray(idFilter)) {
+                idFilter = [idFilter];
+            }
+            returnData = returnData.filter(item => idFilter.includes(item.id));
         }
 
         return returnData;

--- a/src/components/small-item-table/index.js
+++ b/src/components/small-item-table/index.js
@@ -470,10 +470,8 @@ function SmallItemTable(props) {
         }
 
         if (idFilter) {
-            if (!Array.isArray(idFilter)) {
-                idFilter = [idFilter];
-            }
-            returnData = returnData.filter(item => idFilter.includes(item.id));
+            const idArray = Array.isArray(idFilter) ? idFilter : [idFilter];
+            returnData = returnData.filter(item => idArray.includes(item.id));
         }
 
         return returnData;
@@ -498,7 +496,8 @@ function SmallItemTable(props) {
         materialDestructibilityMap,
         materialRepairabilityMap,
         settings,
-        showAllSources
+        showAllSources,
+        idFilter
     ]);
 
     const columns = useMemo(() => {

--- a/src/components/value-cell/index.js
+++ b/src/components/value-cell/index.js
@@ -5,7 +5,7 @@ import './index.css';
 function ValueCell({ value, highlightProfit, children, noValue = '-', count = 1 }) {
     let className = 'center-content';
 
-    if (highlightProfit) {
+    if (highlightProfit && value !== 0) {
         className = `${className} ${value > 0 ? 'craft-profit' : 'craft-loss'}`;
     }
 

--- a/src/data/boss.json
+++ b/src/data/boss.json
@@ -14,69 +14,56 @@
         "behavior": "patrol",
         "loot": [
             {
-                "name": "Gen4 HMK",
-                "itemLink": "/item/iotv-gen4-body-armor-high-mobility-kit",
-                "iconLink": "https://assets.tarkov.dev/5b44d0de86f774503d30cba8-icon.jpg"
+                "id": "5b44d0de86f774503d30cba8",
+                "name": "Gen4 HMK"
             },
             {
-                "name": "Trooper",
-                "itemLink": "/item/highcom-trooper-tfo-body-armor-multicam",
-                "iconLink": "https://assets.tarkov.dev/5c0e655586f774045612eeb2-icon.jpg"
+                "id": "5c0e655586f774045612eeb2",
+                "name": "Trooper"
             },
             {
-                "name": "Hexgrid",
-                "itemLink": "/item/511-tactical-hexgrid-plate-carrier",
-                "iconLink": "https://assets.tarkov.dev/5fd4c474dd870108a754b241-icon.jpg"
+                "id": "5fd4c474dd870108a754b241",
+                "name": "Hexgrid"
             },
             {
-                "name": "Slick",
-                "itemLink": "/item/lbt-6094a-slick-plate-carrier",
-                "iconLink": "https://assets.tarkov.dev/5e4abb5086f77406975c9342-icon.jpg"
+                "id": "5e4abb5086f77406975c9342",
+                "name": "Slick"
             },
             {
-                "name": "EXFIL Black",
-                "itemLink": "/item/team-wendy-exfil-ballistic-helmet-black",
-                "iconLink": "https://assets.tarkov.dev/5e00c1ad86f774747333222c-icon.jpg"
+                "id": "5e00c1ad86f774747333222c",
+                "name": "EXFIL Black"
             },
             {
-                "name": "EXFIL CB",
-                "itemLink": "/item/team-wendy-exfil-ballistic-helmet-coyote-brown",
-                "iconLink": "https://assets.tarkov.dev/5e01ef6886f77445f643baa4-icon.jpg"
+                "id": "5e01ef6886f77445f643baa4",
+                "name": "EXFIL CB"
             },
             {
-                "name": "AK-104",
-                "itemLink": "/item/kalashnikov-ak-104-762x39-assault-rifle",
-                "iconLink": "https://assets.tarkov.dev/5ac66d725acfc43b321d4b60-icon.jpg"
+                "id": "5ac66d725acfc43b321d4b60",
+                "name": "AK-104"
             },
             {
-                "name": "SCAR-L",
-                "itemLink": "/item/fn-scar-l-556x45-assault-rifle",
-                "iconLink": "https://assets.tarkov.dev/6184055050224f204c1da540-icon.jpg"
+                "id": "6184055050224f204c1da540",
+                "name": "SCAR-L"
             },
             {
-                "name": "Galvion Caiman Hybrid helmet",
-                "itemLink": "/item/galvion-caiman-hybrid-helmet",
-                "iconLink": "https://assets.tarkov.dev/5f60b34a41e30a4ab12a6947-icon.jpg"
+                "id": "5f60b34a41e30a4ab12a6947",
+                "name": "Galvion Caiman Hybrid helmet"
             },
             {
-                "name": "M4A1",
-                "itemLink": "/item/colt-m4a1-556x45-assault-rifle",
-                "iconLink": "https://assets.tarkov.dev/5447a9cd4bdc2dbd208b4567-icon.jpg"
+                "id": "5447a9cd4bdc2dbd208b4567",
+                "name": "M4A1"
             },
             {
-                "name": "HK 416A5",
-                "itemLink": "/item/hk-416a5-556x45-assault-rifle",
-                "iconLink": "https://assets.tarkov.dev/5bb2475ed4351e00853264e3-icon.jpg"
+                "id": "5bb2475ed4351e00853264e3",
+                "name": "HK 416A5"
             },
             {
-                "name": "SR-25",
-                "itemLink": "/item/knights-armament-company-sr-25-762x51-marksman-rifle",
-                "iconLink": "https://assets.tarkov.dev/5df8ce05b11454561e39243b-icon.jpg"
+                "id": "5df8ce05b11454561e39243b",
+                "name": "SR-25"
             },
             {
-                "name": "AFAK",
-                "itemLink": "/item/afak-tactical-individual-first-aid-kit",
-                "iconLink": "https://assets.tarkov.dev/60098ad7c2240c0fe85c570a-icon.jpg"
+                "id": "60098ad7c2240c0fe85c570a",
+                "name": "AFAK"
             }
         ]
     },
@@ -100,29 +87,24 @@
         "behavior": "rush",
         "loot": [
             {
-                "name": "AK-104",
-                "itemLink": "/item/kalashnikov-ak-104-762x39-assault-rifle",
-                "iconLink": "https://assets.tarkov.dev/5ac66d725acfc43b321d4b60-icon.jpg"
+                "id": "5ac66d725acfc43b321d4b60",
+                "name": "AK-104"
             },
             {
-                "name": "Gen4 HMK",
-                "itemLink": "/item/iotv-gen4-body-armor-high-mobility-kit",
-                "iconLink": "https://assets.tarkov.dev/5b44d0de86f774503d30cba8-icon.jpg"
+                "id": "5b44d0de86f774503d30cba8",
+                "name": "Gen4 HMK"
             },
             {
-                "name": "Trooper",
-                "itemLink": "/item/highcom-trooper-tfo-body-armor-multicam",
-                "iconLink": "https://assets.tarkov.dev/5c0e655586f774045612eeb2-icon.jpg"
+                "id": "5c0e655586f774045612eeb2",
+                "name": "Trooper"
             },
             {
-                "name": "Hexgrid",
-                "itemLink": "/item/511-tactical-hexgrid-plate-carrier",
-                "iconLink": "https://assets.tarkov.dev/5fd4c474dd870108a754b241-icon.jpg"
+                "id": "5fd4c474dd870108a754b241",
+                "name": "Hexgrid"
             },
             {
-                "name": "AFAK",
-                "itemLink": "/item/afak-tactical-individual-first-aid-kit",
-                "iconLink": "https://assets.tarkov.dev/60098ad7c2240c0fe85c570a-icon.jpg"
+                "id": "60098ad7c2240c0fe85c570a",
+                "name": "AFAK"
             }
         ]
     },
@@ -133,19 +115,16 @@
         "health": 850,
         "loot": [
             {
-                "name": "Secure Flash drive",
-                "itemLink": "/item/secure-flash-drive",
-                "iconLink": "https://assets.tarkov.dev/590c621186f774138d11ea29-icon.jpg"
+                "id": "590c621186f774138d11ea29",
+                "name": "Secure Flash drive"
             },
             {
-                "name": "SAS drive",
-                "itemLink": "/item/sas-drive",
-                "iconLink": "https://assets.tarkov.dev/590c37d286f77443be3d7827-icon.jpg"
+                "id": "590c37d286f77443be3d7827",
+                "name": "SAS drive"
             },
             {
-                "name": "Cultist knife",
-                "itemLink": "/item/cultist-knife",
-                "iconLink": "https://assets.tarkov.dev/5fc64ea372b0dd78d51159dc-icon.jpg"
+                "id": "5fc64ea372b0dd78d51159dc",
+                "name": "Cultist knife"
             }
         ],
         "wikiLink": "https://escapefromtarkov.fandom.com/wiki/cultists",
@@ -158,14 +137,12 @@
         "health": 1120,
         "loot": [
             {
-                "name": "Death Knight mask",
-                "itemLink": "/item/death-knight-mask",
-                "iconLink": "https://assets.tarkov.dev/62963c18dbc8ab5f0d382d0b-grid-image.jpg"
+                "id": "62963c18dbc8ab5f0d382d0b",
+                "name": "Death Knight mask"
             },
             {
-                "name": "Crye Precision CPC plate carrier (Goons Edition)",
-                "itemLink": "/item/crye-precision-cpc-plate-carrier-goons-edition",
-                "iconLink": "https://assets.tarkov.dev/628b9c7d45122232a872358f-grid-image.jpg"
+                "id": "628b9c7d45122232a872358f",
+                "name": "Crye Precision CPC plate carrier (Goons Edition)"
             }
         ],
         "wikiLink": "https://escapefromtarkov.fandom.com/wiki/knight",
@@ -178,14 +155,12 @@
         "health": 1010,
         "loot": [
             {
-                "name": "GP Coin",
-                "itemLink": "/item/gp-coin",
-                "iconLink": "https://assets.tarkov.dev/5d235b4d86f7742e017bc88a-icon.jpg"
+                "id": "5d235b4d86f7742e017bc88a",
+                "name": "GP Coin"
             },
             {
-                "name": "ASh-12",
-                "itemLink": "/item/ash-12-127x55-assault-rifle",
-                "iconLink": "https://assets.tarkov.dev/5cadfbf7ae92152ac412eeef-icon.jpg"
+                "id": "5cadfbf7ae92152ac412eeef",
+                "name": "ASh-12"
             }
         ],
         "wikiLink": "https://escapefromtarkov.fandom.com/wiki/glukhar",
@@ -198,14 +173,12 @@
         "health": 890,
         "loot": [
             {
-                "name": "6B13 M modified assault armor (Tan)",
-                "itemLink": "/item/6b13-m-modified-assault-armor-tan",
-                "iconLink": "https://assets.tarkov.dev/5c0e541586f7747fa54205c9-icon.jpg"
+                "id": "5c0e541586f7747fa54205c9",
+                "name": "6B13 M modified assault armor (Tan)"
             },
             {
-                "name": "Maska-1SCh (Killa)",
-                "itemLink": "/item/maska-1sch-bulletproof-helmet-killa",
-                "iconLink": "https://assets.tarkov.dev/5c0e874186f7745dc7616606-icon.jpg"
+                "id": "5c0e874186f7745dc7616606",
+                "name": "Maska-1SCh (Killa)"
             }
         ],
         "wikiLink": "https://escapefromtarkov.fandom.com/wiki/killa",
@@ -218,14 +191,12 @@
         "health": 752,
         "loot": [
             {
-                "name": "TT-33 7.62x25 TT pistol (Golden)",
-                "itemLink": "/item/tt-33-762x25-tt-pistol-golden",
-                "iconLink": "https://assets.tarkov.dev/5b3b713c5acfc4330140bd8d-icon.jpg"
+                "id": "5b3b713c5acfc4330140bd8d",
+                "name": "TT-33 7.62x25 TT pistol (Golden)"
             },
             {
-                "name": "Physical bitcoin",
-                "itemLink": "/item/physical-bitcoin",
-                "iconLink": "https://assets.tarkov.dev/59faff1d86f7746c51718c9c-icon.jpg"
+                "id": "59faff1d86f7746c51718c9c",
+                "name": "Physical bitcoin"
             }
         ],
         "wikiLink": "https://escapefromtarkov.fandom.com/wiki/reshala",
@@ -238,24 +209,20 @@
         "health": 1270,
         "loot": [
             {
-                "name": "Sanitar's bag",
-                "itemLink": "/item/sanitars-bag",
-                "iconLink": "https://assets.tarkov.dev/5e997f0b86f7741ac73993e2-icon.jpg"
+                "id": "5e997f0b86f7741ac73993e2",
+                "name": "Sanitar's bag"
             },
             {
-                "name": "LEDX",
-                "itemLink": "/item/ledx-skin-transilluminator",
-                "iconLink": "https://assets.tarkov.dev/5c0530ee86f774697952d952-icon.jpg"
+                "id": "5c0530ee86f774697952d952",
+                "name": "LEDX"
             },
             {
-                "name": "Keycard with a blue marking",
-                "itemLink": "/item/keycard-with-a-blue-marking",
-                "iconLink": "https://assets.tarkov.dev/5efde6b4f5448336730dbd61-icon.jpg"
+                "id": "5efde6b4f5448336730dbd61",
+                "name": "Keycard with a blue marking"
             },
             {
-                "name": "Health Resort office key with a blue tape",
-                "itemLink": "/item/health-resort-office-key-with-a-blue-tape",
-                "iconLink": "https://assets.tarkov.dev/5eff09cd30a7dc22fd1ddfed-icon.jpg"
+                "id": "5eff09cd30a7dc22fd1ddfed",
+                "name": "Health Resort office key with a blue tape"
             }
         ],
         "wikiLink": "https://escapefromtarkov.fandom.com/wiki/sanitar",
@@ -268,14 +235,12 @@
         "health": 812,
         "loot": [
             {
-                "name": "Shturman's stash key",
-                "itemLink": "/item/shturmans-stash-key",
-                "iconLink": "https://assets.tarkov.dev/5d08d21286f774736e7c94c3-icon.jpg"
+                "id": "5d08d21286f774736e7c94c3",
+                "name": "Shturman's stash key"
             },
             {
-                "name": "Red Rebel ice pick",
-                "itemLink": "/item/red-rebel-ice-pick",
-                "iconLink": "https://assets.tarkov.dev/5c0126f40db834002a125382-icon.jpg"
+                "id": "5c0126f40db834002a125382",
+                "name": "Red Rebel ice pick"
             }
         ],
         "wikiLink": "https://escapefromtarkov.fandom.com/wiki/shturman",
@@ -288,14 +253,12 @@
         "health": 1220,
         "loot": [
             {
-                "name": "Crye Precision AVS MBAV (Tagilla Edition)",
-                "itemLink": "/item/crye-precision-avs-mbav-tagilla-edition",
-                "iconLink": "https://assets.tarkov.dev/609e860ebd219504d8507525-icon.jpg"
+                "id": "609e860ebd219504d8507525",
+                "name": "Crye Precision AVS MBAV (Tagilla Edition)"
             },
             {
-                "name": "L1 (Norepinephrine) injector",
-                "itemLink": "/item/l1-norepinephrine-injector",
-                "iconLink": "https://assets.tarkov.dev/5ed515e03a40a50460332579-icon.jpg"
+                "id": "5ed515e03a40a50460332579",
+                "name": "L1 (Norepinephrine) injector"
             },
             {
                 "name": "Physical bitcoin",
@@ -303,19 +266,16 @@
                 "iconLink": "https://assets.tarkov.dev/59faff1d86f7746c51718c9c-icon.jpg"
             },
             {
-                "name": "Tagilla's welding mask 'UBEY'",
-                "itemLink": "/item/tagillas-welding-mask-ubey",
-                "iconLink": "https://assets.tarkov.dev/60a7ad2a2198820d95707a2e-icon.jpg"
+                "id": "60a7ad2a2198820d95707a2e",
+                "name": "Tagilla's welding mask 'UBEY'"
             },
             {
-                "name": "Tagilla's welding mask 'Gorilla'",
-                "itemLink": "/item/tagillas-welding-mask-gorilla",
-                "iconLink": "https://assets.tarkov.dev/60a7ad3a0c5cb24b0134664a-icon.jpg"
+                "id": "60a7ad3a0c5cb24b0134664a",
+                "name": "Tagilla's welding mask 'Gorilla'"
             },
             {
-                "name": "BOSS cap",
-                "itemLink": "/item/boss-cap",
-                "iconLink": "https://assets.tarkov.dev/60a7acf20c5cb24b01346648-icon.jpg"
+                "id": "60a7acf20c5cb24b01346648",
+                "name": "BOSS cap"
             }
         ],
         "wikiLink": "https://escapefromtarkov.fandom.com/wiki/tagilla",

--- a/src/data/boss.json
+++ b/src/data/boss.json
@@ -71,15 +71,10 @@
         "name": "Raider",
         "normalizedName": "raider",
         "details": "Scav raiders (also known as just 'raiders') are advanced Scavs that are considerably stronger and more tactical than your typical Scavs. They carry significantly more dangerous weapons and use higher tier ammunition. Additionally, they have much better aim and can frequently drop well geared players with only a few bullets (or you just get head-eyes'd). Scav raiders also patrol in multiple groups and can usually be distinguished by their gear, unique voicelines, and general aggression. Scav Raiders start out friendly to all other Scavs (including player scavs) but they will become hostile if you get to close and ignore their verbal warnings. They will also become hostile to all Scavs if any Scav angers them.",
-        "spawnChanceOverrideString": true,
         "spawnChanceOverride": [
             {
-                "chance": "~15-35%",
-                "map": "reserve"
-            },
-            {
-                "chance": "100%",
-                "map": "The Lab"
+                "chance": 1,
+                "map": "the-lab"
             }
         ],
         "wikiLink": "https://escapefromtarkov.fandom.com/wiki/raiders",

--- a/src/data/item-grids.json
+++ b/src/data/item-grids.json
@@ -2654,5 +2654,31 @@
             "width": 1,
             "height": 1
         }
+    ],
+    "628cd624459354321c4b7fa2": [
+        {
+            "row": 0,
+            "col": 0,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 0,
+            "col": 1,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 0,
+            "col": 2,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 0,
+            "col": 3,
+            "width": 1,
+            "height": 2
+        }
     ]
 }

--- a/src/data/item-grids.json
+++ b/src/data/item-grids.json
@@ -2380,5 +2380,279 @@
             "width": 2,
             "height": 2
         }
+    ],
+    "628b9c7d45122232a872358f": [
+        {
+            "row": 0.5,
+            "col": 0,
+            "width": 1,
+            "height": 3
+        },
+        {
+            "row": 0,
+            "col": 1,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 0,
+            "col": 2,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 0,
+            "col": 3,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 2,
+            "col": 1,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 2,
+            "col": 2,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 2,
+            "col": 3,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 0.5,
+            "col": 4,
+            "width": 1,
+            "height": 3
+        }
+    ],
+    "628b9784bcf6e2659e09b8a2": [
+        {
+            "row": 0,
+            "col": 0,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 0,
+            "col": 1,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 0,
+            "col": 2,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 0,
+            "col": 3,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 0,
+            "col": 4,
+            "width": 1,
+            "height": 2
+        }
+    ],
+    "628d0618d1ba6e4fa07ce5a4": [
+        {
+            "row": 0,
+            "col": 0,
+            "width": 1,
+            "height": 1
+        },
+        {
+            "row": 0,
+            "col": 1,
+            "width": 1,
+            "height": 1
+        },
+        {
+            "row": 0,
+            "col": 2,
+            "width": 1,
+            "height": 1
+        },
+        {
+            "row": 0,
+            "col": 3,
+            "width": 1,
+            "height": 1
+        },
+        {
+            "row": 0,
+            "col": 4,
+            "width": 1,
+            "height": 1
+        },
+        {
+            "row": 1,
+            "col": 0,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 1,
+            "col": 1,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 1,
+            "col": 2,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 1,
+            "col": 3,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 1,
+            "col": 4,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 3,
+            "col": 0,
+            "width": 2,
+            "height": 2
+        },
+        {
+            "row": 3,
+            "col": 2,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 3,
+            "col": 3,
+            "width": 2,
+            "height": 2
+        }
+    ],
+    "628dc750b910320f4c27a732": [
+        {
+            "row": 0,
+            "col": 1,
+            "width": 1,
+            "height": 3
+        },
+        {
+            "row": 0,
+            "col": 2,
+            "width": 1,
+            "height": 3
+        },
+        {
+            "row": 0,
+            "col": 3,
+            "width": 1,
+            "height": 3
+        },
+        {
+            "row": 1,
+            "col": 0,
+            "width": 1,
+            "height": 1
+        },
+        {
+            "row": 1,
+            "col": 4,
+            "width": 1,
+            "height": 1
+        },
+        {
+            "row": 2,
+            "col": 0,
+            "width": 1,
+            "height": 1
+        },
+        {
+            "row": 2,
+            "col": 4,
+            "width": 1,
+            "height": 1
+        },
+        {
+            "row": 3,
+            "col": 0,
+            "width": 1,
+            "height": 1
+        },
+        {
+            "row": 3,
+            "col": 4,
+            "width": 1,
+            "height": 1
+        },
+        {
+            "row": 3,
+            "col": 1.5,
+            "width": 2,
+            "height": 2
+        }
+    ],
+    "628baf0b967de16aab5a4f36": [
+        {
+            "row": 0,
+            "col": 0,
+            "width": 2,
+            "height": 2
+        },
+        {
+            "row": 0,
+            "col": 2,
+            "width": 2,
+            "height": 2
+        },
+        {
+            "row": 2,
+            "col": 0,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 2,
+            "col": 1,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 2,
+            "col": 2,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 2,
+            "col": 3,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 4,
+            "col": 1,
+            "width": 1,
+            "height": 1
+        },
+        {
+            "row": 4,
+            "col": 2,
+            "width": 1,
+            "height": 1
+        }
     ]
 }

--- a/src/features/maps/do-fetch-maps.js
+++ b/src/features/maps/do-fetch-maps.js
@@ -1,6 +1,6 @@
 import { langCode } from '../../modules/lang-helpers';
 
-const doFetchBosses = async () => {
+const doFetchMaps = async () => {
     const language = await langCode();
     const bodyQuery = JSON.stringify({
         query: `{
@@ -47,9 +47,9 @@ const doFetchBosses = async () => {
         body: bodyQuery,
     });
 
-    const bossData = await response.json();
+    const mapsData = await response.json();
 
-    return bossData.data;
+    return mapsData.data.maps;
 };
 
-export default doFetchBosses;
+export default doFetchMaps;

--- a/src/modules/format-boss-data.js
+++ b/src/modules/format-boss-data.js
@@ -27,7 +27,7 @@ function formatBossData(maps) {
                 };
                 bossArray.push(savedBoss);
             }
-            let bossMap = savedBoss.maps.find(savedMap => savedMap.normalizedName === map.normalizedName);
+            let bossMap = savedBoss.maps.find(savedMap => savedMap.id === map.id);
             if (!bossMap) {
                 bossMap = {
                     name: map.name,

--- a/src/modules/format-boss-data.js
+++ b/src/modules/format-boss-data.js
@@ -1,14 +1,14 @@
 function formatBossData(maps) {
 
     // Try to get the formatted boss data from session storage
-    const dataObj = sessionStorage.getItem('boss-array-new');
+    /*const dataObj = sessionStorage.getItem('boss-array-new');
     if (dataObj) {
         try {
             return JSON.parse(dataObj);
         } catch (e) {
             console.log(e);
         }
-    }
+    }*/
 
     const bossArray = [];
 
@@ -45,7 +45,7 @@ function formatBossData(maps) {
     }
 
     // Save to session storage and return the formatted boss data
-    sessionStorage.setItem('boss-array-new', JSON.stringify(bossArray));
+    //sessionStorage.setItem('boss-array-new', JSON.stringify(bossArray));
     return bossArray;
 }
 

--- a/src/modules/format-cost-items.js
+++ b/src/modules/format-cost-items.js
@@ -8,7 +8,7 @@ function getCheapestItemPrice(item, settings, allowAllSources) {
         if (buyFor.vendor.normalizedName === 'flea-market') {
             return (allowAllSources || settings.hasFlea);
         }
-        return (allowAllSources || settings[buyFor.vendor.normalizedName] > buyFor.vendor.minTraderLevel)
+        return (allowAllSources || settings[buyFor.vendor.normalizedName] >= buyFor.vendor.minTraderLevel)
     });
     if (!buySource || buySource.length === 0) {
         let sellToTrader = item.sellFor.filter(sellFor => {

--- a/src/modules/format-cost-items.js
+++ b/src/modules/format-cost-items.js
@@ -23,7 +23,7 @@ function getCheapestItemPrice(item, settings, allowAllSources) {
         } else {
             sellToTrader = sellToTrader[0];
         }
-        return {...sellToTrader, type: 'cash'};
+        return {...sellToTrader, type: 'cash-sell'};
     } else {
         if (buySource.length > 1) {
             buySource = buySource.reduce((prev, current) => {
@@ -115,7 +115,7 @@ function getCheapestItemPriceWithBarters(item, barters, settings, allowAllSource
         }
     }
  
-    if (bestBarter && (!bestPrice.price || barterTotalCost < bestPrice.price)) {
+    if (bestBarter && (!bestPrice.price || barterTotalCost < bestPrice.price || bestPrice.type === 'cash-sell')) {
         bestPrice.price = barterTotalCost;
         bestPrice.priceRUB = barterTotalCost;
         bestPrice.type = 'barter';
@@ -216,6 +216,6 @@ const formatCostItems = (
     });
 };
 
-export { getItemBarters, getCheapestItemPriceWithBarters, getCheapestBarter };
+export { formatCostItems, getItemBarters, getCheapestItemPrice, getCheapestItemPriceWithBarters, getCheapestBarter };
 
 export default formatCostItems;

--- a/src/pages/bitcoin-farm-calculator/index.js
+++ b/src/pages/bitcoin-farm-calculator/index.js
@@ -106,7 +106,7 @@ const BitcoinFarmCalculator = () => {
                         iconLink={graphicCardItem.iconLink}
                         itemLink={`/item/${graphicCardItem.normalizedName}`}
                         name={graphicCardItem.name}
-                        value={graphicsCardBuy.priceRUB}
+                        sellValue={graphicsCardBuy.priceRUB}
                         sellTo={t(capitalizeFirst(
                             graphicsCardBuy.source.replace(/-/g, ' '),
                         ))}
@@ -118,7 +118,7 @@ const BitcoinFarmCalculator = () => {
                         iconLink={bitcoinItem.iconLink}
                         itemLink={`/item/${bitcoinItem.normalizedName}`}
                         name={bitcoinItem.name}
-                        value={btcSell.priceRUB}
+                        sellValue={btcSell.priceRUB}
                         sellTo={t(capitalizeFirst(
                             btcSell.source.replace(/-/g, ' '),
                         ))}

--- a/src/pages/bosses/boss/index.js
+++ b/src/pages/bosses/boss/index.js
@@ -4,13 +4,13 @@ import { useTranslation } from 'react-i18next';
 import { useParams, Link } from 'react-router-dom';
 import capitalize from '../../../modules/capitalize-first';
 import formatBossData from '../../../modules/format-boss-data';
-import ItemNameCell from '../../../components/item-name-cell';
 import { useBossesQuery } from '../../../components/boss-list';
 import DataTable from '../../../components/data-table';
 import PropertyList from '../../../components/property-list';
 import bossJson from '../../../data/boss.json';
 import ErrorPage from '../../../components/error-page';
 import Loading from '../../../components/loading';
+import SmallItemTable from '../../../components/small-item-table';
 import Icon from '@mdi/react';
 import CheekiBreekiEffect from '../../../components/cheeki-breeki-effect';
 import { mdiEmoticonDevil, mdiPoll, mdiDiamondStone, mdiMapLegend, mdiAccountGroup, mdiPartyPopper } from '@mdi/js';
@@ -69,17 +69,6 @@ function BossPage(params) {
                 Header: t('Chance'),
                 accessor: 'chance',
                 Cell: CenterCell
-            }
-        ];
-    }, [t]);
-
-    // Format the boss table columns for locations
-    const columnsLoot = useMemo(() => {
-        return [
-            {
-                Header: t('Name'),
-                accessor: 'name',
-                Cell: ItemNameCell
             }
         ];
     }, [t]);
@@ -237,7 +226,7 @@ function BossPage(params) {
 
                 {bossJsonData &&
                     <h2 className='item-h2' key={'boss-loot-header'}>
-                        {t('Unique Boss Loot')}
+                        {t('Special Boss Loot')}
                         <Icon
                             path={mdiDiamondStone}
                             size={1.5}
@@ -247,14 +236,13 @@ function BossPage(params) {
                 }
                 {bossJsonData &&
                     <div className='loot-table-boss'>
-                        <DataTable
-                            columns={columnsLoot}
-                            data={bossJsonData.loot}
-                            disableSortBy={false}
-                            key={'boss-loot-table'}
-                            sortBy={'name'}
-                            sortByDesc={true}
-                            autoResetSortBy={false}
+                        <SmallItemTable
+                            idFilter={bossJsonData.loot.reduce((prev, current) => {
+                                prev.push(current.id);
+                                return prev;
+                            }, [])}
+                            fleaValue
+                            traderValue
                         />
                     </div>
                 }

--- a/src/pages/bosses/boss/index.js
+++ b/src/pages/bosses/boss/index.js
@@ -112,7 +112,7 @@ function BossPage(params) {
 
     // Collect spawn stats for each map
     var spawnStatsMsg = [];
-console.log(bossData);
+
     for (const map of bossData.maps) {
         // If a specific boss override exists, use that instead of the default from the API
         const spawnChanceOverride = bossJsonData?.spawnChanceOverride?.find(override => override.map === map.normalizedName);

--- a/src/pages/bosses/boss/index.js
+++ b/src/pages/bosses/boss/index.js
@@ -112,7 +112,7 @@ function BossPage(params) {
 
     // Collect spawn stats for each map
     var spawnStatsMsg = [];
-
+console.log(bossData);
     for (const map of bossData.maps) {
         // If a specific boss override exists, use that instead of the default from the API
         const spawnChanceOverride = bossJsonData?.spawnChanceOverride?.find(override => override.map === map.normalizedName);

--- a/src/pages/bosses/boss/index.js
+++ b/src/pages/bosses/boss/index.js
@@ -1,10 +1,10 @@
 import { Helmet } from 'react-helmet';
 import React, { Suspense, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams, Link } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import capitalize from '../../../modules/capitalize-first';
 import formatBossData from '../../../modules/format-boss-data';
-import { useBossesQuery } from '../../../components/boss-list';
+import { useMapsQuery } from '../../../components/boss-list';
 import DataTable from '../../../components/data-table';
 import PropertyList from '../../../components/property-list';
 import bossJson from '../../../data/boss.json';
@@ -75,25 +75,19 @@ function BossPage(params) {
 
     const bossNameLower = params.bossName
 
-    // Fetch bosses
-    const { data: bosses } = useBossesQuery();
+    // Fetch maps
+    const { data: maps } = useMapsQuery();
 
-    // If no bosses have been returned yet, return 'loading'
-    if (!bosses || bosses.length === 0) {
+    // If no maps have been returned yet, return 'loading'
+    if (!maps || maps.length === 0) {
         return <Loading />;
     }
 
     // Format the boss data
-    const bossArray = formatBossData(bosses);
+    const bossArray = formatBossData(maps);
 
     // Get the correct individual boss data
-    var bossData = null;
-    for (const boss of bossArray) {
-        if (boss.normalizedName === bossNameLower) {
-            bossData = boss;
-            break;
-        }
-    }
+    var bossData = bossArray.find(boss => boss.normalizedName === bossNameLower);
 
     // If no boss data has been found, return the error page
     if (!bossData) {
@@ -101,43 +95,48 @@ function BossPage(params) {
     }
 
     // Get static boss data from json file
-    var bossJsonData = null;
-    for (const boss of bossJson) {
-        if (boss.normalizedName === bossNameLower) {
-            bossJsonData = boss;
-        }
-    }
+    var bossJsonData = bossJson.find(boss => boss.normalizedName === bossNameLower);
 
     // Collect a list of all maps without duplicates
-    var maps = [];
-    for (const map of bossData.spawnChance) {
-        if (maps.includes(map.map)) {
+    var bossMaps = [];
+    for (const map of bossData.maps) {
+        if (bossMaps.includes(map.name)) {
             continue;
         }
-        maps.push(map.map);
+        bossMaps.push(map.name);
     }
 
     // Format the bossProperties data for the 'stats' section
     var bossProperties = {}
-    bossProperties[t('map') + ' 🗺️'] = maps;
+    bossProperties[t('map') + ' 🗺️'] = bossMaps;
 
     // Collect spawn stats for each map
     var spawnStatsMsg = [];
 
-    // If a specific boss override exists, use that instead of the default from the API
-    if (bossJsonData && bossJsonData.spawnChanceOverride) {
-        for (const spawn of bossJsonData.spawnChanceOverride) {
-            if (bossJsonData.spawnChanceOverrideString === true) {
-                spawnStatsMsg.push(`${spawn.chance} (${spawn.map})`)
-            } else {
-                spawnStatsMsg.push(`${spawn.chance * 100}% (${spawn.map})`);
-            }
-
+    for (const map of bossData.maps) {
+        // If a specific boss override exists, use that instead of the default from the API
+        const spawnChanceOverride = bossJsonData?.spawnChanceOverride?.find(override => override.map === map.normalizedName);
+        if (spawnChanceOverride) {
+            spawnStatsMsg.push(`${spawnChanceOverride.chance * 100}% (${map.name})`);
+            continue;
         }
-    } else {
-        for (const spawn of bossData.spawnChance) {
-            spawnStatsMsg.push(`${spawn.chance * 100}% (${spawn.map})`)
+        /*if (map.spawns.length === 1) {
+            spawnStatsMsg.push(`${map.spawns[0].spawnChance * 100}% (${map.name})`);
+            continue;
+        }*/
+        let lowerBound = 1;
+        let upperBound = 0;
+        for (const spawn of map.spawns) {
+            lowerBound = lowerBound > spawn.spawnChance ? spawn.spawnChance : lowerBound;
+            upperBound = upperBound < spawn.spawnChance ? spawn.spawnChance : upperBound;
         }
+        upperBound = upperBound * 100;
+        lowerBound = lowerBound * 100;
+        let displayPercent = `${lowerBound}-${upperBound}`;
+        if (lowerBound === upperBound || upperBound === 100) {
+            displayPercent = upperBound;
+        } 
+        spawnStatsMsg.push(`${displayPercent}% (${map.name})`)
     }
 
     bossProperties[t('spawnChance') + ` 🎲`] = spawnStatsMsg.join(', ');
@@ -154,12 +153,17 @@ function BossPage(params) {
 
     // Format the boss table spawnLocation data
     const spawnLocations = []
-    for (const spawnLocation of bossData.spawnLocations) {
-        spawnLocations.push({
-            spawnLocations: spawnLocation.name,
-            chance: `${parseInt(spawnLocation.chance * 100)}%`,
-            map: spawnLocation.map
-        });
+    for (const map of bossData.maps) {
+        for (const spawn of map.spawns) {
+            for (const location of spawn.locations) {
+                const chance = map.spawns.length > 1 && location.chance === 1 ? spawn.spawnChance : location.chance;
+                spawnLocations.push({
+                    spawnLocations: location.name,
+                    chance: `${parseInt(chance * 100)}%`,
+                    map: map.name
+                });
+            }
+        }
     }
 
     // Format the boss table escorts data
@@ -332,8 +336,7 @@ function Boss() {
                 name="description"
                 content={`All the relevant information about ${boss} (boss) in Escape from Tarkov`}
             />
-            <Link
-                key={`boss-canonical-${bossName}`}
+            <link
                 rel="canonical"
                 href={`https://tarkov.dev/boss/${bossName}`}
             />

--- a/src/pages/item/index.js
+++ b/src/pages/item/index.js
@@ -241,6 +241,17 @@ function Item() {
                                 objectiveInfo.count = 1;
                         });
                     });
+                } else if (objectiveData.wearing?.length) {
+                    let requiredCount = 0;
+                    objectiveData.wearing?.forEach(outfit => {
+                        outfit.forEach(item => {
+                            if (item.id === currentItemData?.id) 
+                                requiredCount++
+                        });
+                    });
+                    if (requiredCount === objectiveData.wearing.length) {
+                        objectiveInfo.count = 1;
+                    }
                 }
             });
 

--- a/src/pages/item/index.js
+++ b/src/pages/item/index.js
@@ -468,6 +468,8 @@ function Item() {
         );
     }
 
+    const buySources = currentItemData.buyFor.filter(buyFor => buyFor.price > 0);
+
     return [
         <Helmet key={'loot-tier-helmet'}>
             <meta charSet="utf-8" />
@@ -648,11 +650,11 @@ function Item() {
                             </div>
                         </div>
                     )}
-                    {currentItemData.buyFor && currentItemData.buyFor.length > 0 && (
+                    {buySources && buySources.length > 0 && (
                         <div>
                             <h2>{t('Buy for')}</h2>
                             <div className="information-grid single-line-grid buy">
-                                {currentItemData.buyFor.map(
+                                {buySources.map(
                                     (buyPrice, index) => {
                                         const loyaltyLevel = buyPrice.requirements.find((requirement) => requirement.type === 'loyaltyLevel')?.value;
                                         return (

--- a/src/pages/item/index.js
+++ b/src/pages/item/index.js
@@ -757,7 +757,7 @@ function Item() {
                                 }
                                 tooltipContent={
                                     <>
-                                        {t('Shows all sources of items regardless of what you have set in your settings')}
+                                        {t('Shows all sources of items regardless of your settings')}
                                     </>
                                 }
                             />
@@ -788,7 +788,7 @@ function Item() {
                                 }
                                 tooltipContent={
                                     <>
-                                        {t('Shows all crafts regardless of what you have set in your settings')}
+                                        {t('Shows all barters regardless of your settings')}
                                     </>
                                 }
                             />
@@ -813,7 +813,7 @@ function Item() {
                                 }
                                 tooltipContent={
                                     <>
-                                        {t('Shows all crafts regardless of what you have set in your settings')}
+                                        {t('Shows all crafts regardless of your settings')}
                                     </>
                                 }
                             />
@@ -838,7 +838,7 @@ function Item() {
                                 }
                                 tooltipContent={
                                     <>
-                                        {t('Shows all modules regardless of what you have set in your settings')}
+                                        {t('Shows all modules regardless of your settings')}
                                     </>
                                 }
                             />


### PR DESCRIPTION
Rather than using item names and image urls from a static JSON file, this uses the item data pulled from the API, which should also automatically translate the item names when a different language is selected. Also easily added the sell to trader and sell to flea values for boss loot items.
![image](https://user-images.githubusercontent.com/35779878/188063577-5c833bf2-92df-4da8-9e45-054cc8cd0ab6.png)
Also reworks the way bosses are processed to provide more information about the spawn chances of raiders and rogues.


Also added the missing rig layouts.
![image](https://user-images.githubusercontent.com/35779878/188063649-9935f2cb-d193-4c5a-9f6d-05aac830be79.png)

Also fixed barter savings calculations:
![image](https://user-images.githubusercontent.com/35779878/188171614-e4c5f787-0121-4269-bd62-2f0165194cc8.png)
