### PR TITLE
Account for flea price of 0 for cheapest price

### DIFF
--- a/src/components/small-item-table/index.js
+++ b/src/components/small-item-table/index.js
@@ -388,8 +388,8 @@ function SmallItemTable(props) {
                 formattedItem.cheapestPrice = Number.MAX_SAFE_INTEGER;
                 if (formattedItem.barterPrice) formattedItem.cheapestPrice = formattedItem.barterPrice.price;
                 for (const buyFor of formattedItem.buyFor) {
-                    console.log(formattedItem.name, buyFor)
-                    if (buyFor.priceRUB && buyFor.priceRUB < formattedItem.cheapestPrice) formattedItem.cheapestPrice = buyFor.priceRUB;
+                    if (buyFor.priceRUB && buyFor.priceRUB < formattedItem.cheapestPrice)
+                        formattedItem.cheapestPrice = buyFor.priceRUB;
                 }
                 if (formattedItem.cheapestPrice === Number.MAX_SAFE_INTEGER) {
                     formattedItem.cheapestPrice = 0;

--- a/src/components/small-item-table/index.js
+++ b/src/components/small-item-table/index.js
@@ -388,7 +388,8 @@ function SmallItemTable(props) {
                 formattedItem.cheapestPrice = Number.MAX_SAFE_INTEGER;
                 if (formattedItem.barterPrice) formattedItem.cheapestPrice = formattedItem.barterPrice.price;
                 for (const buyFor of formattedItem.buyFor) {
-                    if (buyFor.priceRUB < formattedItem.cheapestPrice) formattedItem.cheapestPrice = buyFor.priceRUB;
+                    console.log(formattedItem.name, buyFor)
+                    if (buyFor.priceRUB && buyFor.priceRUB < formattedItem.cheapestPrice) formattedItem.cheapestPrice = buyFor.priceRUB;
                 }
                 if (formattedItem.cheapestPrice === Number.MAX_SAFE_INTEGER) {
                     formattedItem.cheapestPrice = 0;

--- a/src/data/boss.json
+++ b/src/data/boss.json
@@ -138,6 +138,26 @@
             {
                 "id": "628b9c7d45122232a872358f",
                 "name": "Crye Precision CPC plate carrier (Goons Edition)"
+            },
+            {
+                "id": "6287549856af630b0f672cc4",
+                "name": "Desert Tech MDR 7.62x51 assault rifle Killtube"
+            },
+            {
+                "id": "628755f166bb7d4a3c32bc45",
+                "name": "FN SCAR-H 7.62x51 assault rifle (FDE) Face"
+            },
+            {
+                "id": "628755c60c9eb3366b521908",
+                "name": "CMMG Mk47 Mutant 7.62x39 assault rifle Mace"
+            },
+            {
+                "id": "628754510c9eb3366b5218f8",
+                "name": "Glock 17 9x19 pistol Jackie"
+            },
+            {
+                "id": "628753ee0c9eb3366b5218d4",
+                "name": "Glock 18C 9x19 machine pistol Lizzie"
             }
         ],
         "wikiLink": "https://escapefromtarkov.fandom.com/wiki/knight",

--- a/src/pages/item/index.js
+++ b/src/pages/item/index.js
@@ -248,6 +248,17 @@ function Item() {
                         if (item.id === currentItemData?.id) 
                             objectiveInfo.count = 1;
                     });
+                } else if (objectiveData.usingWeaponMods?.length) {
+                    let requiredCount = 0;
+                    objectiveData.usingWeaponMods?.forEach(modSet => {
+                        modSet.forEach(item => {
+                            if (item.id === currentItemData?.id) 
+                                requiredCount++
+                        });
+                    });
+                    if (requiredCount === objectiveData.usingWeaponMods.length) {
+                        objectiveInfo.count = 1;
+                    }
                 }
                 if (objectiveData.wearing?.length === 1) {
                     objectiveData.wearing?.forEach(outfit => {


### PR DESCRIPTION
When calculating the cheapest price for the "items contained" table on the item details page, it currently bugs out if there's no flea price and fails to list an available trader price as the cheapest price. This fixes that.

Also adds some weapon presets to Death Knight's boss loot.