### PR TITLE
Style fixes and more

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -15,8 +15,7 @@ body {
     margin: 0;
     padding: 0;
     height: 100%;
-    font-family: bender, -apple-system, system-ui, BlinkMacSystemFont, 'Segoe UI', Roboto,
-        'Helvetica Neue', Arial, sans-serif;
+    font-family: bender, -apple-system, system-ui, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
     font-style: normal;
     font-weight: 400;
     font-size: 16px;

--- a/src/App.css
+++ b/src/App.css
@@ -223,7 +223,7 @@ div.tippy-box[data-placement^='right'] > .tippy-arrow::before {
     opacity: 0.4;
 }
 
-@media screen and (min-width: 710px) {
+@media screen and (min-width: 800px) {
     .control-wrapper {
         display: none;
     }
@@ -234,13 +234,13 @@ div.tippy-box[data-placement^='right'] > .tippy-arrow::before {
     }
 }
 
-@media screen and (min-width: 1200px) {
+@media screen and (min-width: 1280px) {
     .page-wrapper {
         margin: 0 auto;
     }
 }
 
-@media screen and (min-width: 1800px) {
+@media screen and (min-width: 1920px) {
     .page-wrapper {
         margin: 0 auto;
         max-width: 1600px;

--- a/src/components/cost-items-cell/index.css
+++ b/src/components/cost-items-cell/index.css
@@ -40,3 +40,8 @@ img.barter-icon {
     flex-grow: 1;
     white-space: nowrap;
 }
+
+.cost-image-wrapper img {
+    width: 32px;
+    height: 32px;
+}

--- a/src/components/cost-items-cell/index.js
+++ b/src/components/cost-items-cell/index.js
@@ -3,7 +3,9 @@ import { useDispatch } from 'react-redux';
 
 import ItemCost from '../item-cost';
 import RewardImage from '../reward-image';
+
 import './index.css';
+
 import { toggleItem as toggleCraftItem } from '../../features/crafts/craftsSlice';
 import { toggleItem as toggleBarterItem } from '../../features/barters/bartersSlice';
 
@@ -44,8 +46,6 @@ function CostItemsCell({ costItems, craftId, barterId }) {
                             <RewardImage
                                 count={costItem.count}
                                 iconLink={`https://assets.tarkov.dev/${costItem.id}-icon.jpg`}
-                                height="34"
-                                width="34"
                                 isTool={costItem.isTool}
                             />
                         </div>

--- a/src/components/crafts-table/index.css
+++ b/src/components/crafts-table/index.css
@@ -13,5 +13,6 @@
 }
 
 .table-image-tool {
-    border: 1px solid #0292c0;
+    outline: 1px solid #0292c0;
+    outline-offset: -1px;
 }

--- a/src/components/data-table/index.css
+++ b/src/components/data-table/index.css
@@ -57,9 +57,10 @@ td.data-cell:last-child {
 }
 
 .data-table .table-image {
-    max-height: 64px;
     max-width: 64px;
-    border: 1px solid #4a5154;
+    max-height: 64px;
+    outline: 1px solid #4a5154;
+    outline-offset: -1px;
 }
 
 .data-table tr td {

--- a/src/components/data-table/index.css
+++ b/src/components/data-table/index.css
@@ -107,7 +107,7 @@ div.no-data-info {
     text-align: center;
 }
 
-@media screen and (min-width: 900px) {
+@media screen and (min-width: 800px) {
     .table-wrapper {
         overflow-x: initial;
     }

--- a/src/components/filter/index.css
+++ b/src/components/filter/index.css
@@ -148,7 +148,7 @@
     border-bottom-right-radius: 4px;
 }
 
-@media screen and (min-width: 710px) {
+@media screen and (min-width: 800px) {
     .button-group-wrapper {
         margin-right: 10px;
         gap: 10px;

--- a/src/components/footer/index.css
+++ b/src/components/footer/index.css
@@ -34,7 +34,7 @@
     width: 100%;
 }
 
-@media screen and (min-width: 700px) {
+@media screen and (min-width: 800px) {
     .footer-section-wrapper {
         width: 20%;
     }

--- a/src/components/item-grid/index.css
+++ b/src/components/item-grid/index.css
@@ -6,7 +6,7 @@
     margin-bottom: 10px;
     padding: 10px 0;
     width: 100%;
-    --grid-base: 50px;
+    --grid-base: 48px;
 }
 
 .item-group-wrapper .text-label {
@@ -20,14 +20,6 @@
     border: 0;
     background-color: rgb(239, 239, 239);
     padding: 10px;
-}
-
-.select__menu {
-    color: #000;
-}
-
-.rc-slider-mark .rc-slider-mark-text-active {
-    color: #fff;
 }
 
 .item-group-title {
@@ -55,6 +47,7 @@
     display: grid;
     grid-auto-rows: var(--grid-base);
     grid-template-columns: repeat(auto-fill, minmax(var(--grid-base), 1fr));
+    grid-gap: 1px;
     margin: auto;
     width: 90vw;
 }
@@ -175,7 +168,7 @@
 
 @media screen and (min-width: 1920px) {
     .item-group-wrapper {
-        --grid-base: 60px;
+        --grid-base: 64px;
     }
 }
 

--- a/src/components/item-grid/index.css
+++ b/src/components/item-grid/index.css
@@ -172,7 +172,7 @@
     }
 }
 
-@media screen and (min-width: 710px) {
+@media screen and (min-width: 800px) {
     .item-group-title {
         width: 10vw;
     }

--- a/src/components/item-image/index.css
+++ b/src/components/item-image/index.css
@@ -1,0 +1,29 @@
+.item-image-text {
+    position: absolute;
+    top: 2px;
+    right: 5px;
+    cursor: default;
+    color: #a4aeb4;
+    font-weight: bold;
+    text-shadow: 1px 1px 0 #000, -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000;
+}
+.item-image-mask {
+    background: linear-gradient(to left, #9a8866 20%, #c7c5b3 40%, #c7c5b3 60%, #9a8866 80%);
+    background-size: 200% auto;
+    width: 200px;
+    height: 200px;
+    opacity: 0.9;
+
+    -webkit-animation: shine 1s linear infinite;
+            animation: shine 1s linear infinite;
+}
+@-webkit-keyframes shine {
+    to {
+        background-position: -200% center;
+    }
+}
+@keyframes shine {
+    to {
+        background-position: -200% center;
+    }
+}

--- a/src/components/item-image/index.js
+++ b/src/components/item-image/index.js
@@ -1,3 +1,5 @@
+import './index.css';
+
 const colors = {
     violet: [
         '#271d2a',
@@ -39,38 +41,42 @@ const colors = {
 
 function ItemImage(props) {
     const { item } = props;
-    const color = colors[item.backgroundColor];
-
-    const backgroundStyle = {
-        backgroundColor: color[1],
-        backgroundImage: `url('data:image/svg+xml,\
-        <svg xmlns="http://www.w3.org/2000/svg" width="400" height="400" fill-opacity=".25" >\
-                 <rect x="200" width="200" height="200" />\
-                 <rect y="200" width="200" height="200" />\
-                 </svg>')`,
-        backgroundSize: '2px 2px',
-        position: 'relative',
-        textAlign: 'center',
-    };
-
-    const textStyle = {
-        cursor: 'default',
-        color: '#a4aeb4',
-        position: 'absolute',
-        top: '2px',
-        right: '5px',
-        fontWeight: 'bold',
-        textShadow: '1px 1px 0 #000, -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000'
-    };
 
     if (item.image512pxLink.includes('unknown-item') && !item.gridImageLink.includes('unknown-item')) {
         return (<img src={item.gridImageLink} alt={item.name}/>);
     }
 
+    const color = colors[item.backgroundColor];
+
+    const backgroundStyle = {
+        backgroundColor: color[1],
+        backgroundImage: `url('data:image/svg+xml,\
+            <svg xmlns="http://www.w3.org/2000/svg" width="4" height="4" fill-opacity=".25" >\
+                <rect x="2" width="2" height="2" />\
+                <rect y="2" width="2" height="2" />\
+            </svg>')`,
+        backgroundSize: '2px 2px',
+        position: 'relative',
+        height: '200px',
+    };
+
+    if (item.types.includes('loading')) {
+        const loadingStyle = {
+            WebkitMask:`url(${item.image512pxLink}) center/cover`,
+                  mask:`url(${item.image512pxLink}) center/cover`,
+        };
+        
+        return (
+            <div style={backgroundStyle}>
+                <div className="item-image-mask" style={loadingStyle}></div>
+            </div>
+        )
+    }
+
     return (
         <div style={backgroundStyle}>
             <img src={item.image512pxLink} alt={item.name}/>
-            <div style={textStyle}>{item.shortName}</div>
+            <div className='item-image-text'>{item.shortName}</div>
         </div>
     );
 }

--- a/src/components/item-name-cell/index.js
+++ b/src/components/item-name-cell/index.js
@@ -15,10 +15,8 @@ function ItemNameCell(props) {
                     <img
                         alt={props.row.original.name}
                         className="table-image"
-                        height="64"
                         loading="lazy"
                         src={props.row.original.iconLink}
-                        width="64"
                     />
                 </Link>
             </div>

--- a/src/components/item-search/index.css
+++ b/src/components/item-search/index.css
@@ -37,7 +37,7 @@
     pointer-events: none;
 }
 
-@media screen and (min-width: 700px) {
+@media screen and (min-width: 800px) {
     .search-tip-wrapper {
         border: 2px solid #9a8866;
         display: block;

--- a/src/components/item-table/index.css
+++ b/src/components/item-table/index.css
@@ -1,7 +1,4 @@
-/* .data-table td.data-cell {
-    padding: 10px 0;
-}
-
+/*
 .item-table-name-wrapper {
     align-items: center;
     display: flex;
@@ -10,17 +7,4 @@
 .item-table-image-wrapper {
     margin-right: 10px;
 }
-
-.data-table .table-image {
-    border: 1px solid #4a5154;
-}
-
-.data-table .trader-icon {
-    max-width: 40px;
-}
-
-.data-table .trader-price-content {
-    align-items: center;
-    display: flex;
-    gap: 15px;
-} */
+*/

--- a/src/components/items-for-hideout/index.css
+++ b/src/components/items-for-hideout/index.css
@@ -46,8 +46,10 @@
 }
 
 .hideout-item-image-wrapper img {
-    width: 34px;
-    border: 1px solid #4a5154;
+    outline: 1px solid #4a5154;
+    outline-offset: -1px;
+    width: 32px;
+    height: 32px;
 }
 
 .hideout-item-list-extra-row {

--- a/src/components/items-for-hideout/index.js
+++ b/src/components/items-for-hideout/index.js
@@ -64,9 +64,7 @@ function ItemsForHideout(props) {
         );
     }
 
-    let displayList = unbuilt;
-    if (showAll)
-        displayList = data;
+    let displayList = showAll ? data : unbuilt;
 
     return (
         <div className="table-wrapper">
@@ -115,8 +113,6 @@ function ItemsForHideout(props) {
                                             <img
                                                 alt={item.item.name}
                                                 loading="lazy"
-                                                height="34"
-                                                width="34"
                                                 src={item.item.iconLink}
                                             />
                                         </div>

--- a/src/components/menu/index.css
+++ b/src/components/menu/index.css
@@ -157,8 +157,8 @@
 }
 
 .menu svg {
-    height: 20px;
     width: 20px;
+    height: 20px;
 }
 
 .menu .last-link:hover .supporters-wrapper {

--- a/src/components/menu/index.css
+++ b/src/components/menu/index.css
@@ -187,7 +187,7 @@ li.desktop-only-link {
     display: none;
 }
 
-@media only screen and (min-width: 1100px) {
+@media screen and (min-width: 1280px) {
     .branding {
         margin-right: 0;
     }
@@ -213,7 +213,7 @@ li.desktop-only-link {
     }
 }
 
-@media screen and (min-width: 1400px) {
+@media screen and (min-width: 1920px) {
     .menu li.only-large {
         display: flex;
     }

--- a/src/components/menu/index.js
+++ b/src/components/menu/index.js
@@ -68,7 +68,7 @@ const Menu = () => {
                 <Icon
                     path={mdiMenu}
                     size={1}
-                    className="mobile-icon"
+                    className="mobile-icon icon-with-text"
                     onClick={handleMenuClick}
                 />
                 <Link className="branding" to="/">

--- a/src/components/property-list/index.css
+++ b/src/components/property-list/index.css
@@ -20,7 +20,7 @@
     font-size: 14px;
 }
 
-@media screen and (min-width: 780px) {
+@media screen and (min-width: 800px) {
     .property-wrapper {
         flex-basis: 10%;
         white-space: nowrap;

--- a/src/components/quest-items-cell/index.css
+++ b/src/components/quest-items-cell/index.css
@@ -6,12 +6,13 @@
 
 .quest-image-wrapper {
     margin-right: 10px;
-    height: 34px;
-    width: 34px;
 }
 
 .quest-image-wrapper img {
-    border: 1px solid #4a5154;
+    outline: 1px solid #4a5154;
+    outline-offset: -1px;
+    width: 32px;
+    height: 32px;
 }
 
 .amount-wrapper,

--- a/src/components/quest-items-cell/index.js
+++ b/src/components/quest-items-cell/index.js
@@ -33,8 +33,6 @@ function QuestItemsCell({ questItems }) {
                     <img
                         alt={questItem.name}
                         loading="lazy"
-                        height="34"
-                        width="34"
                         src={questItem.iconLink}
                     />
                 </div>

--- a/src/components/quests-list/index.css
+++ b/src/components/quests-list/index.css
@@ -10,8 +10,8 @@
 
 .quest-giver-image {
     margin-right: 10px;
-    max-height: 64px;
     max-width: 64px;
+    max-height: 64px;
 }
 
 .quest-list thead {

--- a/src/components/remote-control-id/index.css
+++ b/src/components/remote-control-id/index.css
@@ -96,7 +96,7 @@
     color: #ccc;
 }
 
-@media screen and (min-width: 710px) {
+@media screen and (min-width: 800px) {
     .id-wrapper {
         display: block;
     }

--- a/src/components/reward-cell/index.css
+++ b/src/components/reward-cell/index.css
@@ -17,7 +17,7 @@
     white-space: nowrap;
 }
 
-@media screen and (min-width: 700px) {
+@media screen and (min-width: 800px) {
     .reward-info-wrapper div:first-child {
         white-space: initial;
     }

--- a/src/components/reward-image/index.css
+++ b/src/components/reward-image/index.css
@@ -18,7 +18,7 @@
     text-align: center;
 }
 
-@media screen and (min-width: 700px) {
+@media screen and (min-width: 800px) {
     .reward-image-wrapper {
         margin-right: 10px;
     }

--- a/src/components/small-item-table/index.css
+++ b/src/components/small-item-table/index.css
@@ -42,22 +42,7 @@
     display: none;
 }
 
-/* .small-data-table tr,
-.small-data-table td {
-    display: block;
-}
-
-@media screen and (min-width: 700px) {
-    .small-data-table tr {
-        display: table-row;
-    }
-
-    .small-data-table td {
-        display: table-cell;
-    }
-} */
-
-@media screen and (min-width: 900px) {
+@media screen and (min-width: 800px) {
     .small-item-table-image-wrapper img {
         height: 64px;
         width: 64px;

--- a/src/components/small-item-table/index.css
+++ b/src/components/small-item-table/index.css
@@ -20,12 +20,13 @@
 }
 
 .small-item-table-image-wrapper img {
-    height: 32px;
     width: 32px;
+    height: 32px;
 }
 
 .small-data-table .table-image {
-    border: 1px solid #4a5154;
+    outline: 1px solid #4a5154;
+    outline-offset: -1px;
 }
 
 .small-data-table .trader-icon {
@@ -44,8 +45,8 @@
 
 @media screen and (min-width: 800px) {
     .small-item-table-image-wrapper img {
-        height: 64px;
         width: 64px;
+        height: 64px;
     }
 
     .small-item-table-name-wrapper cite {

--- a/src/pages/ammo/index.js
+++ b/src/pages/ammo/index.js
@@ -223,11 +223,10 @@ function Ammo() {
                     return (
                         <CenterCell>
                             <img
-                                alt={`${props.row.original.name} icon`}
-                                height={64}
+                                alt={`${props.row.original.name}`}
+                                className="table-image"
                                 loading="lazy"
                                 src={props.value}
-                                width={64}
                             />
                         </CenterCell>
                     );

--- a/src/pages/api-users/index.css
+++ b/src/pages/api-users/index.css
@@ -37,7 +37,7 @@
     order: -1;
 }
 
-@media screen and (min-width: 760px) {
+@media screen and (min-width: 800px) {
     .api-user-data-wrapper {
         text-align: center;
         width: 50%;

--- a/src/pages/barters/index.css
+++ b/src/pages/barters/index.css
@@ -19,7 +19,7 @@
     font-size: 14px;
 }
 
-@media screen and (min-width: 710px) {
+@media screen and (min-width: 800px) {
     .barters-page-title {
         margin: 0;
         text-align: left;

--- a/src/pages/bitcoin-farm-calculator/index.js
+++ b/src/pages/bitcoin-farm-calculator/index.js
@@ -107,9 +107,7 @@ const BitcoinFarmCalculator = () => {
                         itemLink={`/item/${graphicCardItem.normalizedName}`}
                         name={graphicCardItem.name}
                         sellValue={graphicsCardBuy.priceRUB}
-                        sellTo={t(capitalizeFirst(
-                            graphicsCardBuy.source.replace(/-/g, ' '),
-                        ))}
+                        sellTo={graphicsCardBuy.vendor.name}
                     />
                 )}
                 {Boolean(bitcoinItem) && (
@@ -119,9 +117,7 @@ const BitcoinFarmCalculator = () => {
                         itemLink={`/item/${bitcoinItem.normalizedName}`}
                         name={bitcoinItem.name}
                         sellValue={btcSell.priceRUB}
-                        sellTo={t(capitalizeFirst(
-                            btcSell.source.replace(/-/g, ' '),
-                        ))}
+                        sellTo={btcSell.vendor.name}
                     />
                 )}
             </div>

--- a/src/pages/bitcoin-farm-calculator/index.js
+++ b/src/pages/bitcoin-farm-calculator/index.js
@@ -21,7 +21,6 @@ import {
 // import BtcGraph from './graph';
 import ProfitInfo from './profit-info';
 import StationSkillTraderSetting from '../../components/station-skill-trader-setting';
-import capitalizeFirst from '../../modules/capitalize-first';
 
 const BitcoinFarmCalculator = () => {
     const { t } = useTranslation();

--- a/src/pages/bosses/index.css
+++ b/src/pages/bosses/index.css
@@ -9,8 +9,8 @@
 }
 
 .boss-list-wrapper img {
-    height: 128px;
     width: 128px;
+    height: 128px;
 }
 
 .boss-sub-text {

--- a/src/pages/bosses/index.css
+++ b/src/pages/bosses/index.css
@@ -20,4 +20,4 @@
     font-weight: 400;
 }
 
-@media screen and (min-width: 700px) {}
+@media screen and (min-width: 800px) {}

--- a/src/pages/crafts/index.css
+++ b/src/pages/crafts/index.css
@@ -23,7 +23,7 @@
     width: 26px;
 }
 
-@media screen and (min-width: 710px) {
+@media screen and (min-width: 800px) {
     .crafts-page-title {
         margin: 0;
         text-align: left;

--- a/src/pages/item/index.css
+++ b/src/pages/item/index.css
@@ -97,13 +97,13 @@
 }
 
 .text-and-image-information-wrapper img {
-    height: 32px;
     width: 32px;
+    height: 32px;
 }
 
 .text-and-image-information-wrapper .warning-icon {
-    height: 14px;
     width: 14px;
+    height: 14px;
     vertical-align: text-bottom;
     position: relative;
     bottom: 2px;

--- a/src/pages/item/index.css
+++ b/src/pages/item/index.css
@@ -15,6 +15,11 @@
     font-weight: bold;
 }
 
+.item-icon {
+    width: 64px;
+    height: 64px;
+}
+
 .icon-and-link-wrapper {
     align-items: flex-start;
     display: none;

--- a/src/pages/item/index.css
+++ b/src/pages/item/index.css
@@ -181,7 +181,7 @@
     margin-top: 10px;
 }
 
-@media screen and (min-width: 700px) {
+@media screen and (min-width: 800px) {
     .item-page-wrapper {
         padding-top: 20px;
     }

--- a/src/pages/item/index.js
+++ b/src/pages/item/index.js
@@ -512,10 +512,8 @@ function Item() {
                             </div>
                             <img
                                 alt={currentItemData.name}
-                                className={'item-image'}
+                                className={'item-icon'}
                                 loading="lazy"
-                                height={62}
-                                width={62}
                                 src={currentItemData.iconLink}
                             />
                         </h1>

--- a/src/pages/items/backpacks/index.js
+++ b/src/pages/items/backpacks/index.js
@@ -34,10 +34,8 @@ function Backpacks(props) {
                         <img
                             alt=""
                             className="table-image"
-                            height="64"
                             loading="lazy"
                             src={value}
-                            width="64"
                         />
                     );
                 },
@@ -48,9 +46,9 @@ function Backpacks(props) {
                 Cell: ({ value }) => {
                     return (
                         <CanvasGrid
+                            width={value.width}
                             height={value.height}
                             grid={value.pockets}
-                            width={value.width}
                         />
                     );
                 },

--- a/src/pages/items/backpacks/index.js
+++ b/src/pages/items/backpacks/index.js
@@ -8,6 +8,7 @@ import {mdiBagPersonal} from '@mdi/js';
 import CanvasGrid from '../../../components/canvas-grid';
 import DataTable from '../../../components/data-table';
 import ValueCell from '../../../components/value-cell';
+import LoadingSmall from '../../../components/loading-small';
 import { useItemsWithTypeQuery } from '../../../features/items/queries';
 import { Filter, ToggleFilter } from '../../../components/filter';
 
@@ -103,40 +104,40 @@ function Backpacks(props) {
     );
 
     const data = useMemo(
-        () =>
-            displayItems
-                .map((item) => {
-                    const match = item.name.match(/(.*)\s\(\d.+?$/);
-                    let itemName = item.name;
+        () => displayItems
+            .map((item) => {
+                const match = item.name.match(/(.*)\s\(\d.+?$/);
+                let itemName = item.name;
 
-                    if (match) {
-                        itemName = match[1].trim();
-                    }
+                if (match) {
+                    itemName = match[1].trim();
+                }
 
-                    return {
-                        grid: item.grid,
-                        id: item.id,
-                        image:
-                            item.iconLink ||
-                            'https://tarkov.dev/images/unknown-item-icon.jpg',
-                        name: itemName,
-                        price: item.avg24hPrice,
-                        pricePerSlot: showNetPPS ? Math.floor(item.avg24hPrice / (item.properties.capacity - (item.width * item.height))) 
-                                      : Math.floor(item.avg24hPrice / item.properties.capacity),
-                        ratio: (
-                            item.properties.capacity / (item.width * item.height)
-                        ).toFixed(2),
-                        size: item.properties.capacity,
-                        slots: (item.width * item.height),
-                        weight: `${parseFloat(item.properties.weight).toFixed(2)} kg`,
-                        wikiLink: item.wikiLink,
-                        itemLink: `/item/${item.normalizedName}`,
-                        notes: item.notes,
-                    };
-                })
-                .filter(Boolean),
+                return {
+                    grid: item.grid,
+                    id: item.id,
+                    image: item.iconLink || 'https://tarkov.dev/images/unknown-item-icon.jpg',
+                    name: itemName,
+                    price: item.avg24hPrice,
+                    pricePerSlot: showNetPPS ? Math.floor(item.avg24hPrice / (item.properties.capacity - (item.width * item.height))) 
+                                             : Math.floor(item.avg24hPrice / item.properties.capacity),
+                    ratio: (item.properties.capacity / (item.width * item.height)).toFixed(2),
+                    size: item.properties.capacity,
+                    slots: (item.width * item.height),
+                    weight: `${parseFloat(item.properties.weight).toFixed(2)} kg`,
+                    wikiLink: item.wikiLink,
+                    itemLink: `/item/${item.normalizedName}`,
+                    notes: item.notes,
+                };
+            })
+            .filter(Boolean),
         [displayItems, showNetPPS],
     );
+
+    let extraRow = null;
+    if (data.length <= 0) {
+        extraRow = <LoadingSmall />;
+    }
 
     return [
         <Helmet key={'backpacks-table'}>
@@ -166,6 +167,7 @@ function Backpacks(props) {
             <DataTable
                 columns={columns}
                 data={data}
+                extraRow={extraRow}
                 sortBy={'slots'}
                 sortByDesc={true}
                 autoResetSortBy={false}

--- a/src/pages/items/helmets/index.js
+++ b/src/pages/items/helmets/index.js
@@ -149,10 +149,8 @@ function Helmets(props) {
                             <img
                                 alt=""
                                 className="table-image"
-                                height="64"
                                 loading="lazy"
                                 src={value}
-                                width="64"
                             />
                         </div>
                     );

--- a/src/pages/items/rigs/index.js
+++ b/src/pages/items/rigs/index.js
@@ -22,7 +22,7 @@ const marks = {
     25: 0,
 };
 
-function Backpacks(props) {
+function Rigs(props) {
     const { data: items } = useItemsQuery();
 
     const [includeArmoredRigs, setIncludeArmoredRigs] =
@@ -269,4 +269,4 @@ function Backpacks(props) {
     ];
 }
 
-export default Backpacks;
+export default Rigs;

--- a/src/pages/items/rigs/index.js
+++ b/src/pages/items/rigs/index.js
@@ -61,10 +61,8 @@ function Rigs(props) {
                             <img
                                 alt=""
                                 className="table-image"
-                                height="64"
                                 loading="lazy"
                                 src={value}
-                                width="64"
                             />
                         </div>
                     );

--- a/src/pages/moobot/index.css
+++ b/src/pages/moobot/index.css
@@ -11,7 +11,7 @@
     white-space: pre-wrap;
 }
 
-@media screen and (min-width: 900px) {
+@media screen and (min-width: 800px) {
     .moobot-page-wrapper pre {
         white-space: pre;
     }

--- a/src/pages/nightbot/index.css
+++ b/src/pages/nightbot/index.css
@@ -11,7 +11,7 @@
     white-space: pre-wrap;
 }
 
-@media screen and (min-width: 900px) {
+@media screen and (min-width: 800px) {
     .nightbot-page-wrapper pre {
         white-space: pre;
     }

--- a/src/pages/settings/index.css
+++ b/src/pages/settings/index.css
@@ -44,7 +44,7 @@
     border-radius: 4px;
 }
 
-@media screen and (min-width: 1040px) {
+@media screen and (min-width: 1280px) {
     .settings-group-wrapper {
         justify-content: flex-start;
     }

--- a/src/pages/start/index.css
+++ b/src/pages/start/index.css
@@ -74,8 +74,8 @@
 }
 
 .start-section-wrapper .trader-icon {
-    height: 24px;
     width: 24px;
+    height: 24px;
 }
 
 .traders-list .trader-icon {

--- a/src/pages/start/index.css
+++ b/src/pages/start/index.css
@@ -106,7 +106,7 @@
     cursor: pointer;
   }
 
-@media screen and (min-width: 1220px) {
+@media screen and (min-width: 1280px) {
     .start-section-wrapper img {
         max-width: 256px;
     }

--- a/src/pages/stream-elements/index.css
+++ b/src/pages/stream-elements/index.css
@@ -11,7 +11,7 @@
     white-space: pre-wrap;
 }
 
-@media screen and (min-width: 900px) {
+@media screen and (min-width: 800px) {
     .stream-elements-page-wrapper pre {
         white-space: pre;
     }

--- a/src/pages/traders/index.css
+++ b/src/pages/traders/index.css
@@ -13,5 +13,5 @@
     width: 128px;
 }
 
-@media screen and (min-width: 700px) {
+@media screen and (min-width: 800px) {
 }

--- a/src/pages/traders/index.css
+++ b/src/pages/traders/index.css
@@ -9,8 +9,8 @@
 }
 
 .traders-list-wrapper img {
-    height: 128px;
     width: 128px;
+    height: 128px;
 }
 
 @media screen and (min-width: 800px) {


### PR DESCRIPTION
# Many CSS fixes

With new images, a fix to all places where icons were displayed was needed.
Also other fixes, `screen min-width` consistency and some refactoring;

## Description 🗒️

- Added gradient animation to item image loading;
- Moved some css to separate file
- Fix size of `itemIcon` on mobiles
- Fix vendor `name` in bitcoin farm calculator
- Added loading `extraRow` to backpacks
- Fix menu icon on mobile was attached to screen border
- Now that icons are of correct size fix `border -> outline` and size `34px -> 32px`;
- Removed hardcoded icon image size;
- Fix class name for Rigs
- Fix `screen min-width` to be consistent in all CSS's (800/1280/1920)
- Fix `grid-base` to be multiple of 16 on loot-tier;
- Added a 1px gap between grit item images on loot-tier

## Item image loading:

https://user-images.githubusercontent.com/10927011/189690196-bb729a3a-1fc6-4cc3-a363-4c812caff0c7.mov

