### PR TITLE
Make item image height dynamic

### DIFF
--- a/src/components/item-image/index.js
+++ b/src/components/item-image/index.js
@@ -46,16 +46,6 @@ function ItemImage(props) {
         return (<img src={item.gridImageLink} alt={item.name}/>);
     }
 
-    let height = 200;
-    const itemWidth = item.properties?.defaultWidth || item.width;
-    const itemHeight = item.properties?.defaultHeight || item.height;
-    if (itemWidth > itemHeight) {
-        height = itemHeight * 86;
-        if (height > 200) {
-            height = 200;
-        }
-    }
-
     const color = colors[item.backgroundColor];
 
     const backgroundStyle = {
@@ -67,7 +57,6 @@ function ItemImage(props) {
             </svg>')`,
         backgroundSize: '2px 2px',
         position: 'relative',
-        height: `${height}px`,
     };
 
     if (item.types.includes('loading')) {

--- a/src/components/item-image/index.js
+++ b/src/components/item-image/index.js
@@ -46,6 +46,16 @@ function ItemImage(props) {
         return (<img src={item.gridImageLink} alt={item.name}/>);
     }
 
+    let height = 200;
+    const itemWidth = item.properties?.defaultWidth || item.width;
+    const itemHeight = item.properties?.defaultHeight || item.height;
+    if (itemWidth > itemHeight) {
+        height = itemHeight * 86;
+        if (height > 200) {
+            height = 200;
+        }
+    }
+
     const color = colors[item.backgroundColor];
 
     const backgroundStyle = {
@@ -57,7 +67,7 @@ function ItemImage(props) {
             </svg>')`,
         backgroundSize: '2px 2px',
         position: 'relative',
-        height: '200px',
+        height: `${height}px`,
     };
 
     if (item.types.includes('loading')) {


### PR DESCRIPTION
The height of the image elements on item detail pages was locked to 200. That wasn't ideal for wide short items because they would take up more space than necessary. This changes the height on items to be dynamic depending on the actual size of the item, but to still be no taller than 200px.

Before:
![image](https://user-images.githubusercontent.com/35779878/190633833-eb601ebb-deb7-43cb-8a34-c7181e8d7920.png)

After:
![image](https://user-images.githubusercontent.com/35779878/190633861-c5ef655d-e92c-4e0c-a48d-f2e496b4a178.png)
