### PR TITLE
Add class effective durability toggle to armors

### DIFF
--- a/src/components/small-item-table/index.js
+++ b/src/components/small-item-table/index.js
@@ -156,6 +156,7 @@ function SmallItemTable(props) {
         sumColumns,
         totalTraderPrice,
         idFilter,
+        useClassEffectiveDurability,
     } = props;
     const dispatch = useDispatch();
     const { t } = useTranslation();
@@ -805,7 +806,12 @@ function SmallItemTable(props) {
         if (effectiveDurability) {
             useColumns.push({
                 Header: t('Effective Durability'),
-                accessor: 'effectiveDurability',
+                accessor: (item) => {
+                    if (useClassEffectiveDurability) {
+                        return item.effectiveDurability * (item.armorClass * item.armorClass);
+                    }
+                    return item.effectiveDurability;
+                },
                 Cell: CenterCell,
             });
         }
@@ -886,6 +892,7 @@ function SmallItemTable(props) {
         weight,
         cheapestPrice,
         totalTraderPrice,
+        useClassEffectiveDurability,
     ]);
 
     let extraRow = false;

--- a/src/pages/items/armor/index.js
+++ b/src/pages/items/armor/index.js
@@ -23,6 +23,10 @@ const marks = {
 };
 
 function Armor(props) {
+    const [useClassEffectiveDurability, setUseClassEffectiveDurability] = useStateWithLocalStorage(
+        'useClassEffectiveDurability',
+        false,
+    );
     const [includeRigs, setIncludeRigs] = useStateWithLocalStorage(
         'includeRigs',
         true,
@@ -69,6 +73,11 @@ function Armor(props) {
                 </h1>
                 <Filter center>
                     <ToggleFilter
+                        label={t('Class effective durability')}
+                        onChange={(e) => setUseClassEffectiveDurability(!useClassEffectiveDurability)}
+                        checked={useClassEffectiveDurability}
+                    />
+                    <ToggleFilter
                         label={t('Include rigs')}
                         onChange={(e) => setIncludeRigs(!includeRigs)}
                         checked={includeRigs}
@@ -103,6 +112,7 @@ function Armor(props) {
                     value: maxArmorClass,
                 }}
                 maxPrice={maxPrice}
+                useClassEffectiveDurability={useClassEffectiveDurability}
                 fleaPrice
                 armorClass
                 armorZones


### PR DESCRIPTION
Add toggle to Armors page to switch between regular effective durability and class effective durability.
![image](https://user-images.githubusercontent.com/35779878/191136274-d99518eb-a9ce-40fb-a377-2012f36dd3ce.png)
![image](https://user-images.githubusercontent.com/35779878/191136284-bd1ba21c-83bb-40d7-b216-fee9dadb8ed6.png)
