### PR TITLE
Add cheapest price column to tables

### DIFF
--- a/src/components/barter-tooltip/index.js
+++ b/src/components/barter-tooltip/index.js
@@ -11,8 +11,10 @@ import {
 
 import './index.css';
 
-function BarterToolip({ source, requiredItems }) {
+function BarterToolip({ barter, source, requiredItems }) {
     const { t } = useTranslation();
+    source = source || barter?.source;
+    requiredItems = requiredItems || barter?.requiredItems;
 
     if (!source || !requiredItems) {
         return "No barters found for this item";
@@ -30,6 +32,22 @@ function BarterToolip({ source, requiredItems }) {
                 {t('Barter at')} {source}
             </h3>
             {requiredItems.map((requiredItem) => {
+                let itemName = requiredItem.item.name;
+                let price = requiredItem.item.avg24hPrice;
+                let sourceName = 'flea-market';
+                const isDogTag = requiredItem.attributes && requiredItem.attributes.some(att => att.name === 'minLevel');
+                if (isDogTag) {
+                    const bestSell = requiredItem.item.sellFor.reduce((bestPrice, sellFor) => {
+                        if (sellFor.priceRUB > bestPrice.priceRUB) {
+                            return sellFor;
+                        }
+                        return bestPrice;
+                    }, {priceRUB: 0});
+                    const minLevel = requiredItem.attributes.find(att => att.name === 'minLevel').value;
+                    price = bestSell.priceRUB * minLevel;
+                    sourceName = bestSell.vendor.normalizedName;
+                    itemName = `${itemName} ≥ ${minLevel}`;
+                }
                 return (
                     <div
                         className="cost-item-wrapper"
@@ -44,7 +62,7 @@ function BarterToolip({ source, requiredItems }) {
                                 <Link
                                     to={`/item/${requiredItem.item.normalizedName}`}
                                 >
-                                    {requiredItem.item.name}
+                                    {itemName}
                                 </Link>
                             </div>
                             <div className="price-wrapper">
@@ -52,14 +70,14 @@ function BarterToolip({ source, requiredItems }) {
                                     alt={t('Barter')}
                                     className="barter-icon"
                                     loading="lazy"
-                                    src={`${process.env.PUBLIC_URL}/images/flea-market-icon.jpg`}
+                                    src={`${process.env.PUBLIC_URL}/images/${sourceName}-icon.jpg`}
                                 />
                                 {requiredItem.count} <span>X</span>{' '}
-                                {formatPrice(requiredItem.item.avg24hPrice)}{' '}
+                                {formatPrice(price)}{' '}
                                 <span>=</span>{' '}
                                 {formatPrice(
                                     requiredItem.count *
-                                    requiredItem.item.avg24hPrice,
+                                    price,
                                 )}
                             </div>
                         </div>

--- a/src/features/barters/do-fetch-barters.js
+++ b/src/features/barters/do-fetch-barters.js
@@ -39,6 +39,7 @@ const doFetchBarters = async () => {
                                     minTraderLevel
                                     taskUnlock {
                                         id
+                                        tarkovDataId
                                         name
                                     }
                                 }
@@ -62,6 +63,7 @@ const doFetchBarters = async () => {
                                     minTraderLevel
                                     taskUnlock {
                                         id
+                                        tarkovDataId
                                         name
                                     }
                                 }
@@ -111,6 +113,7 @@ const doFetchBarters = async () => {
                                     minTraderLevel
                                     taskUnlock {
                                         id
+                                        tarkovDataId
                                         name
                                     }
                                 }
@@ -134,6 +137,7 @@ const doFetchBarters = async () => {
                                     minTraderLevel
                                     taskUnlock {
                                         id
+                                        tarkovDataId
                                         name
                                     }
                                 }
@@ -158,6 +162,7 @@ const doFetchBarters = async () => {
                 level
                 taskUnlock {
                     id
+                    tarkovDataId
                     name
                 }
             }

--- a/src/features/crafts/craftsSlice.js
+++ b/src/features/crafts/craftsSlice.js
@@ -56,6 +56,7 @@ export const fetchCrafts = createAsyncThunk('crafts/fetchCrafts', async () => {
                       minTraderLevel
                       taskUnlock {
                           id
+                          tarkovDataId
                           name
                       }
                   }
@@ -79,6 +80,7 @@ export const fetchCrafts = createAsyncThunk('crafts/fetchCrafts', async () => {
                       minTraderLevel
                       taskUnlock {
                           id
+                          tarkovDataId
                           name
                       }
                   }
@@ -126,6 +128,7 @@ export const fetchCrafts = createAsyncThunk('crafts/fetchCrafts', async () => {
                       minTraderLevel
                       taskUnlock {
                           id
+                          tarkovDataId
                           name
                       }
                   }
@@ -149,6 +152,7 @@ export const fetchCrafts = createAsyncThunk('crafts/fetchCrafts', async () => {
                       minTraderLevel
                       taskUnlock {
                           id
+                          tarkovDataId
                           name
                       }
                   }

--- a/src/features/items/do-fetch-items.js
+++ b/src/features/items/do-fetch-items.js
@@ -57,6 +57,7 @@ const doFetchItems = async () => {
                             minTraderLevel
                             taskUnlock {
                                 id
+                                tarkovDataId
                                 name
                             }
                         }
@@ -84,6 +85,7 @@ const doFetchItems = async () => {
                             minTraderLevel
                             taskUnlock {
                                 id
+                                tarkovDataId
                                 name
                             }
                         }
@@ -107,6 +109,7 @@ const doFetchItems = async () => {
                     ...on ItemPropertiesAmmo {
                         caliber
                         damage
+                        projectileCount
                         penetrationPower
                         armorDamage
                         fragmentationChance

--- a/src/pages/item/index.js
+++ b/src/pages/item/index.js
@@ -802,7 +802,7 @@ function Item() {
                             containedInFilter={currentItemData.containsItems}
                             fleaPrice
                             barterPrice
-                            traderValue
+                            traderValue={1}
                             traderPrice
                             cheapestPrice
                             sumColumns

--- a/src/pages/items/armor/index.js
+++ b/src/pages/items/armor/index.js
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Helmet } from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 
@@ -23,6 +24,7 @@ const marks = {
 };
 
 function Armor(props) {
+    const [showAllArmorSources, setShowAllArmorSources] = useState(false);
     const [useClassEffectiveDurability, setUseClassEffectiveDurability] = useStateWithLocalStorage(
         'useClassEffectiveDurability',
         false,
@@ -73,6 +75,18 @@ function Armor(props) {
                 </h1>
                 <Filter center>
                     <ToggleFilter
+                        checked={showAllArmorSources}
+                        label={t('Ignore settings')}
+                        onChange={(e) =>
+                            setShowAllArmorSources(!showAllArmorSources)
+                        }
+                        tooltipContent={
+                            <>
+                                {t('Shows all sources of items regardless of your settings')}
+                            </>
+                        }
+                    />
+                    <ToggleFilter
                         label={t('Class effective durability')}
                         onChange={(e) => setUseClassEffectiveDurability(!useClassEffectiveDurability)}
                         checked={useClassEffectiveDurability}
@@ -113,15 +127,15 @@ function Armor(props) {
                 }}
                 maxPrice={maxPrice}
                 useClassEffectiveDurability={useClassEffectiveDurability}
-                fleaPrice
                 armorClass
                 armorZones
-                barterPrice
+                cheapestPrice={1}
                 maxDurability
                 effectiveDurability
                 repairability
                 weight
                 stats
+                showAllSources={showAllArmorSources}
             />
             
             <div className="page-wrapper items-page-wrapper">

--- a/src/pages/items/barter-items/index.js
+++ b/src/pages/items/barter-items/index.js
@@ -60,7 +60,7 @@ function BarterItems() {
                 nameFilter={nameFilter}
                 typeFilter="barter"
                 fleaValue
-                traderValue
+                traderValue={1}
                 maxItems={50}
                 autoScroll
             />

--- a/src/pages/items/bsg-category/index.js
+++ b/src/pages/items/bsg-category/index.js
@@ -5,7 +5,7 @@ import { useParams } from 'react-router-dom';
 
 import ErrorPage from '../../../components/error-page';
 
-import { Filter, InputFilter } from '../../../components/filter';
+import { Filter, InputFilter, ToggleFilter } from '../../../components/filter';
 import SmallItemTable from '../../../components/small-item-table';
 import QueueBrowserTask from '../../../modules/queue-browser-task';
 
@@ -15,6 +15,7 @@ function BsgCategory() {
     const defaultQuery = new URLSearchParams(window.location.search).get(
         'search',
     );
+    const [showAllItemSources, setShowAllItemSources] = useState(false);
     const [nameFilter, setNameFilter] = useState(defaultQuery || '');
     let { bsgCategoryName } = useParams();
     const { t } = useTranslation();
@@ -65,6 +66,18 @@ function BsgCategory() {
                     </cite> */}
                 </h1>
                 <Filter center>
+                    <ToggleFilter
+                        checked={showAllItemSources}
+                        label={t('Ignore settings')}
+                        onChange={(e) =>
+                            setShowAllItemSources(!showAllItemSources)
+                        }
+                        tooltipContent={
+                            <>
+                                {t('Shows all sources of items regardless of your settings')}
+                            </>
+                        }
+                    />
                     <InputFilter
                         defaultValue={nameFilter}
                         onChange={handleNameFilterChange}
@@ -76,9 +89,10 @@ function BsgCategory() {
             <SmallItemTable
                 nameFilter={nameFilter}
                 bsgCategoryFilter={category.id}
-                fleaValue
-                traderValue
-                traderPrice
+                showAllSources={showAllItemSources}
+                traderValue={1}
+                fleaValue={2}
+                cheapestPrice={3}
             />
         </div>,
     ];

--- a/src/pages/items/containers/index.js
+++ b/src/pages/items/containers/index.js
@@ -38,12 +38,11 @@ function Containers(props) {
 
             <SmallItemTable
                 typeFilter="container"
-                fleaPrice
+                cheapestPrice={1}
                 gridSlots
                 innerSize
                 slotRatio
                 pricePerSlot
-                barterPrice
                 showContainedItems
                 showNetPPS={showNetPPS}
             />

--- a/src/pages/items/glasses/index.js
+++ b/src/pages/items/glasses/index.js
@@ -1,89 +1,16 @@
-import { useMemo } from 'react';
+import { useState } from 'react';
 import { Helmet } from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 
 import Icon from '@mdi/react';
 import {mdiSunglasses} from '@mdi/js';
 
-import ItemNameCell from '../../../components/item-name-cell';
-import DataTable from '../../../components/data-table';
-import formatPrice from '../../../modules/format-price';
-import { useItemsQuery } from '../../../features/items/queries';
+import { Filter, ToggleFilter } from '../../../components/filter';
+import SmallItemTable from '../../../components/small-item-table';
 
-const centerCell = ({ value }) => {
-    return <div className="center-content">{value}</div>;
-};
-
-function Glasses(props) {
-    const { data: items } = useItemsQuery();
+function Glasses() {
     const { t } = useTranslation();
-
-    const displayItems = useMemo(
-        () => items.filter((item) => item.types.includes('glasses')),
-        [items],
-    );
-
-    const columns = useMemo(
-        () => [
-            {
-                Header: t('Name'),
-                accessor: 'name',
-                Cell: ItemNameCell,
-            },
-            {
-                Header: t('Armor class'),
-                accessor: 'armorClass',
-                Cell: centerCell,
-            },
-            {
-                Header: t('Blindness protection'),
-                accessor: 'blindness',
-                Cell: centerCell,
-            },
-            {
-                Header: ({ value }) => {
-                    return (
-                        <div className="center-content">
-                            {t('Status')}
-                            <div>{t('Turn/Ergo')}</div>
-                        </div>
-                    );
-                },
-                accessor: 'stats',
-                Cell: centerCell,
-            },
-            {
-                Header: t('Cost'),
-                accessor: 'price',
-                Cell: centerCell,
-            },
-        ],
-        [t],
-    );
-
-    const data = useMemo(
-        () =>
-            displayItems
-                .map((item) => {
-                    return {
-                        ...item,
-                        itemLink: `/item/${item.normalizedName}`,
-                        armorClass: item.properties.class,
-                        blindness: `${
-                            (item.properties.blindnessProtection || 0) * 100
-                        }%`,
-                        stats: `${item.properties.turnPenalty * 100 || 0}% / ${
-                            item.properties.ergoPenalty || 0
-                        }`,
-                        image:
-                            item.iconLink ||
-                            'https://tarkov.dev/images/unknown-item-icon.jpg',
-                        price: `${formatPrice(item.avg24hPrice)}`,
-                    };
-                })
-                .filter(Boolean),
-        [displayItems],
-    );
+    const [showAllItemSources, setShowAllItemSources] = useState(false);
 
     return [
         <Helmet key={'glasses-table'}>
@@ -101,11 +28,29 @@ function Glasses(props) {
                     <Icon path={mdiSunglasses} size={1.5} className="icon-with-text" /> 
                     {t('Glasses chart')}
                 </h1>
+                <Filter center>
+                    <ToggleFilter
+                        checked={showAllItemSources}
+                        label={t('Ignore settings')}
+                        onChange={(e) =>
+                            setShowAllItemSources(!showAllItemSources)
+                        }
+                        tooltipContent={
+                            <>
+                                {t('Shows all sources of items regardless of your settings')}
+                            </>
+                        }
+                    />
+                </Filter>
             </div>
 
-            <DataTable 
-                columns={columns} 
-                data={data} 
+            <SmallItemTable
+                typeFilter={'glasses'}
+                showAllSources={showAllItemSources}
+                armorClass={1}
+                blindnessProtection={2}
+                stats={3}
+                cheapestPrice={4}
             />
 
             <div className="page-wrapper items-page-wrapper">

--- a/src/pages/items/grenades/index.js
+++ b/src/pages/items/grenades/index.js
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import Icon from '@mdi/react';
 import {mdiGasCylinder} from '@mdi/js';
 
-import { Filter, InputFilter } from '../../../components/filter';
+import { Filter, InputFilter, ToggleFilter } from '../../../components/filter';
 import SmallItemTable from '../../../components/small-item-table';
 import QueueBrowserTask from '../../../modules/queue-browser-task';
 
@@ -13,6 +13,7 @@ function Grenades() {
     const defaultQuery = new URLSearchParams(window.location.search).get(
         'search',
     );
+    const [showAllItemSources, setShowAllItemSources] = useState(false);
     const [nameFilter, setNameFilter] = useState(defaultQuery || '');
     const { t } = useTranslation();
 
@@ -48,6 +49,18 @@ function Grenades() {
                     {t('Grenades')}
                 </h1>
                 <Filter center>
+                    <ToggleFilter
+                        checked={showAllItemSources}
+                        label={t('Ignore settings')}
+                        onChange={(e) =>
+                            setShowAllItemSources(!showAllItemSources)
+                        }
+                        tooltipContent={
+                            <>
+                                {t('Shows all sources of items regardless of your settings')}
+                            </>
+                        }
+                    />
                     <InputFilter
                         defaultValue={nameFilter}
                         onChange={handleNameFilterChange}
@@ -59,9 +72,10 @@ function Grenades() {
             <SmallItemTable
                 nameFilter={nameFilter}
                 typeFilter="grenade"
-                fleaValue
-                traderValue
-                traderPrice
+                showAllSources={showAllItemSources}
+                traderValue={1}
+                fleaValue={2}
+                cheapestPrice={3}
             />
 
             <div className="page-wrapper items-page-wrapper">

--- a/src/pages/items/guns/index.js
+++ b/src/pages/items/guns/index.js
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import Icon from '@mdi/react';
 import {mdiPistol} from '@mdi/js';
 
-import { Filter, InputFilter } from '../../../components/filter';
+import { Filter, InputFilter, ToggleFilter } from '../../../components/filter';
 import SmallItemTable from '../../../components/small-item-table';
 import QueueBrowserTask from '../../../modules/queue-browser-task';
 
@@ -13,6 +13,7 @@ function Guns() {
     const defaultQuery = new URLSearchParams(window.location.search).get(
         'search',
     );
+    const [showAllItemSources, setShowAllItemSources] = useState(false);
     const [nameFilter, setNameFilter] = useState(defaultQuery || '');
     const { t } = useTranslation();
 
@@ -48,6 +49,18 @@ function Guns() {
                     {t('Guns')}
                 </h1>
                 <Filter center>
+                    <ToggleFilter
+                        checked={showAllItemSources}
+                        label={t('Ignore settings')}
+                        onChange={(e) =>
+                            setShowAllItemSources(!showAllItemSources)
+                        }
+                        tooltipContent={
+                            <>
+                                {t('Shows all sources of items regardless of your settings')}
+                            </>
+                        }
+                    />
                     <InputFilter
                         defaultValue={nameFilter}
                         onChange={handleNameFilterChange}
@@ -60,11 +73,12 @@ function Guns() {
                 nameFilter={nameFilter}
                 totalTraderPrice={true}
                 typeFilter="gun"
-                fleaValue
-                traderValue
-                traderPrice
+                showAllSources={showAllItemSources}
                 maxItems={50}
                 autoScroll
+                traderValue={1}
+                fleaValue={2}
+                cheapestPrice={3}
             />
 
             <div className="page-wrapper items-page-wrapper">

--- a/src/pages/items/headsets/index.js
+++ b/src/pages/items/headsets/index.js
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import Icon from '@mdi/react';
 import {mdiHeadset} from '@mdi/js';
 
-import { Filter, InputFilter } from '../../../components/filter';
+import { Filter, InputFilter, ToggleFilter } from '../../../components/filter';
 import SmallItemTable from '../../../components/small-item-table';
 import QueueBrowserTask from '../../../modules/queue-browser-task';
 
@@ -14,6 +14,7 @@ function Headsets() {
         'search',
     );
     const [nameFilter, setNameFilter] = useState(defaultQuery || '');
+    const [showAllItemSources, setShowAllItemSources] = useState(false);
     const { t } = useTranslation();
 
     const handleNameFilterChange = useCallback(
@@ -48,6 +49,18 @@ function Headsets() {
                     {t('Headsets')}
                 </h1>
                 <Filter center>
+                    <ToggleFilter
+                        checked={showAllItemSources}
+                        label={t('Ignore settings')}
+                        onChange={(e) =>
+                            setShowAllItemSources(!showAllItemSources)
+                        }
+                        tooltipContent={
+                            <>
+                                {t('Shows all sources of items regardless of your settings')}
+                            </>
+                        }
+                    />
                     <InputFilter
                         defaultValue={nameFilter}
                         onChange={handleNameFilterChange}
@@ -59,11 +72,11 @@ function Headsets() {
             <SmallItemTable
                 nameFilter={nameFilter}
                 typeFilter="headphones"
-                fleaValue
-                weight
-                barterPrice
-                traderValue
-                traderPrice
+                showAllSources={showAllItemSources}
+                weight={1}
+                traderValue={2}
+                fleaValue={3}
+                cheapestPrice
             />
 
             <div className="page-wrapper items-page-wrapper">

--- a/src/pages/items/keys/index.js
+++ b/src/pages/items/keys/index.js
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import Icon from '@mdi/react';
 import {mdiKeyVariant} from '@mdi/js';
 
-import { Filter, InputFilter } from '../../../components/filter';
+import { Filter, InputFilter, ToggleFilter } from '../../../components/filter';
 import SmallItemTable from '../../../components/small-item-table';
 import QueueBrowserTask from '../../../modules/queue-browser-task';
 
@@ -13,6 +13,7 @@ function Keys() {
     const defaultQuery = new URLSearchParams(window.location.search).get(
         'search',
     );
+    const [showAllItemSources, setShowAllItemSources] = useState(false);
     const [nameFilter, setNameFilter] = useState(defaultQuery || '');
     const { t } = useTranslation();
 
@@ -48,6 +49,18 @@ function Keys() {
                     {t('Keys')}
                 </h1>
                 <Filter center>
+                    <ToggleFilter
+                        checked={showAllItemSources}
+                        label={t('Ignore settings')}
+                        onChange={(e) =>
+                            setShowAllItemSources(!showAllItemSources)
+                        }
+                        tooltipContent={
+                            <>
+                                {t('Shows all sources of items regardless of your settings')}
+                            </>
+                        }
+                    />
                     <InputFilter
                         defaultValue={nameFilter}
                         onChange={handleNameFilterChange}
@@ -59,8 +72,10 @@ function Keys() {
             <SmallItemTable
                 nameFilter={nameFilter}
                 typeFilter="keys"
-                fleaValue
-                traderValue
+                showAllSources={showAllItemSources}
+                traderValue={1}
+                fleaValue={2}
+                cheapestPrice={3}
             />
 
             <div className="page-wrapper items-page-wrapper">

--- a/src/pages/items/mods/index.js
+++ b/src/pages/items/mods/index.js
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import Icon from '@mdi/react';
 import {mdiMagazineRifle} from '@mdi/js';
 
-import { Filter, InputFilter } from '../../../components/filter';
+import { Filter, InputFilter, ToggleFilter } from '../../../components/filter';
 import SmallItemTable from '../../../components/small-item-table';
 import QueueBrowserTask from '../../../modules/queue-browser-task';
 
@@ -13,6 +13,7 @@ function Mods() {
     const defaultQuery = new URLSearchParams(window.location.search).get(
         'search',
     );
+    const [showAllItemSources, setShowAllItemSources] = useState(false);
     const [nameFilter, setNameFilter] = useState(defaultQuery || '');
     const { t } = useTranslation();
 
@@ -48,6 +49,18 @@ function Mods() {
                     {t('Mods')}
                 </h1>
                 <Filter center>
+                    <ToggleFilter
+                        checked={showAllItemSources}
+                        label={t('Ignore settings')}
+                        onChange={(e) =>
+                            setShowAllItemSources(!showAllItemSources)
+                        }
+                        tooltipContent={
+                            <>
+                                {t('Shows all sources of items regardless of your settings')}
+                            </>
+                        }
+                    />
                     <InputFilter
                         defaultValue={nameFilter}
                         onChange={handleNameFilterChange}
@@ -59,24 +72,25 @@ function Mods() {
             <SmallItemTable
                 nameFilter={nameFilter}
                 typeFilter="mods"
-                fleaValue
-                traderValue
-                traderPrice
+                showAllSources={showAllItemSources}
                 autoScroll
                 maxItems={50}
+                traderValue={1}
+                fleaValue={2}
+                cheapestPrice={3}
             />
 
             <div className="page-wrapper items-page-wrapper">
                 <p>
                     {"In Escape from Tarkov, the performance and functioning of a weapon are controlled by elaborate mechanisms organized into five categories:"}
-                    <ul>
-                        <li>{"Functional Mods"}</li>
-                        <li>{"Muzzle devices (Functional Mods)"}</li>
-                        <li>{"Sights (Functional Mods)"}</li>
-                        <li>{"Gear Mods"}</li>
-                        <li>{"Vital parts"}</li>
-                    </ul>
                 </p>
+                <ul>
+                    <li>{"Functional Mods"}</li>
+                    <li>{"Muzzle devices (Functional Mods)"}</li>
+                    <li>{"Sights (Functional Mods)"}</li>
+                    <li>{"Gear Mods"}</li>
+                    <li>{"Vital parts"}</li>
+                </ul>
             </div>
         </div>,
     ];

--- a/src/pages/items/provisions/index.js
+++ b/src/pages/items/provisions/index.js
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import Icon from '@mdi/react';
 import {mdiFoodForkDrink} from '@mdi/js';
 
-import { Filter, InputFilter } from '../../../components/filter';
+import { Filter, InputFilter, ToggleFilter } from '../../../components/filter';
 import SmallItemTable from '../../../components/small-item-table';
 import QueueBrowserTask from '../../../modules/queue-browser-task';
 
@@ -14,6 +14,8 @@ function Provisions() {
         'search',
     );
     const [nameFilter, setNameFilter] = useState(defaultQuery || '');
+    const [showAllItemSources, setShowAllItemSources] = useState(false);
+    const [useTotalEnergyCost, setUseTotalEnergyCost] = useState(true);
     const { t } = useTranslation();
 
     const handleNameFilterChange = useCallback(
@@ -48,6 +50,30 @@ function Provisions() {
                     {t('Provisions')}
                 </h1>
                 <Filter center>
+                    <ToggleFilter
+                        checked={showAllItemSources}
+                        label={t('Ignore settings')}
+                        onChange={(e) =>
+                            setShowAllItemSources(!showAllItemSources)
+                        }
+                        tooltipContent={
+                            <>
+                                {t('Shows all sources of items regardless of your settings')}
+                            </>
+                        }
+                    />
+                    <ToggleFilter
+                        checked={useTotalEnergyCost}
+                        label={t('Total energy cost')}
+                        onChange={(e) =>
+                            setUseTotalEnergyCost(!useTotalEnergyCost)
+                        }
+                        tooltipContent={
+                            <>
+                                {t('Include the cost of lost hydration in the cost of energy')}
+                            </>
+                        }
+                    />
                     <InputFilter
                         defaultValue={nameFilter}
                         onChange={handleNameFilterChange}
@@ -58,10 +84,17 @@ function Provisions() {
 
             <SmallItemTable
                 nameFilter={nameFilter}
-                typeFilter="provisions"
-                fleaValue
-                traderValue
-                traderPrice
+                bsgCategoryFilter="543be6674bdc2df1348b4569"
+                showAllSources={showAllItemSources}
+                totalEnergyCost={useTotalEnergyCost}
+                hydration={1}
+                energy={2}
+                traderValue={3}
+                fleaValue={4}
+                cheapestPrice={5}
+                hydrationCost={6}
+                energyCost={7}
+                provisionValue={8}
             />
 
             <div className="page-wrapper items-page-wrapper">

--- a/src/pages/start/index.js
+++ b/src/pages/start/index.js
@@ -93,7 +93,7 @@ function Start() {
                         autoScroll={loadMoreState}
                         totalTraderPrice={true}
                         fleaValue
-                        traderValue
+                        traderValue={1}
                         instaProfit
                         hideBorders
                         key="start-items-table"

--- a/src/pages/traders/trader/index.js
+++ b/src/pages/traders/trader/index.js
@@ -157,7 +157,7 @@ function Trader() {
                 loyaltyLevelFilter={Number.isInteger(selectedTable) ? selectedTable : false}
                 traderPrice={selectedTable === 'level' ? false : true}
                 fleaValue
-                traderValue
+                traderValue={1}
                 fleaPrice
                 traderBuyback={selectedTable === 'level' ? true : false}
                 traderBuybackFilter={selectedTable === 'level' ? true : false}


### PR DESCRIPTION
Instead of using multiple columns to show the flea price, trader cash price, and barter cost, this switches many of the tables to use the "Cheapest Price" column, which displays the cheapest of all those prices and displays a tooltip to show the source of the price. This allows users to get a meaningful price sort with a single column.
Before:
![image](https://user-images.githubusercontent.com/35779878/191352035-004fda87-fbc4-4de5-b181-7356d96d4c3c.png)
After:
![image](https://user-images.githubusercontent.com/35779878/191352117-df90dc25-381f-483d-82bf-567dfff0fbd2.png)
Also enhanced some tables, such as provisions, to help show the best value items:
![image](https://user-images.githubusercontent.com/35779878/191352232-a8479f77-1d14-46db-8885-8eb24925fc5a.png)
