### PR TITLE
Better cheapeast price

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -432,11 +432,31 @@ function App() {
                     ]}
                 />
                 <Route
+                    path={'/items/food-and-drink'}
+                    element={[
+                        <Provisions
+                            sessionID={sessionID}
+                            key="provisions-wrapper"
+                        />,
+                        remoteControlSessionElement,
+                    ]}
+                />
+                <Route
                     path={'/items/grenades'}
                     element={[
                         <Grenades
                             sessionID={sessionID}
                             key="grenades-wrapper"
+                        />,
+                        remoteControlSessionElement,
+                    ]}
+                />
+                <Route
+                    path={'/items/headphones'}
+                    element={[
+                        <Headsets
+                            sessionID={sessionID}
+                            key="headsets-wrapper"
                         />,
                         remoteControlSessionElement,
                     ]}

--- a/src/components/barter-tooltip/index.js
+++ b/src/components/barter-tooltip/index.js
@@ -22,7 +22,6 @@ function BarterToolip({ barter, source, requiredItems, showTitle = true, title }
 
     let titleElement = '';
     if (showTitle) {
-        const titleText = title || `${t('Barter at')} ${source}`;
         titleElement = (
             <h3>
                 <Icon
@@ -30,9 +29,14 @@ function BarterToolip({ barter, source, requiredItems, showTitle = true, title }
                     size={1}
                     className="icon-with-text"
                 />
-                {titleText}
+                {t('Barter at')} {source}
             </h3>
         );
+        if (title) {
+            titleElement = (
+                <h4>{title}</h4>
+            );
+        }
     }
 
     return (

--- a/src/components/barter-tooltip/index.js
+++ b/src/components/barter-tooltip/index.js
@@ -11,7 +11,7 @@ import {
 
 import './index.css';
 
-function BarterToolip({ barter, source, requiredItems }) {
+function BarterToolip({ barter, source, requiredItems, showTitle = true, title }) {
     const { t } = useTranslation();
     source = source || barter?.source;
     requiredItems = requiredItems || barter?.requiredItems;
@@ -20,17 +20,25 @@ function BarterToolip({ barter, source, requiredItems }) {
         return "No barters found for this item";
     }
 
-    return (
-        <div className="cost-with-barter-wrapper">
-
+    let titleElement = '';
+    if (showTitle) {
+        const titleText = title || `${t('Barter at')} ${source}`;
+        titleElement = (
             <h3>
                 <Icon
                     path={mdiAccountSwitch}
                     size={1}
                     className="icon-with-text"
                 />
-                {t('Barter at')} {source}
+                {titleText}
             </h3>
+        );
+    }
+
+    return (
+        <div className="cost-with-barter-wrapper">
+
+            {titleElement}
             {requiredItems.map((requiredItem) => {
                 let itemName = requiredItem.item.name;
                 let price = requiredItem.item.avg24hPrice;

--- a/src/components/filter/index.js
+++ b/src/components/filter/index.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import Switch from 'react-switch';
 import Select from 'react-select';
 import Slider, { Range } from 'rc-slider';
@@ -261,6 +261,76 @@ function SelectFilter({
     );
 }
 
+function SelectItemFilter({
+    defaultValue,
+    onChange,
+    isMulti = false,
+    label,
+    tooltip,
+    tooltipDisabled,
+    onMenuOpen,
+    onMenuClose,
+    wide,
+    items,
+}) {
+    const [selectedItem, setSelectedItem] = useState(false);
+    const selectInputRef = useRef(null);
+
+    const elements = [(
+        <SelectFilter
+            key={'select-item-filter'}
+            label={label}
+            options={items.map((item) => {
+                return {
+                    label: item.name,
+                    value: item.id,
+                };
+            })}
+            onChange={(event) => {
+                if (!event) {
+                    return true;
+                }
+
+                setSelectedItem(
+                    items.find(
+                        (item) => item.id === event.value,
+                    ),
+                );
+                if (onChange) {
+                    onChange(event);
+                }
+            }}
+            parentRef={selectInputRef}
+            wide={wide}
+            defaultValue={defaultValue}
+            isMulti={isMulti}
+            tooltip={tooltip}
+            tooltipDisabled={tooltipDisabled}
+            onMenuOpen={onMenuOpen}
+            onMenuClose={onMenuClose}
+        />
+    )];
+
+    if (selectedItem) {
+        elements.push((
+            <img
+                key={'select-item-filter-selected-icon'}
+                alt={`${selectedItem.name}-icon`}
+                onClick={() => {
+                    selectInputRef.current?.clearValue();
+                    setSelectedItem(false);
+                    if (onChange) {
+                        onChange({label: '', value: false});
+                    }
+                }}
+                loading="lazy"
+                src={selectedItem.iconLink}
+            />
+        ))
+    }
+    return elements;
+}
+
 function InputFilter({
     defaultValue,
     type = 'text',
@@ -330,4 +400,5 @@ export {
     ButtonGroupFilter,
     ButtonGroupFilterButton,
     RangeFilter,
+    SelectItemFilter,
 };

--- a/src/components/small-item-table/index.js
+++ b/src/components/small-item-table/index.js
@@ -1158,6 +1158,9 @@ function SmallItemTable(props) {
             useColumns.push({
                 Header: t('Weight (kg)'),
                 accessor: 'weight',
+                sortType: (a, b, columnId, desc) => {
+                    return a.original.weight - b.original.weight;
+                },
                 Cell: CenterCell,
                 position: weight,
             });
@@ -1448,6 +1451,7 @@ function SmallItemTable(props) {
                             if (priceInfo.vendor.taskUnlock) {
                                 taskIcon = (
                                     <Icon
+                                        key="price-task-tooltip-icon"
                                         path={mdiClipboardList}
                                         size={1}
                                         className="icon-with-text"
@@ -1459,6 +1463,7 @@ function SmallItemTable(props) {
                             priceSource += ` LL${priceInfo.barter.level}`;
                             barterIcon = (
                                 <Icon
+                                key="barter-tooltip-icon"
                                     path={mdiAccountSwitch}
                                     size={1}
                                     className="icon-with-text"
@@ -1468,6 +1473,7 @@ function SmallItemTable(props) {
                             if (priceInfo.barter.taskUnlock) {
                                 taskIcon = (
                                     <Icon
+                                        key="barter-task-tooltip-icon"
                                         path={mdiClipboardList}
                                         size={1}
                                         className="icon-with-text"
@@ -1486,8 +1492,8 @@ function SmallItemTable(props) {
                         displayedPrice.push(priceSource);
                         displayedPrice.push(barterIcon);
                         displayedPrice.push(taskIcon);
-                        priceContent.push(formatPrice(props.value*props.row.original.count));
-                        priceContent.push((<div class="trader-unlock-wrapper">{displayedPrice}</div>))
+                        priceContent.push((<div key="price-info">{formatPrice(props.value*props.row.original.count)}</div>));
+                        priceContent.push((<div key="price-source-info" className="trader-unlock-wrapper">{displayedPrice}</div>))
                     } else {
                         priceContent.push('-');
                     }

--- a/src/components/small-item-table/index.js
+++ b/src/components/small-item-table/index.js
@@ -1496,7 +1496,7 @@ function SmallItemTable(props) {
                             condition={tipContent}
                             wrapper={(children) => {
                                 return (
-                                    <Tippy placement="bottom" content={tipContent}>
+                                    <Tippy placement="right" content={tipContent}>
                                         {children}
                                     </Tippy>
                                 );

--- a/src/components/small-item-table/index.js
+++ b/src/components/small-item-table/index.js
@@ -14,11 +14,13 @@ import FleaPriceCell from '../flea-price-cell';
 import BarterToolTip from '../barter-tooltip';
 import DataTable from '../data-table';
 import LoadingSmall from '../loading-small';
+import ArrowIcon from '../../components/data-table/Arrow.js';
 
 import formatPrice from '../../modules/format-price';
 import itemSearch from '../../modules/item-search';
 import { getCheapestBarter } from '../../modules/format-cost-items';
 import { formatCaliber } from '../../modules/format-ammo';
+import itemCanContain from '../../modules/item-can-contain';
 
 import {
     selectAllBarters,
@@ -115,6 +117,50 @@ const getArmorZoneString = (armorZones) => {
         .join(', ');
 };
 
+const getGuns = (items, targetItem) => {
+    let parentItems = [];
+    const currentParentItems = items.filter((innerItem) => 
+        itemCanContain(innerItem, targetItem, 'slots'),
+    );
+
+    for (const parentItem of currentParentItems) {
+        if (parentItem.types.includes('gun')) {
+            parentItems.push(parentItem);
+
+            continue;
+        }
+
+        parentItems = parentItems.concat(getGuns(items, parentItem));
+    }
+
+    let idCache = [];
+
+    parentItems = parentItems
+        .map((parentItem) => {
+            if (idCache.includes(parentItem.id)) {
+                return false;
+            }
+
+            idCache.push(parentItem.id);
+
+            return parentItem;
+        })
+        .filter(Boolean);
+
+    return parentItems;
+};
+
+const getAttachmentPoints = (items, targetItem) => {
+    return items
+        .filter((parentItem) => itemCanContain(parentItem, targetItem, 'slots'))
+        .map((item) => {
+            return {
+                ...item,
+                fitsTo: getGuns(items, item),
+            };
+        });
+};
+
 function SmallItemTable(props) {
     let {
         maxItems,
@@ -162,6 +208,7 @@ function SmallItemTable(props) {
         idFilter,
         useClassEffectiveDurability,
         excludeArmor,
+        requireArmor,
         minSlots,
         has3Slot,
         has4Slot,
@@ -178,6 +225,15 @@ function SmallItemTable(props) {
         energyCost,
         totalEnergyCost,
         provisionValue,
+        soundSuppression,
+        blocksHeadset,
+        showAttachments,
+        includeBlockingHeadset,
+        ergonomics,
+        ergoCost,
+        recoilModifier,
+        showAttachTo,
+        attachesToItemFilter,
     } = props;
     const dispatch = useDispatch();
     const { t } = useTranslation();
@@ -240,6 +296,107 @@ function SmallItemTable(props) {
     }, [containedInFilter]);
 
     const data = useMemo(() => {
+        const formatItem = itemData => {
+            const formattedItem = {
+                id: itemData.id,
+                name: itemData.name,
+                shortName: itemData.shortName,
+                normalizedName: itemData.normalizedName,
+                avg24hPrice: itemData.avg24hPrice,
+                lastLowPrice: itemData.lastLowPrice,
+                // iconLink: `https://assets.tarkov.dev/${itemData.id}-icon.jpg`,
+                iconLink: itemData.iconLink || `${process.env.PUBLIC_URL}/images/unknown-item-icon.jpg`,
+                instaProfit: 0,
+                itemLink: `/item/${itemData.normalizedName}`,
+                traderName: itemData.traderName,
+                traderNormalizedName: itemData.traderNormalizedName,
+                traderPrice: itemData.traderPrice,
+                traderPriceRUB: itemData.traderPriceRUB,
+                traderCurrency: itemData.traderCurrency,
+                types: itemData.types,
+                buyFor: itemData.buyFor.filter(buyFor => {
+                    if (buyFor.vendor.normalizedName === 'flea-market' && !showAllSources && !settings.hasFlea) return false;
+                    if (!showAllSources && settings[buyFor.vendor.normalizedName] < buyFor.vendor.minTraderLevel) return false;
+                    return true;
+                }),
+                sellFor: itemData.sellFor,
+                bestSell: itemData.sellFor.filter(sellFor => {
+                    if (sellFor.vendor.normalizedName === 'flea-market') return false;
+                    if (!showAllSources && sellFor.vendor.normalizedName === 'jaeger' && !settings.jaeger) return false;
+                    return true;
+                }),
+                buyOnFleaPrice: itemData.buyFor.find(
+                    (buyPrice) => buyPrice.vendor.normalizedName === 'flea-market' && (showAllSources || settings.hasFlea),
+                ),
+                barters: barters.filter(
+                    (barter) => barter.rewardItems[0].item.id === itemData.id,
+                ),
+                grid: itemData.grid,
+                pricePerSlot: showNetPPS ? Math.floor(itemData.avg24hPrice / (itemData.properties.capacity - (itemData.width * itemData.height)))
+                              : itemData.avg24hPrice / itemData.properties.capacity,
+                ratio: (itemData.properties.capacity / (itemData.width * itemData.height)).toFixed(2),
+                size: itemData.properties.capacity,
+                notes: itemData.notes,
+                slots: itemData.width * itemData.height,
+                armorClass: itemData.properties.class,
+                armorZone: getArmorZoneString(itemData.properties.zones || itemData.properties.headZones),
+                maxDurability: itemData.properties.durability,
+                effectiveDurability: Math.floor(itemData.properties?.durability / materialDestructibilityMap[itemData.properties?.material?.id]),
+                repairability: materialRepairabilityMap[itemData.properties?.material?.id],
+                stats: `${Math.round((itemData.properties.speedPenalty || 0) *100)}% / ${Math.round((itemData.properties.turnPenalty || 0) *100)}% / ${itemData.properties.ergoPenalty || 0}`,
+                weight: itemData.weight,
+                properties: itemData.properties,
+                categories: itemData.categories,
+                categoryIds: itemData.categoryIds,
+            };
+
+            if (formattedItem.bestSell.length > 1) {
+                formattedItem.bestSell = formattedItem.bestSell.reduce((prev, current) => {
+                    if (prev.priceRUB > current.priceRUB) return prev;
+                    return current;
+                }, {priceRUB: 0})
+            } else if (formattedItem.bestSell.length === 1) {
+                formattedItem.bestSell = formattedItem.bestSell[0];
+            }
+
+            if (!showAllSources && !settings.hasFlea) {
+                formattedItem.buyOnFleaPrice = 0
+            }
+
+            if (formattedItem.buyOnFleaPrice && formattedItem.buyOnFleaPrice.price > 0) {
+                formattedItem.instaProfit = itemData.traderPriceRUB - formattedItem.buyOnFleaPrice.price;
+            }
+
+            if (formattedItem.barters.length > 0) {
+                formattedItem.barterPrice = getCheapestBarter(itemData, formattedItem.barters, settings, showAllSources);
+
+                if (formattedItem.barterPrice && (!itemData.avg24hPrice || formattedItem.barterPrice.price < itemData.avg24hPrice)) {
+                    formattedItem.pricePerSlot = showNetPPS ? Math.floor(formattedItem.barterPrice.price / (itemData.properties.capacity - itemData.slots))
+                                                 : formattedItem.barterPrice.price / itemData.properties.capacity;
+                }
+            }
+            formattedItem.cheapestPrice = Number.MAX_SAFE_INTEGER;
+            if (formattedItem.barterPrice) {
+                //console.log(formattedItem.barterPrice.barter, settings[formattedItem.barterPrice.barter.trader.normalizedName]);
+                //if (!showAllSources && settings[buyFor.vendor.normalizedName] < buyFor.vendor.minTraderLevel)
+                formattedItem.cheapestPrice = formattedItem.barterPrice.price;
+            }
+            for (const buyFor of formattedItem.buyFor) {
+                if (buyFor.priceRUB && buyFor.priceRUB < formattedItem.cheapestPrice)
+                    formattedItem.cheapestPrice = buyFor.priceRUB;
+            }
+            if (formattedItem.cheapestPrice === Number.MAX_SAFE_INTEGER) {
+                formattedItem.cheapestPrice = 0;
+            }
+
+            if (traderBuybackFilter) {
+                formattedItem.buyback = formattedItem.bestSell?.priceRUB / formattedItem.buyOnFleaPrice.price;
+            }
+
+            formattedItem.count = containedItems[itemData.id] || 1;
+
+            return formattedItem;
+        };
         let returnData = items
             .filter((item) => {
                 return !item.types.includes('disabled');
@@ -294,6 +451,7 @@ function SmallItemTable(props) {
                     return true;
                 }
 
+                //console.log(item.properties[minPropertyFilter.property], minPropertyFilter.value);
                 if (
                     item.properties[minPropertyFilter.property] <
                     minPropertyFilter.value
@@ -321,8 +479,12 @@ function SmallItemTable(props) {
                 if (!bsgCategoryFilter) {
                     return true;
                 }
+                let categories = bsgCategoryFilter;
+                if (!Array.isArray(categories)) {
+                    categories = [categories];
+                }
 
-                return item.categories.find(category => category.id === bsgCategoryFilter);
+                return item.categories.some(category => categories.includes(category.id));
             })
             .filter(item => {
                 if (!containedInFilter) {
@@ -330,100 +492,14 @@ function SmallItemTable(props) {
                 }
                 return containedItems[item.id];
             })
+            .filter(item => {
+                if (includeBlockingHeadset) {
+                    return true;
+                }
+                return !item.properties.blocksHeadset;
+            })
             .map((itemData) => {
-                const formattedItem = {
-                    id: itemData.id,
-                    name: itemData.name,
-                    shortName: itemData.shortName,
-                    normalizedName: itemData.normalizedName,
-                    avg24hPrice: itemData.avg24hPrice,
-                    lastLowPrice: itemData.lastLowPrice,
-                    // iconLink: `https://assets.tarkov.dev/${itemData.id}-icon.jpg`,
-                    iconLink: itemData.iconLink || `${process.env.PUBLIC_URL}/images/unknown-item-icon.jpg`,
-                    instaProfit: 0,
-                    itemLink: `/item/${itemData.normalizedName}`,
-                    traderName: itemData.traderName,
-                    traderNormalizedName: itemData.traderNormalizedName,
-                    traderPrice: itemData.traderPrice,
-                    traderPriceRUB: itemData.traderPriceRUB,
-                    traderCurrency: itemData.traderCurrency,
-                    types: itemData.types,
-                    buyFor: itemData.buyFor.filter(buyFor => {
-                        if (buyFor.vendor.normalizedName === 'flea-market' && !showAllSources && !settings.hasFlea) return false;
-                        if (!showAllSources && settings[buyFor.vendor.normalizedName] < buyFor.vendor.minTraderLevel) return false;
-                        return true;
-                    }),
-                    sellFor: itemData.sellFor,
-                    bestSell: itemData.sellFor.filter(sellFor => {
-                        if (sellFor.vendor.normalizedName === 'flea-market') return false;
-                        if (!showAllSources && sellFor.vendor.normalizedName === 'jaeger' && !settings.jaeger) return false;
-                        return true;
-                    }),
-                    buyOnFleaPrice: itemData.buyFor.find(
-                        (buyPrice) => buyPrice.vendor.normalizedName === 'flea-market' && (showAllSources || settings.hasFlea),
-                    ),
-                    barters: barters.filter(
-                        (barter) => barter.rewardItems[0].item.id === itemData.id,
-                    ),
-                    grid: itemData.grid,
-                    pricePerSlot: showNetPPS ? Math.floor(itemData.avg24hPrice / (itemData.properties.capacity - (itemData.width * itemData.height)))
-                                  : itemData.avg24hPrice / itemData.properties.capacity,
-                    ratio: (itemData.properties.capacity / (itemData.width * itemData.height)).toFixed(2),
-                    size: itemData.properties.capacity,
-                    notes: itemData.notes,
-                    slots: itemData.width * itemData.height,
-                    armorClass: itemData.properties.class,
-                    armorZone: getArmorZoneString(itemData.properties.zones || itemData.properties.headZones),
-                    maxDurability: itemData.properties.durability,
-                    effectiveDurability: Math.floor(itemData.properties?.durability / materialDestructibilityMap[itemData.properties?.material?.id]),
-                    repairability: materialRepairabilityMap[itemData.properties?.material?.id],
-                    stats: `${Math.round((itemData.properties.speedPenalty || 0) *100)}% / ${Math.round((itemData.properties.turnPenalty || 0) *100)}% / ${itemData.properties.ergoPenalty || 0}`,
-                    weight: itemData.weight,
-                    properties: itemData.properties,
-                };
-
-                if (formattedItem.bestSell.length > 1) {
-                    formattedItem.bestSell = formattedItem.bestSell.reduce((prev, current) => {
-                        if (prev.priceRUB > current.priceRUB) return prev;
-                        return current;
-                    }, {priceRUB: 0})
-                } else if (formattedItem.bestSell.length === 1) {
-                    formattedItem.bestSell = formattedItem.bestSell[0];
-                }
-
-                if (!showAllSources && !settings.hasFlea) {
-                    formattedItem.buyOnFleaPrice = 0
-                }
-
-                if (formattedItem.buyOnFleaPrice && formattedItem.buyOnFleaPrice.price > 0) {
-                    formattedItem.instaProfit = itemData.traderPriceRUB - formattedItem.buyOnFleaPrice.price;
-                }
-
-                if (formattedItem.barters.length > 0) {
-                    formattedItem.barterPrice = getCheapestBarter(itemData, formattedItem.barters, settings, showAllSources);
-
-                    if (formattedItem.barterPrice && (!itemData.avg24hPrice || formattedItem.barterPrice.price < itemData.avg24hPrice)) {
-                        formattedItem.pricePerSlot = showNetPPS ? Math.floor(formattedItem.barterPrice.price / (itemData.properties.capacity - itemData.slots))
-                                                     : formattedItem.barterPrice.price / itemData.properties.capacity;
-                    }
-                }
-                formattedItem.cheapestPrice = Number.MAX_SAFE_INTEGER;
-                if (formattedItem.barterPrice) {
-                    //console.log(formattedItem.barterPrice.barter, settings[formattedItem.barterPrice.barter.trader.normalizedName]);
-                    //if (!showAllSources && settings[buyFor.vendor.normalizedName] < buyFor.vendor.minTraderLevel)
-                    formattedItem.cheapestPrice = formattedItem.barterPrice.price;
-                }
-                for (const buyFor of formattedItem.buyFor) {
-                    if (buyFor.priceRUB && buyFor.priceRUB < formattedItem.cheapestPrice)
-                        formattedItem.cheapestPrice = buyFor.priceRUB;
-                }
-                if (formattedItem.cheapestPrice === Number.MAX_SAFE_INTEGER) {
-                    formattedItem.cheapestPrice = 0;
-                }
-
-                formattedItem.count = containedItems[itemData.id] || 1;
-
-                return formattedItem;
+                return formatItem(itemData);
             })
             .filter((item) => {
                 if (!maxPrice) {
@@ -483,12 +559,6 @@ function SmallItemTable(props) {
                 .filter(
                     (item) => item.buyOnFleaPrice && item.buyOnFleaPrice.price > 0,
                 )
-                .map((item) => {
-                    return {
-                        ...item,
-                        buyback: item.bestSell?.priceRUB / item.buyOnFleaPrice.price,
-                    };
-                })
                 .sort((a, b) => {
                     return b.buyback - a.buyback;
                 });
@@ -505,6 +575,10 @@ function SmallItemTable(props) {
 
         if (excludeArmor) {
             returnData = returnData.filter(item => !item.properties.class);
+        }
+
+        if (requireArmor) {
+            returnData = returnData.filter(item => item.properties.class);
         }
 
         if (minSlots) {
@@ -542,6 +616,58 @@ function SmallItemTable(props) {
             });
         }
 
+        if (showAttachments) {
+            returnData.forEach(item => {
+                item.subRows = items.filter(linkedItem => {
+                    if (!item.properties?.slots) return false;
+                    for (const slot of item.properties.slots) {
+                        const included = slot.filters.allowedItems.includes(linkedItem.id) ||
+                            linkedItem.categoryIds.some(catId => slot.filters.allowedCategories.includes(catId));
+                        const excluded = slot.filters.excludedItems.includes(linkedItem.id) ||
+                            linkedItem.categoryIds.some(catId => slot.filters.excludedCategories.includes(catId));
+                        if (included && !excluded) return true;
+                    }
+                    return false;
+                }).map(item => formatItem(item));
+            });
+        }
+
+        if (showAttachTo || attachesToItemFilter) {
+            returnData.forEach(item => {
+                item.fitsTo = getGuns(items, item);
+            });
+        }
+
+        if (attachesToItemFilter) {
+            returnData = returnData.filter(item => {
+                for (const baseItem of item.fitsTo) {
+                    if (baseItem.id === attachesToItemFilter.id) {
+                        return true;
+                    }
+                }
+
+                return false;
+            });
+        }
+
+        if (showAttachTo) {
+            returnData.forEach(formattedItem => {
+                formattedItem.subRows = getAttachmentPoints(items, formattedItem).filter((item) => {
+                    if (!attachesToItemFilter) {
+                        return true;
+                    }
+
+                    for (const subRow of item.fitsTo) {
+                        if (subRow.id === attachesToItemFilter.id) {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }).map(parentItem => formatItem(parentItem));
+            });
+        } 
+
         return returnData;
     }, [
         nameFilter,
@@ -568,9 +694,14 @@ function SmallItemTable(props) {
         showAllSources,
         idFilter,
         excludeArmor,
+        requireArmor,
         minSlots,
         has3Slot,
         has4Slot,
+        showAttachments,
+        includeBlockingHeadset,
+        showAttachTo,
+        attachesToItemFilter,
     ]);
     const lowHydrationCost = useMemo(() => {
         if (!totalEnergyCost && !provisionValue) {
@@ -620,7 +751,42 @@ function SmallItemTable(props) {
     ]);
 
     const columns = useMemo(() => {
-        const useColumns = [
+        const useColumns = [];
+        if (showAttachments || showAttachTo) {
+            useColumns.push({
+                id: 'expander',
+                Header: ({
+                    getToggleAllRowsExpandedProps,
+                    isAllRowsExpanded,
+                }) =>
+                    // <span {...getToggleAllRowsExpandedProps()}>
+                    //     {isAllRowsExpanded ? 'v' : '>'}
+                    // </span>
+                    null,
+                Cell: ({ row }) =>
+                    // Use the row.canExpand and row.getToggleRowExpandedProps prop getter
+                    // to build the toggle for expanding a row
+                    row.canExpand ? (
+                        <span
+                            {...row.getToggleRowExpandedProps({
+                                style: {
+                                    // We can even use the row.depth property
+                                    // and paddingLeft to indicate the depth
+                                    // of the row
+                                    // paddingLeft: `${row.depth * 2}rem`,
+                                },
+                            })}
+                        >
+                            {row.isExpanded ? (
+                                <ArrowIcon />
+                            ) : (
+                                <ArrowIcon className={'arrow-right'} />
+                            )}
+                        </span>
+                    ) : null,
+            });
+        }
+        useColumns.push(
             {
                 Header: t('Name'),
                 accessor: 'name',
@@ -633,7 +799,7 @@ function SmallItemTable(props) {
                     );
                 },
             },
-        ];
+        );
 
         if (fleaValue) {
             useColumns.push({
@@ -1165,6 +1331,72 @@ function SmallItemTable(props) {
             });
         }
 
+        if (soundSuppression) {
+            useColumns.push({
+                Header: t('Sound suppression'),
+                accessor: (item) => item.properties.deafening,
+                Cell: CenterCell,
+                position: soundSuppression,
+            });
+        }
+
+        if (blocksHeadset) {
+            useColumns.push({
+                Header: t('Blocks earpiece'),
+                accessor: (item) => item.properties.blocksHeadset ? 'Yes' : 'No',
+                Cell: CenterCell,
+                position: blocksHeadset,
+            });
+        }
+
+        if (ergonomics) {
+            useColumns.push({
+                Header: t('Ergonomics'),
+                accessor: (item) => item.properties.ergonomics,
+                Cell: CenterCell,
+                position: ergonomics,
+            });
+        }
+
+        if (ergoCost) {
+            useColumns.push({
+                Header: t('Cost per ergo'),
+                accessor: (item) => {
+                    if (item.cheapestPrice) {
+                        return item.cheapestPrice / item.properties.ergonomics;
+                    }
+                    return Number.MAX_SAFE_INTEGER;
+                },
+                Cell: ({ value }) => {
+                    if (!value) {
+                        value = '-';
+                    } else if (value === Number.MAX_SAFE_INTEGER) {
+                        value = '-'
+                    } else {
+                        value = formatPrice(value);
+                    }
+                    return <CenterCell value={value} nowrap />;
+                },
+                position: ergoCost,
+            });
+        }
+
+        if (recoilModifier) {
+            useColumns.push({
+                Header: t('Recoil'),
+                accessor: (item) => item.properties.recoilModifier,
+                Cell: ({value}) => {
+                    if (!value) {
+                        value = '-'
+                    } else {
+                        value = `${Math.round(value * 100)}%`;
+                    }
+                    return <CenterCell value={value} nowrap />;
+                },
+                position: recoilModifier,
+            });
+        }
+
         if (cheapestPrice) {
             useColumns.push({
                 Header: t('Cheapest Price'),
@@ -1200,6 +1432,12 @@ function SmallItemTable(props) {
                                     {t('This item can\'t be sold on the Flea Market')}
                                 </div>
                             ));
+                        } else {
+                            tipContent.push((
+                                <div key={'no-flea-tooltip'}>
+                                    {t('This item has not been observed on the Flea Market')}
+                                </div>
+                            ));
                         }
                         tipContent.push((
                             <div key={'no-trader-sell-tooltip'}>
@@ -1229,6 +1467,9 @@ function SmallItemTable(props) {
             const column = useColumns[i];
             if (Number.isInteger(column.position)) {
                 let position = parseInt(column.position);
+                if (showAttachments || showAttachTo) {
+                    position++;
+                }
                 if (position < 1) {
                     position = 1;
                 }
@@ -1289,6 +1530,13 @@ function SmallItemTable(props) {
         lowEnergyCost,
         totalEnergyCost,
         provisionValue,
+        soundSuppression,
+        blocksHeadset,
+        showAttachments,
+        showAttachTo,
+        ergonomics,
+        ergoCost,
+        recoilModifier,
     ]);
 
     let extraRow = false;

--- a/src/pages/items/armor/index.js
+++ b/src/pages/items/armor/index.js
@@ -98,7 +98,7 @@ function Armor(props) {
                     />
                     <RangeFilter
                         defaultValue={[minArmorClass, maxArmorClass]}
-                        label={t('Min armor class')}
+                        label={t('Armor class')}
                         min={1}
                         max={6}
                         marks={marks}

--- a/src/pages/items/headsets/index.js
+++ b/src/pages/items/headsets/index.js
@@ -76,7 +76,7 @@ function Headsets() {
                 weight={1}
                 traderValue={2}
                 fleaValue={3}
-                cheapestPrice
+                cheapestPrice={4}
             />
 
             <div className="page-wrapper items-page-wrapper">


### PR DESCRIPTION
Adds the price source to the cheapest price column. Tooltips are used to show barter ingredients or tasks required to unlock trader offers.
![image](https://user-images.githubusercontent.com/35779878/191539541-7afd02ce-aeee-4634-a726-b004d547364e.png)

Also use cheapest price column on helmets, pistol grips, and suppressors pages.