### PR TITLE
Link presets on guns page and item pages

### DIFF
--- a/scripts/cache-api-data.mjs
+++ b/scripts/cache-api-data.mjs
@@ -1,0 +1,13 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+import doFetchItems from '../src/features/items/do-fetch-items.mjs';
+
+(async () => {
+    console.time('Caching API data');
+    
+    const items = await doFetchItems(true);
+
+    await fs.writeFile('./public/data/item.json', JSON.stringify(items));
+    console.timeEnd('Caching API data');
+})();

--- a/src/components/filter/index.js
+++ b/src/components/filter/index.js
@@ -211,6 +211,7 @@ const selectFilterStyle = {
 
 function SelectFilter({
     defaultValue,
+    value,
     options,
     onChange,
     isMulti = false,
@@ -237,16 +238,26 @@ function SelectFilter({
                 );
             }}
         >
-            <label
-                className={`single-filter-wrapper ${
-                    wide ? 'single-filter-wrapper-wide' : ''
-                }`}
+            <ConditionalWrapper
+                condition={label}
+                wrapper={(labelChildren) => {
+                    return (
+                        <label
+                            className={`single-filter-wrapper ${
+                                wide ? 'single-filter-wrapper-wide' : ''
+                            }`}
+                        >
+                            <span className={'single-filter-label'}>{label}</span>
+                            {labelChildren}
+                        </label>
+                    )
+                }}
             >
-                <span className={'single-filter-label'}>{label}</span>
                 <Select
                     className="basic-multi-select"
                     classNamePrefix="select"
                     defaultValue={defaultValue}
+                    value={value}
                     isMulti={isMulti}
                     name="colors"
                     onChange={onChange}
@@ -256,13 +267,15 @@ function SelectFilter({
                     ref={parentRef}
                     styles={selectFilterStyle}
                 />
-            </label>
+            </ConditionalWrapper>
         </ConditionalWrapper>
     );
 }
 
 function SelectItemFilter({
     defaultValue,
+    value,
+    selection,
     onChange,
     isMulti = false,
     label,
@@ -272,6 +285,8 @@ function SelectItemFilter({
     onMenuClose,
     wide,
     items,
+    showImage = true,
+    shortNames
 }) {
     const [selectedItem, setSelectedItem] = useState(false);
     const selectInputRef = useRef(null);
@@ -282,8 +297,9 @@ function SelectItemFilter({
             label={label}
             options={items.map((item) => {
                 return {
-                    label: item.name,
+                    label: shortNames? item.shortName : item.name,
                     value: item.id,
+                    selected: selection && selection.id === item.id
                 };
             })}
             onChange={(event) => {
@@ -303,6 +319,7 @@ function SelectItemFilter({
             parentRef={selectInputRef}
             wide={wide}
             defaultValue={defaultValue}
+            value={value}
             isMulti={isMulti}
             tooltip={tooltip}
             tooltipDisabled={tooltipDisabled}
@@ -311,7 +328,7 @@ function SelectItemFilter({
         />
     )];
 
-    if (selectedItem) {
+    if (selectedItem && showImage) {
         elements.push((
             <img
                 key={'select-item-filter-selected-icon'}

--- a/src/components/preset-selector/index.js
+++ b/src/components/preset-selector/index.js
@@ -1,0 +1,53 @@
+import React, { useMemo, useState } from 'react';
+import { useNavigate } from "react-router-dom";
+
+import { useItemsQuery } from '../../features/items/queries';
+import { SelectItemFilter } from '../filter';
+
+export function PresetSelector({ item, alt = '' }) {
+    const navigate = useNavigate();
+
+    // Use the primary items API query to fetch all items
+    const result = useItemsQuery();
+
+    const [selected, setSelected] = useState(item);
+
+    const baseId = useMemo(() => {
+        setSelected(item);
+        if (item.types.includes('preset')) {
+            return item.properties.baseItem.id;
+        }
+        return item.id;
+    }, [item]);
+
+    const selectedValue = useMemo(() => {
+        return {
+            label: selected.shortName,
+            value: selected.id
+        };
+    }, [selected]);
+
+    const items = result.data.filter(testItem => testItem.id === baseId || (testItem.types.includes('preset') && testItem.properties.baseItem.id === baseId)).sort((a, b) => {
+        return a.shortName.localeCompare(b.shortName);
+    });
+
+    if (items.length < 2) {
+        return alt;
+    }
+    return (
+        <div>
+            <SelectItemFilter 
+                items={items} 
+                value={selectedValue}
+                shortNames 
+                showImage={false}
+                onChange={(event) => {
+                    if (!event) {
+                        return true;
+                    }
+                    navigate(`/item/${event.value}`);
+                }}
+            />
+        </div>
+    );
+}

--- a/src/components/preset-selector/index.js
+++ b/src/components/preset-selector/index.js
@@ -27,7 +27,14 @@ export function PresetSelector({ item, alt = '' }) {
         };
     }, [selected]);
 
-    const items = result.data.filter(testItem => testItem.id === baseId || (testItem.types.includes('preset') && testItem.properties.baseItem.id === baseId)).sort((a, b) => {
+    const items = result.data.filter(
+        testItem => testItem.id === baseId || (testItem.types.includes('preset') && testItem.properties.baseItem.id === baseId)
+    ).filter(testItem => {
+        if (!testItem.types.includes('preset')) {
+            return true;
+        }
+        return testItem.properties.baseItem.properties.defaultPreset.id !== testItem.id;
+    }).sort((a, b) => {
         return a.shortName.localeCompare(b.shortName);
     });
 

--- a/src/components/small-item-table/index.js
+++ b/src/components/small-item-table/index.js
@@ -671,6 +671,8 @@ function SmallItemTable(props) {
                         return false;
                     }
                     return linkedItem.properties.baseItem.id === item.id;
+                }).sort((a, b) => {
+                    return a.shortName.localeCompare(b.shortName);
                 }).map(item => formatItem(item));
             });
         }

--- a/src/components/small-item-table/index.js
+++ b/src/components/small-item-table/index.js
@@ -259,6 +259,7 @@ function SmallItemTable(props) {
         showAttachTo,
         attachesToItemFilter,
         showSlotValue,
+        showPresets,
     } = props;
     const dispatch = useDispatch();
     const { t } = useTranslation();
@@ -663,6 +664,17 @@ function SmallItemTable(props) {
             });
         }
 
+        if (showPresets) {
+            returnData.forEach(item => {
+                item.subRows = items.filter(linkedItem => {
+                    if (!linkedItem.types.includes('preset')){ 
+                        return false;
+                    }
+                    return linkedItem.properties.baseItem.id === item.id;
+                }).map(item => formatItem(item));
+            });
+        }
+
         if (showAttachTo || attachesToItemFilter) {
             returnData.forEach(item => {
                 item.fitsTo = getGuns(items, item);
@@ -733,6 +745,7 @@ function SmallItemTable(props) {
         includeBlockingHeadset,
         showAttachTo,
         attachesToItemFilter,
+        showPresets,
     ]);
     const lowHydrationCost = useMemo(() => {
         if (!totalEnergyCost && !provisionValue) {
@@ -783,7 +796,7 @@ function SmallItemTable(props) {
 
     const columns = useMemo(() => {
         const useColumns = [];
-        if (showAttachments || showAttachTo) {
+        if (showAttachments || showAttachTo || showPresets) {
             useColumns.push({
                 id: 'expander',
                 Header: ({
@@ -1562,7 +1575,7 @@ function SmallItemTable(props) {
             const column = useColumns[i];
             if (Number.isInteger(column.position)) {
                 let position = parseInt(column.position);
-                if (showAttachments || showAttachTo) {
+                if (showAttachments || showAttachTo || showPresets) {
                     position++;
                 }
                 if (position < 1) {
@@ -1632,7 +1645,8 @@ function SmallItemTable(props) {
         ergoCost,
         recoilModifier,
         showSlotValue,
-        showAllSources
+        showAllSources,
+        showPresets
     ]);
 
     let extraRow = false;

--- a/src/components/small-item-table/index.js
+++ b/src/components/small-item-table/index.js
@@ -671,6 +671,8 @@ function SmallItemTable(props) {
                         return false;
                     }
                     return linkedItem.properties.baseItem.id === item.id;
+                }).filter(linkedItem => {
+                    return linkedItem.properties.baseItem.properties.defaultPreset.id !== linkedItem.id;
                 }).sort((a, b) => {
                     return a.shortName.localeCompare(b.shortName);
                 }).map(item => formatItem(item));

--- a/src/features/items/do-fetch-items.js
+++ b/src/features/items/do-fetch-items.js
@@ -301,6 +301,13 @@ const doFetchItems = async () => {
                             id
                             name
                             normalizedName
+                            properties {
+                                ...on ItemPropertiesWeapon {
+                                    defaultPreset {
+                                        id
+                                    }
+                                }
+                            }
                         }
                         ergonomics
                         recoilVertical

--- a/src/pages/item/index.js
+++ b/src/pages/item/index.js
@@ -42,6 +42,7 @@ import fleaFee from '../../modules/flea-market-fee';
 import bestPrice from '../../modules/best-price';
 
 import './index.css';
+import { PresetSelector } from '../../components/preset-selector';
 
 dayjs.extend(relativeTime);
 
@@ -528,9 +529,14 @@ function Item() {
                                 src={currentItemData.iconLink}
                             />
                         </h1>
-                        <cite className="item-short-name-wrapper">
-                            {currentItemData.shortName}
-                        </cite>
+                        <PresetSelector 
+                            item={currentItemData}
+                            alt={(
+                                <cite className="item-short-name-wrapper">
+                                    {currentItemData.shortName}
+                                </cite>
+                            )}
+                        />
                         {currentItemData.wikiLink && (
                             <span className="wiki-link-wrapper">
                                 <a href={currentItemData.wikiLink}>

--- a/src/pages/items/guns/index.js
+++ b/src/pages/items/guns/index.js
@@ -74,6 +74,7 @@ function Guns() {
                 totalTraderPrice={true}
                 typeFilter="gun"
                 showAllSources={showAllItemSources}
+                showPresets
                 maxItems={50}
                 autoScroll
                 traderValue={1}


### PR DESCRIPTION
On the guns page, presets are listed as subrows for each gun:
![image](https://user-images.githubusercontent.com/35779878/192113040-094d75d8-b3a8-4f0d-ad1a-ef9d720d2406.png)

On an item page, when an item has presets, a select box of all the presets is displayed:
![image](https://user-images.githubusercontent.com/35779878/192113062-9f782d65-e523-45a1-82b1-67a25512733c.png)
Selecting a preset will navigate to that item page.

If an item doesn't have presets, the shortName displays instead:
![image](https://user-images.githubusercontent.com/35779878/192113099-25f88b25-bd38-41c4-a77f-330cdaa2404c.png)
