### PR TITLE
removes the manual notes attribute from items

### DIFF
--- a/src/components/item-name-cell/index.js
+++ b/src/components/item-name-cell/index.js
@@ -5,36 +5,40 @@ import ContainedItemsList from '../contained-items-list';
 import './index.css';
 
 function ItemNameCell(props) {
+    let {item, showContainedItems, showRestrictedType} = props;
+    if (!item) {
+        item = props.row.original;
+    }
     return (
         <div className="small-item-table-description-wrapper">
             <div className="small-item-table-image-wrapper">
                 <Link
-                    to={props.row.original.itemLink}
+                    to={item.itemLink}
                     className="small-item-table-image-link"
                 >
                     <img
-                        alt={props.row.original.name}
+                        alt={item.name}
                         className="table-image"
                         loading="lazy"
-                        src={props.row.original.iconLink}
+                        src={item.iconLink}
                     />
                 </Link>
             </div>
             <div className="small-item-table-name-wrapper">
                 <Link
                     className="craft-reward-item-title"
-                    to={props.row.original.itemLink}
+                    to={item.itemLink}
                 >
-                    {props.row.original.name}{props.row.original.count > 1 ? ` x ${props.row.original.count}` : ''}
+                    {item.name}{item.count > 1 ? ` x ${item.count}` : ''}
                 </Link>
-                {props.row.original.notes ? (
-                    <cite>{props.row.original.notes}</cite>
-                ) : (
-                    ''
-                )}
-                {props.showContainedItems && (props.row.original.properties?.grids || props.row.original.properties?.slots) && (
+                {showRestrictedType && (
                     <cite>
-                        <ContainedItemsList item={props.row.original} />
+                        <ContainedItemsList item={item} showRestrictedType={showRestrictedType} />
+                    </cite>
+                )}
+                {showContainedItems && (item.properties?.grids || item.properties?.slots) && (
+                    <cite>
+                        <ContainedItemsList item={item} />
                     </cite>
                 )}
             </div>

--- a/src/components/items-for-hideout/index.js
+++ b/src/components/items-for-hideout/index.js
@@ -1,16 +1,39 @@
-import { useMemo } from 'react';
-import { useSelector } from 'react-redux';
+import { useEffect, useMemo } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { useHideoutQuery } from '../../features/hideout/queries';
+
+import { selectAllHideoutModules, fetchHideout } from '../../features/hideout/hideoutSlice';
 
 import './index.css';
 
 function ItemsForHideout(props) {
     const { itemFilter, showAll } = props;
     const { t } = useTranslation();
-    const { data: hideout } = useHideoutQuery();
     const settings = useSelector((state) => state.settings);
+
+    const dispatch = useDispatch();
+    const hideout = useSelector(selectAllHideoutModules);
+    const hideoutStatus = useSelector((state) => {
+        return state.hideout.status;
+    });
+
+    useEffect(() => {
+        let timer = false;
+        if (hideoutStatus === 'idle') {
+            dispatch(fetchHideout());
+        }
+
+        if (!timer) {
+            timer = setInterval(() => {
+                dispatch(fetchHideout());
+            }, 600000);
+        }
+
+        return () => {
+            clearInterval(timer);
+        };
+    }, [hideoutStatus, dispatch]);
 
     // Data manipulation section
     const data = useMemo(() => {

--- a/src/components/small-item-table/index.js
+++ b/src/components/small-item-table/index.js
@@ -268,6 +268,7 @@ function SmallItemTable(props) {
         attachesToItemFilter,
         showSlotValue,
         showPresets,
+        showRestrictedType,
     } = props;
     const dispatch = useDispatch();
     const { t } = useTranslation();
@@ -382,7 +383,6 @@ function SmallItemTable(props) {
                               : itemData.avg24hPrice / itemData.properties.capacity,
                 ratio: (itemData.properties.capacity / (itemData.width * itemData.height)).toFixed(2),
                 size: itemData.properties.capacity,
-                notes: itemData.notes,
                 slots: itemData.width * itemData.height,
                 armorClass: itemData.properties.class,
                 armorZone: getArmorZoneString(itemData.properties.zones || itemData.properties.headZones),
@@ -866,8 +866,9 @@ function SmallItemTable(props) {
                 Cell: (props) => {
                     return (
                         <ItemNameCell
-                            {...props}
+                            item={props.row.original}
                             showContainedItems={showContainedItems}
+                            showRestrictedType={showRestrictedType}
                         />
                     );
                 },
@@ -1693,7 +1694,8 @@ function SmallItemTable(props) {
         recoilModifier,
         showSlotValue,
         showAllSources,
-        showPresets
+        showPresets,
+        showRestrictedType,
     ]);
 
     let extraRow = false;

--- a/src/features/items/do-fetch-items.js
+++ b/src/features/items/do-fetch-items.js
@@ -3,10 +3,6 @@ import fetch  from 'cross-fetch';
 import fleaMarketFee from '../../modules/flea-market-fee.js';
 import camelcaseToDashes from '../../modules/camelcase-to-dashes.js';
 
-const NOTES = {
-    '60a2828e8689911a226117f9': `Can't store Pillbox, Day Pack, LK 3F or MBSS inside`,
-};
-
 const doFetchItems = async (language, prebuild = false) => {
     const QueryBody = JSON.stringify({
         query: `{
@@ -517,7 +513,6 @@ const doFetchItems = async (language, prebuild = false) => {
             // iconLink: `https://assets.tarkov.dev/${rawItem.id}-icon.jpg`,
             iconLink: rawItem.iconLink,
             grid: grid,
-            notes: NOTES[rawItem.id],
             properties: {
                 weight: rawItem.weight,
                 ...rawItem.properties

--- a/src/pages/items/backpacks/index.js
+++ b/src/pages/items/backpacks/index.js
@@ -43,7 +43,8 @@ function Backpacks() {
                         }
                     />
                     <ToggleFilter
-                        label={t('Net Price per Slot?')}
+                        label={t('Net price per slot')}
+                        tooltipContent={t('Show price per additional slot of storage gained from the container')}
                         onChange={(e) => setShowNetPPS(!showNetPPS)}
                         checked={showNetPPS}
                     />
@@ -52,13 +53,14 @@ function Backpacks() {
 
             <SmallItemTable
                 typeFilter={'backpack'}
+                showNetPPS={showNetPPS}
+                showAllSources={showAllItemSources}
+                showRestrictedType={'backpack'}
                 grid={1}
                 innerSize={2}
                 weight={3}
                 cheapestPrice={4}
                 pricePerSlot={5}
-                showNetPPS={showNetPPS}
-                showAllSources={showAllItemSources}
             />
             
             <div className="page-wrapper items-page-wrapper">


### PR DESCRIPTION
The items query added a manual "notes" attribute to one item, specifically for use on the backpacks page:
![image](https://user-images.githubusercontent.com/35779878/193355165-5de9dd54-b710-4776-b967-122df20502a9.png)
This PR removes that manual note and instead changes it to a dynamic list on that page for all backpacks:
![image](https://user-images.githubusercontent.com/35779878/193355248-6e31edde-0733-445b-9282-4abdbc93a02a.png)
