### PR TITLE
Attempt to survive non-fatal api errors

### DIFF
--- a/scripts/cache-api-data.mjs
+++ b/scripts/cache-api-data.mjs
@@ -119,7 +119,7 @@ try {
         resolve();
     }));
 
-    apiPromises.push(doFetchBarters('en').then(barters => {
+    apiPromises.push(doFetchBarters('en', true).then(barters => {
         for (const barter of barters) {
             barter.rewardItems.forEach(containedItem => {
                 const item = containedItem.item;
@@ -142,7 +142,7 @@ try {
         fs.writeFileSync('./src/data/barters.json', JSON.stringify(barters));
     }));
 
-    apiPromises.push(doFetchCrafts('en').then(crafts => {
+    apiPromises.push(doFetchCrafts('en', true).then(crafts => {
         for (const craft of crafts) {
             craft.rewardItems.forEach(containedItem => {
                 const item = containedItem.item;
@@ -165,11 +165,11 @@ try {
         fs.writeFileSync('./src/data/crafts.json', JSON.stringify(crafts));
     }));
 
-    apiPromises.push(doFetchHideout('en').then(hideout => {
+    apiPromises.push(doFetchHideout('en', true).then(hideout => {
         fs.writeFileSync('./src/data/hideout.json', JSON.stringify(hideout));
     }));
 
-    apiPromises.push(doFetchTraders('en').then(traders => {
+    apiPromises.push(doFetchTraders('en', true).then(traders => {
         fs.writeFileSync('./src/data/traders.json', JSON.stringify(traders));
     }));
     apiPromises.push(new Promise(async resolve => {
@@ -189,15 +189,15 @@ try {
         resolve();
     }));
 
-    apiPromises.push(doFetchMaps('en').then(maps => {
+    apiPromises.push(doFetchMaps('en', true).then(maps => {
         fs.writeFileSync('./src/data/maps_cached.json', JSON.stringify(maps));
     }));
 
-    apiPromises.push(doFetchMeta('en').then(meta => {
+    apiPromises.push(doFetchMeta('en', true).then(meta => {
         fs.writeFileSync('./src/data/meta.json', JSON.stringify(meta));
     }));
 
-    apiPromises.push(doFetchQuests('en').then(quests => {
+    apiPromises.push(doFetchQuests('en', true).then(quests => {
         fs.writeFileSync('./src/data/quests.json', JSON.stringify(quests));
         return new Promise(async resolve => {
             const taskLangs = {};

--- a/src/features/items/do-fetch-items.js
+++ b/src/features/items/do-fetch-items.js
@@ -421,7 +421,35 @@ const doFetchItems = async (language, prebuild = false) => {
         })
     ]);
     //console.timeEnd('items query');
-    if (itemData.errors) return Promise.reject(new Error(itemData.errors[0].message));
+    if (itemData.errors) {
+        for (const error of itemData.errors) {
+            let badItem = false;
+            if (error.path) {
+                let traverseLimit = 2;
+                if (error.path[0] === 'fleaMarket') {
+                    traverseLimit = 1;
+                }
+                badItem = itemData.data;
+                for (let i = 0; i < traverseLimit; i++) {
+                    badItem = badItem[error.path[i]];
+                }
+            }
+            console.log(`Error in items API query: ${error.message}`, error.path);
+            if (badItem) {
+                console.log(badItem)
+            }
+        }
+        // only throw error if this is for prebuild or data wasn't returned
+        if (
+            prebuild || !itemData.data || 
+            !itemData.data.items || !itemData.data.items.length || 
+            !itemData.data.fleaMarket || 
+            !itemData.data.traders || !itemData.data.traders.length || 
+            !itemData.data.currencies || !itemData.data.currencies.length
+        ) {
+            return Promise.reject(new Error(itemData.errors[0].message));
+        }
+    }
 
     const flea = itemData.data.fleaMarket;
 

--- a/src/features/maps/do-fetch-maps.js
+++ b/src/features/maps/do-fetch-maps.js
@@ -1,6 +1,6 @@
 import fetch  from 'cross-fetch';
 
-const doFetchMaps = async (language) => {
+const doFetchMaps = async (language, prebuild = false) => {
     const bodyQuery = JSON.stringify({
         query: `{
             maps(lang: ${language}) {
@@ -47,6 +47,29 @@ const doFetchMaps = async (language) => {
     });
 
     const mapsData = await response.json();
+
+    if (mapsData.errors) {
+        for (const error of mapsData.errors) {
+            let badItem = false;
+            if (error.path) {
+                badItem = mapsData.data;
+                for (let i = 0; i < 2; i++) {
+                    badItem = badItem[error.path[i]];
+                }
+            }
+            console.log(`Error in maps API query: ${error.message}`);
+            if (badItem) {
+                console.log(badItem)
+            }
+        }
+        // only throw error if this is for prebuild or data wasn't returned
+        if (
+            prebuild || !mapsData.data || 
+            !mapsData.data.maps || !mapsData.data.maps.length
+        ) {
+            return Promise.reject(new Error(mapsData.errors[0].message));
+        }
+    }
 
     return mapsData.data.maps;
 };

--- a/src/features/meta/do-fetch-meta.js
+++ b/src/features/meta/do-fetch-meta.js
@@ -1,6 +1,6 @@
 import fetch  from 'cross-fetch';
 
-const doFetchMeta = async (language) => {
+const doFetchMeta = async (language, prebuild = false) => {
     const bodyQuery = JSON.stringify({
         query: `{
             fleaMarket(lang: ${language}) {
@@ -42,7 +42,34 @@ const doFetchMeta = async (language) => {
 
     const metaData = await response.json();
 
-    if (metaData.errors) return Promise.reject(new Error(metaData.errors[0]));
+    if (metaData.errors) {
+        for (const error of metaData.errors) {
+            let badItem = false;
+            if (error.path) {
+                let traverseLimit = 2;
+                if (error.path[0] === 'fleaMarket') {
+                    traverseLimit = 1;
+                }
+                badItem = metaData.data;
+                for (let i = 0; i < traverseLimit; i++) {
+                    badItem = badItem[error.path[i]];
+                }
+            }
+            console.log(`Error in meta API query: ${error.message}`, error.path);
+            if (badItem) {
+                console.log(badItem)
+            }
+        }
+        // only throw error if this is for prebuild or data wasn't returned
+        if (
+            prebuild || !metaData.data || 
+            !metaData.data.fleaMarket || 
+            !metaData.data.armorMaterials || !metaData.data.armorMaterials.length || 
+            !metaData.data.itemCategories || !metaData.data.itemCategories.length
+        ) {
+            return Promise.reject(new Error(metaData.errors[0].message));
+        }
+    }
 
     return {flea: metaData.data.fleaMarket, armor: metaData.data.armorMaterials, categories: metaData.data.itemCategories};
 };


### PR DESCRIPTION
Currently, API errors will either cause the query to fail entirely or will be ignored entirely. This PR changes things so that all errors will be output to the console but if data is returned from the API query, the site will attempt to use that data. Should make the site a bit more robust for when we accidentally introduce API errors.

Caching data during prebuild will ALWAYS fail if there are any errors, because we don't want a deployment to cache error-ridden data.