### PR TITLE
Update TarkovTracker progress immediately

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -82,6 +82,8 @@ const APIDocs = React.lazy(() => import('./pages/api-docs'));
 const socketServer = `wss://socket.tarkov.dev`;
 
 let socket = false;
+let oldUse = false;
+let tarkovTrackerProgressInterval = false;
 
 loadPolyfills();
 
@@ -116,8 +118,13 @@ function App() {
     );
 
     useEffect(() => {
-        let tarkovTrackerProgressInterval = false;
-        if (useTarkovTracker && progressStatus === 'idle') {
+        if (!oldUse && useTarkovTracker && tarkovTrackerProgressInterval) {
+            clearInterval(tarkovTrackerProgressInterval);
+            tarkovTrackerProgressInterval = false;
+        }
+        oldUse = useTarkovTracker;
+
+        if (useTarkovTracker && progressStatus !== 'loading' && !tarkovTrackerProgressInterval) {
             dispatch(fetchTarkovTrackerProgress(tarkovTrackerAPIKey));
         }
 
@@ -129,6 +136,7 @@ function App() {
 
         if (tarkovTrackerProgressInterval && !useTarkovTracker) {
             clearInterval(tarkovTrackerProgressInterval);
+            tarkovTrackerProgressInterval = false;
         }
 
         return () => {

--- a/src/App.js
+++ b/src/App.js
@@ -82,7 +82,6 @@ const APIDocs = React.lazy(() => import('./pages/api-docs'));
 const socketServer = `wss://socket.tarkov.dev`;
 
 let socket = false;
-let oldUse = false;
 let tarkovTrackerProgressInterval = false;
 
 loadPolyfills();
@@ -118,12 +117,6 @@ function App() {
     );
 
     useEffect(() => {
-        if (!oldUse && useTarkovTracker && tarkovTrackerProgressInterval) {
-            clearInterval(tarkovTrackerProgressInterval);
-            tarkovTrackerProgressInterval = false;
-        }
-        oldUse = useTarkovTracker;
-
         if (useTarkovTracker && progressStatus !== 'loading' && !tarkovTrackerProgressInterval) {
             dispatch(fetchTarkovTrackerProgress(tarkovTrackerAPIKey));
         }

--- a/src/components/barters-table/index.js
+++ b/src/components/barters-table/index.js
@@ -21,13 +21,13 @@ import FleaMarketLoadingIcon from '../FleaMarketLoadingIcon';
 import './index.css';
 
 function BartersTable(props) {
-    const { selectedTrader, nameFilter, itemFilter, removeDogtags, showAll } =
+    const { selectedTrader, nameFilter, itemFilter, showAll } =
         props;
     const dispatch = useDispatch();
     const { t } = useTranslation();
     const settings = useSelector((state) => state.settings);
-    const { includeFlea, hasJaeger } = useMemo(() => {
-        return {includeFlea: settings.includeFlea, hasJaeger: settings.hasJaeger};
+    const { includeFlea, hasJaeger, removeDogtags } = useMemo(() => {
+        return {includeFlea: settings.includeFlea, hasJaeger: settings.hasJaeger, removeDogtags: settings.hideDogtagBarters};
     }, [settings]);
     //const includeFlea = useSelector((state) => state.settings.hasFlea);
     //const hasJaeger = useSelector((state) => state.settings.jaeger);

--- a/src/components/quest-table/index.js
+++ b/src/components/quest-table/index.js
@@ -151,6 +151,7 @@ function QuestTable({
     minimumTraderLevel,
     requiredItems,
     rewardItems,
+    reputationRewards,
  }) {
     const { t } = useTranslation();
     const settings = useSelector((state) => state.settings);
@@ -415,7 +416,14 @@ function QuestTable({
             useColumns.push({
                 Header: t('Minimum level'),
                 accessor: 'minPlayerLevel',
-                Cell: CenterCell,
+                Cell: (props) => {
+                    if (!props.value) {
+                        return '';
+                    }
+                    return (
+                        <CenterCell value={props.value}/>
+                    );
+                },
                 position: minimumLevel,
             });
         }
@@ -428,7 +436,31 @@ function QuestTable({
                 },
                 Cell: (props) => {
                     return (
-                        <CenterCell value ={props.row.original.traderLevelRequirements.map(req => req.level).join(', ')}/>
+                        <CenterCell value={props.row.original.traderLevelRequirements.map(req => req.level).join(', ')}/>
+                    );
+                },
+                position: minimumTraderLevel,
+            });
+        }
+
+        if (reputationRewards) {
+            useColumns.push({
+                Header: t('Reputation rewards'),
+                accessor: (questData) => {
+                    return questData.finishRewards.traderStanding[0]?.standing;
+                },
+                Cell: (props) => {
+                    return (
+                        <CenterCell value={props.row.original.finishRewards.traderStanding?.reduce((standings, current) => {
+                            const trader = traders.find(t => t.id === current.trader.id);
+                            standings.push((
+                                <div key={trader.id}>
+                                    <Link to={`/traders/${trader.normalizedName}`}>{trader.name}</Link>
+                                    <span>: {current.standing}</span>
+                                </div>
+                            ));
+                            return standings;
+                        }, [])}/>
                     );
                 },
                 position: minimumTraderLevel,
@@ -468,6 +500,7 @@ function QuestTable({
         minimumTraderLevel,
         requiredItems,
         rewardItems,
+        reputationRewards,
     ]);
 
     let extraRow = false;

--- a/src/components/quest-table/index.js
+++ b/src/components/quest-table/index.js
@@ -477,7 +477,7 @@ function QuestTable({
     } else if (allQuestData.length !== shownQuests.length) {
         extraRow = (
             <>
-                {t('Some completed quests hidden by ')}<Link to="/settings/">{t('your settings')}</Link>
+                {t('Some tasks hidden by filter settings')}
             </>
         );
     }

--- a/src/components/quest-table/index.js
+++ b/src/components/quest-table/index.js
@@ -195,6 +195,13 @@ function QuestTable({
                 rewardItems: [],
             };
 
+            if (reputationRewards) {
+                questData.totalRepReward = rawQuest.finishRewards.traderStanding?.reduce((total, current) => {
+                    total += current.standing;
+                    return Math.round(total * 100) / 100;
+                }, 0);
+            }
+
             if (requiredItemFilter || requiredItems) {
                 questData.requiredItems = getRequiredQuestItems(rawQuest, requiredItemFilter).map(req => {
                     return {
@@ -243,6 +250,7 @@ function QuestTable({
         rewardItemFilter,
         requiredItems,
         rewardItems,
+        reputationRewards,
     ]);
 
     const shownQuests = useMemo(() => {
@@ -446,9 +454,7 @@ function QuestTable({
         if (reputationRewards) {
             useColumns.push({
                 Header: t('Reputation rewards'),
-                accessor: (questData) => {
-                    return questData.finishRewards.traderStanding[0]?.standing;
-                },
+                accessor: 'totalRepReward',
                 Cell: (props) => {
                     return (
                         <CenterCell value={props.row.original.finishRewards.traderStanding?.reduce((standings, current) => {
@@ -462,6 +468,9 @@ function QuestTable({
                             return standings;
                         }, [])}/>
                     );
+                },
+                sortType: (a, b, columnId, desc) => {
+                    return a.original.totalRepReward - b.original.totalRepReward;
                 },
                 position: minimumTraderLevel,
             });
@@ -495,6 +504,7 @@ function QuestTable({
         t,
         settings,
         quests,
+        traders,
         questRequirements,
         minimumLevel,
         minimumTraderLevel,

--- a/src/features/barters/do-fetch-barters.js
+++ b/src/features/barters/do-fetch-barters.js
@@ -216,10 +216,10 @@ const doFetchBarters = async (language, prebuild = false) => {
 
     return bartersData.data.barters.map(barter => {
         barter.rewardItems.forEach(contained => {
-            contained.item.iconLink = contained.item.defaultPreset?.iconLink || contained.item.iconLink;
+            contained.item.iconLink = contained.item.properties?.defaultPreset?.iconLink || contained.item.iconLink;
         });
         barter.requiredItems.forEach(contained => {
-            contained.item.iconLink = contained.item.defaultPreset?.iconLink || contained.item.iconLink;
+            contained.item.iconLink = contained.item.properties?.defaultPreset?.iconLink || contained.item.iconLink;
         });
         return barter;
     });

--- a/src/features/crafts/do-fetch-crafts.js
+++ b/src/features/crafts/do-fetch-crafts.js
@@ -214,10 +214,10 @@ export default async function doFetchCrafts(language, prebuild = false) {
         (craft) => !craft.source.toLowerCase().includes('christmas'),
     ).map(craft => {
         craft.rewardItems.forEach(contained => {
-            contained.item.iconLink = contained.item.defaultPreset?.iconLink || contained.item.iconLink;
+            contained.item.iconLink = contained.item.properties?.defaultPreset?.iconLink || contained.item.iconLink;
         });
         craft.requiredItems.forEach(contained => {
-            contained.item.iconLink = contained.item.defaultPreset?.iconLink || contained.item.iconLink;
+            contained.item.iconLink = contained.item.properties?.defaultPreset?.iconLink || contained.item.iconLink;
         });
         return craft;
     });;

--- a/src/features/settings/settingsSlice.js
+++ b/src/features/settings/settingsSlice.js
@@ -3,7 +3,7 @@ import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 export const fetchTarkovTrackerProgress = createAsyncThunk(
     'settings/fetchTarkovTrackerProgress',
     async (apiKey) => {
-        if (!apiKey) {
+        if (!apiKey || typeof apiKey !== 'string' || !apiKey.match(/^[a-zA-Z0-9]{22}$/)) {
             return false;
         }
 

--- a/src/features/settings/settingsSlice.js
+++ b/src/features/settings/settingsSlice.js
@@ -175,9 +175,6 @@ const settingsSlice = createSlice({
             );
         },
         toggleTarkovTracker: (state, action) => {
-            /*if (!state.useTarkovTracker && action.payload) {
-                fetchTarkovTrackerProgress(state.tarkovTrackerAPIKey);
-            }*/
             state.useTarkovTracker = action.payload;
             localStorageWriteJson(
                 'useTarkovTracker',

--- a/src/features/settings/settingsSlice.js
+++ b/src/features/settings/settingsSlice.js
@@ -175,6 +175,9 @@ const settingsSlice = createSlice({
             );
         },
         toggleTarkovTracker: (state, action) => {
+            /*if (!state.useTarkovTracker && action.payload) {
+                fetchTarkovTrackerProgress(state.tarkovTrackerAPIKey);
+            }*/
             state.useTarkovTracker = action.payload;
             localStorageWriteJson(
                 'useTarkovTracker',

--- a/src/features/settings/settingsSlice.js
+++ b/src/features/settings/settingsSlice.js
@@ -150,6 +150,7 @@ const settingsSlice = createSlice({
         tarkovTrackerModules: [],
         hideRemoteControl: localStorageReadJson('hide-remote-control', false),
         minDogtagLevel: localStorageReadJson('minDogtagLevel', 1),
+        hideDogtagBarters: localStorageReadJson('hideTogtagBarters', false),
     },
     reducers: {
         setTarkovTrackerAPIKey: (state, action) => {
@@ -166,6 +167,10 @@ const settingsSlice = createSlice({
         setMinDogtagLevel: (state, action) => {
             state.minDogtagLevel = parseInt(action.payload);
             localStorageWriteJson('minDogtagLevel', parseInt(action.payload));
+        },
+        toggleHideDogtagBarters: (state, action) => {
+            state.hideDogtagBarters = action.payload;
+            localStorageWriteJson('hideDogtagBarters', action.payload);
         },
         setStationOrTraderLevel: (state, action) => {
             state[action.payload.target] = action.payload.value;
@@ -265,6 +270,7 @@ export const {
     setStationOrTraderLevel,
     toggleTarkovTracker,
     toggleHideRemoteControl,
+    toggleHideDogtagBarters,
 } = settingsSlice.actions;
 
 export default settingsSlice.reducer;

--- a/src/modules/format-cost-items.js
+++ b/src/modules/format-cost-items.js
@@ -77,6 +77,9 @@ function getCheapestBarter(item, barters, settings, allowAllSources) {
             (accumulatedPrice, requiredItem) => {
                 let price = getCheapestItemPrice(requiredItem.item, settings, allowAllSources).priceRUB;
                 if (isAnyDogtag(requiredItem.item.id)) {
+                    if (settings.hideDogtagBarters) {
+                        return 0;
+                    }
                     const dogtagCost = getDogTagCost(requiredItem, settings);
                     price = dogtagCost.price;
                 }
@@ -115,6 +118,9 @@ function getCheapestItemPriceWithBarters(item, barters, settings, allowAllSource
             (accumulatedPrice, requiredItem) => {
                 let price = getCheapestItemPrice(requiredItem.item, settings, allowAllSources).priceRUB;
                 if (isAnyDogtag(requiredItem.item.id)) {
+                    if (settings.hideDogtagBarters) {
+                        return 0;
+                    }
                     const dogtagCost = getDogTagCost(requiredItem, settings);
                     price = dogtagCost.price;
                 }

--- a/src/pages/barters/index.js
+++ b/src/pages/barters/index.js
@@ -17,6 +17,8 @@ import {
 
 import { selectAllTraders, fetchTraders } from '../../features/traders/tradersSlice';
 
+import { toggleHideDogtagBarters } from '../../features/settings/settingsSlice';
+
 import './index.css';
 
 function Barters() {
@@ -32,10 +34,7 @@ function Barters() {
         'showAllBarters',
         false,
     );
-    const [hideDogtags, setHideDogtags] = useStateWithLocalStorage(
-        'hideDogtagBarters',
-        false,
-    );
+    const hideDogtagBarters = useSelector((state) => state.settings.hideDogtagBarters);
 
     const dispatch = useDispatch();
     const allTraders = useSelector(selectAllTraders);
@@ -89,12 +88,12 @@ function Barters() {
                         }
                     />
                     <ToggleFilter
-                        checked={hideDogtags}
+                        checked={hideDogtagBarters}
                         label={t('Hide dogtags')}
-                        onChange={(e) => setHideDogtags(!hideDogtags)}
+                        onChange={(e) => dispatch(toggleHideDogtagBarters(!hideDogtagBarters))}
                         tooltipContent={
                             <>
-                                {t('The true "cost" of barters using Dogtags is difficult to estimate')}
+                                {t('The true "cost" of barters using Dogtags is difficult to estimate, so you may want to exclude dogtag barters')}
                             </>
                         }
                     />
@@ -148,7 +147,6 @@ function Barters() {
                 nameFilter={nameFilter}
                 selectedTrader={selectedTrader}
                 key="barters-page-barters-table"
-                removeDogtags={hideDogtags}
                 showAll={showAll}
             />
 

--- a/src/pages/item/index.css
+++ b/src/pages/item/index.css
@@ -192,10 +192,6 @@
         padding-top: 20px;
     }
 
-    .item-page-wrapper h2 {
-        /* margin-top: 70px; */
-    }
-
     .item-crafts-headline-wrapper,
     .item-barters-headline-wrapper,
     .item-contents-headline-wrapper,

--- a/src/pages/item/index.js
+++ b/src/pages/item/index.js
@@ -36,10 +36,12 @@ import {
     useItemByNameQuery,
     useItemByIdQuery,
 } from '../../features/items/queries';
+import { toggleHideDogtagBarters } from '../../features/settings/settingsSlice';
 
 import formatPrice from '../../modules/format-price';
 import fleaFee from '../../modules/flea-market-fee';
 import bestPrice from '../../modules/best-price';
+import { isAnyDogtag } from '../../modules/dogtags';
 
 import './index.css';
 import { PresetSelector } from '../../components/preset-selector';
@@ -132,6 +134,7 @@ function Item() {
     const questsStatus = useSelector((state) => {
         return state.quests.status;
     });
+    const hideDogtagBarters = useSelector((state) => state.settings.hideDogtagBarters);
 
     useEffect(() => {
         let timer = false;
@@ -270,6 +273,22 @@ function Item() {
 
     if (!currentItemData && (itemStatus === 'success' || itemStatus === 'failed')) {
         return <ErrorPage />;
+    }
+
+    let dogtagToggle = '';
+    if (isAnyDogtag(currentItemData.id)) {
+        dogtagToggle = (
+            <ToggleFilter
+                checked={hideDogtagBarters}
+                label={t('Hide dogtag barters')}
+                onChange={(e) => dispatch(toggleHideDogtagBarters(!hideDogtagBarters))}
+                tooltipContent={
+                    <>
+                        {t('The true "cost" of barters using Dogtags is difficult to estimate, so you may want to exclude dogtag barters')}
+                    </>
+                }
+            />
+        );
     }
 
     const hasProperties = !!currentItemData.properties;
@@ -775,6 +794,7 @@ function Item() {
                                     </>
                                 }
                             />
+                            {dogtagToggle}
                         </div>
                         <BartersTable
                             itemFilter={currentItemData.id}

--- a/src/pages/quests/index.js
+++ b/src/pages/quests/index.js
@@ -147,6 +147,7 @@ function Quests() {
                 nameFilter={nameFilter}
                 questRequirements={1}
                 minimumLevel={2}
+                reputationRewards={3}
             />
 
             <div>

--- a/src/pages/settings/index.js
+++ b/src/pages/settings/index.js
@@ -14,6 +14,7 @@ import {
     setTarkovTrackerAPIKey,
     toggleTarkovTracker,
     toggleHideRemoteControl,
+    toggleHideDogtagBarters,
     // selectCompletedQuests,
 } from '../../features/settings/settingsSlice';
 
@@ -64,6 +65,7 @@ function Settings() {
     const useTarkovTracker = useSelector(
         (state) => state.settings.useTarkovTracker,
     );
+    const hideDogtagBarters = useSelector((state) => state.settings.hideDogtagBarters);
 
     const refs = {
         'bitcoin-farm': useRef(null),
@@ -213,11 +215,16 @@ function Settings() {
                 })}
             </div>
             <div className="settings-group-wrapper">
-                <h2>{t('Misc.')}</h2>
+                <h2>{t('Dogtag Barters')}</h2>
                 <ToggleFilter
-                    label={t('Hide remote control')}
-                    onChange={handleHideRemoteValueToggle}
-                    checked={hideRemoteControlValue}
+                    checked={hideDogtagBarters}
+                    label={t('Exclude')}
+                    onChange={(e) => dispatch(toggleHideDogtagBarters(!hideDogtagBarters))}
+                    tooltipContent={
+                        <>
+                            {t('The true "cost" of barters using Dogtags is difficult to estimate, so you may want to exclude dogtag barters')}
+                        </>
+                    }
                 />
                 <InputFilter
                     label={t('Minimum dogtag level')}
@@ -242,6 +249,12 @@ function Settings() {
                             <div>{t(`The current estimated average player level is {{avgPlayerLevel}}`, {avgPlayerLevel: estimatedAvgPlayerLevel})}</div>
                         </div>
                     )}
+                />
+                <h2>{t('Misc.')}</h2>
+                <ToggleFilter
+                    label={t('Hide remote control')}
+                    onChange={handleHideRemoteValueToggle}
+                    checked={hideRemoteControlValue}
                 />
             </div>
             {/* cheeki breeki */}


### PR DESCRIPTION
Before, when the "Use TarkovTracker" switch was toggled on, the site would wait until the remainder of the 5-minute update interval to sync progress with Tarkov Tracker. Now, flipping that switch will cause an immediate sync.

Also makes the "exclude dogtag barters" toggle a site-wide setting.

Also also fixes icon images for weapons received from barters and crafts so they're not images of the stripped receivers.

Resolves #234 