### PR TITLE
Allow tooltips on PropertyList

### DIFF
--- a/src/components/property-list/index.js
+++ b/src/components/property-list/index.js
@@ -1,12 +1,19 @@
 import { useMemo } from 'react';
 import propertyFormatter from '../../modules/property-format';
 import { useTranslation } from 'react-i18next';
+import Tippy from '@tippyjs/react';
 
 import './index.css';
 
 const skipProps = ['grid', 'ConflictingItems', '__typename', 'slots'];
 
+const ConditionalWrapper = ({ condition, wrapper, children }) => {
+    return condition ? wrapper(children) : children;
+};
+
 function PropertyList({ properties }) {
+    const { t } = useTranslation();
+
     const data = useMemo(
         () =>
             Object.entries(properties ?? {})
@@ -16,14 +23,12 @@ function PropertyList({ properties }) {
                 .map(([property, value]) => {
                     return propertyFormatter(property, value);
                 })
-                .filter(([property, value]) => value !== undefined)
-                .filter(([property, value]) => value?.length !== 0)
+                .filter(([property, value]) => value.value !== undefined)
+                .filter(([property, value]) => value.value?.length !== 0)
                 .sort((a, b) => a[0].localeCompare(b[0])),
 
-        [properties],
+        [properties, t],
     );
-
-    const { t } = useTranslation();
 
     return (
         <div className="property-list">
@@ -31,9 +36,21 @@ function PropertyList({ properties }) {
                 return (
                     <div className="property-wrapper" key={property}>
                         <div>
-                            {value}
+                            {value.value}
                             <div className="property-key-wrapper">
-                                {t(property)}
+                                <ConditionalWrapper
+                                    condition={value.tooltip}
+                                    wrapper={(children) => 
+                                        <Tippy
+                                            content={value.tooltip}
+                                            placement="bottom"
+                                        >
+                                            <div>{t(children)}</div>
+                                        </Tippy>
+                                    }
+                                >
+                                    {property}
+                                </ConditionalWrapper>
                             </div>
                         </div>
                     </div>

--- a/src/components/property-list/index.js
+++ b/src/components/property-list/index.js
@@ -27,7 +27,7 @@ function PropertyList({ properties }) {
                 .filter(([property, value]) => value.value?.length !== 0)
                 .sort((a, b) => a[0].localeCompare(b[0])),
 
-        [properties, t],
+        [properties],
     );
 
     return (

--- a/src/modules/property-format.js
+++ b/src/modules/property-format.js
@@ -41,6 +41,16 @@ const itemCategoryLinkFormat = inputCategory => {
 };
 
 const formatter = (key, value) => {
+    let tooltip = false;
+    if (typeof value === 'object' && value.value) {
+        if (value.tooltip) {
+            tooltip = value.tooltip;
+        }
+        value = value.value;
+    } else if (typeof value === 'object' && !Array.isArray(value)) {
+        console.log('not array', key, value)
+    }
+
     if (key === 'Weight') {
         return [key, `${value} kg`];
     }
@@ -150,15 +160,27 @@ const formatter = (key, value) => {
         }).filter(Boolean)];//.reduce((prev, curr) => [prev, (<br/>), curr])];
     }
 
+    if (key === 'material') {
+        if (typeof value === 'object') {
+            value = value.name;
+        }
+    }
+
     const displayKey = defaultFormat(key);
-    if (Array.isArray(value)) {
-        return [displayKey, value.join(', ')];
+
+    value = {
+        value: value,
+        tooltip: tooltip,
+    }
+
+    if (Array.isArray(value.value)) {
+        value.value = value.value.join(', ');
     }
 
     // if the value is an object, return an empty array meaning that we
     // can't format that value
-    if (typeof value === 'object') {
-        return [displayKey, undefined];
+    if (typeof value.value === 'object') {
+        value.value = undefined;
     }
 
     return [displayKey, value];

--- a/src/pages/bosses/boss/index.js
+++ b/src/pages/bosses/boss/index.js
@@ -144,16 +144,25 @@ function BossPage(params) {
         spawnStatsMsg.push(`${displayPercent}% (${map.name})`)
     }
 
-    bossProperties[t('spawnChance') + ` 🎲`] = spawnStatsMsg.join(', ');
+    bossProperties[t('spawnChance') + ` 🎲`] = {
+        value: spawnStatsMsg.join(', '),
+        tooltip: 'Chance that the boss spawns on a given map',
+    };
 
     // Display health stats
     if (bossJsonData) {
-        bossProperties[t('health') + ' 🖤'] = bossJsonData.health;
+        bossProperties[t('health') + ' 🖤'] = {
+            value: bossJsonData.health,
+            tooltip: t('Total boss health'),
+        };
     }
 
     // Display behavior info
     if (bossJsonData) {
-        bossProperties[t('behavior') + ' 💡'] = bossJsonData.behavior;
+        bossProperties[t('behavior') + ' 💡'] = {
+            value: bossJsonData.behavior,
+            tooltip: t("The boss's general AI behavior"),
+        };
     }
 
     // Format the boss table spawnLocation data
@@ -229,12 +238,6 @@ function BossPage(params) {
                     />
                 </h2>
                 <PropertyList properties={bossProperties} />
-                <p>Key:</p>
-                <ul>
-                    <li>Behavior: The general AI behavior of the given boss</li>
-                    <li>Health: Total boss health</li>
-                    <li>Spawn Chance: A percentage chance that the boss spawns on a given map</li>
-                </ul>
 
                 {bossJsonData &&
                     <h2 className='item-h2' key={'boss-loot-header'}>

--- a/src/pages/bosses/boss/index.js
+++ b/src/pages/bosses/boss/index.js
@@ -146,7 +146,7 @@ function BossPage(params) {
 
     bossProperties[t('spawnChance') + ` 🎲`] = {
         value: spawnStatsMsg.join(', '),
-        tooltip: 'Chance that the boss spawns on a given map',
+        tooltip: t('Chance that the boss spawns on a given map'),
     };
 
     // Display health stats


### PR DESCRIPTION
Adds support for tooltips on the PropertyList element. Used on the boss page to move the key to tooltips. Here's how it looked before:
![image](https://user-images.githubusercontent.com/35779878/205185844-7ccde171-2b1b-4f4d-a1d0-224915bad9f1.png)

And with the change that moves the key to tooltips:
![image](https://user-images.githubusercontent.com/35779878/205185891-603252d6-d24a-413b-951f-9be2021539a1.png)
