### PR TITLE
show christmas tree in hideout build costs

### DIFF
--- a/src/pages/hideout/index.js
+++ b/src/pages/hideout/index.js
@@ -111,9 +111,9 @@ function Hideout() {
                 </ButtonGroupFilter>
             </Filter>
             {hideout.map((hideoutModule) => {
-                if (hideoutModule.name === 'Christmas Tree') {
+                /*if (hideoutModule.name === 'Christmas Tree') {
                     return null;
-                }
+                }*/
 
                 if (
                     selectedStation &&


### PR DESCRIPTION
The requirements to build the Christmas Tree currently do not display on the hideout build costs page. This PR fixes that issue.