### PR TITLE
GitHub Ratelimit Fixes

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -37,6 +37,8 @@ jobs:
       - name: Build
         if: ${{ steps.branch-deploy.outputs.continue == 'true' }}
         run: npm run build
+        env:
+          GITHUB_TOKEN: ${{ secrets.HIDEOUT_BOT_TOKEN }}
 
       - name: deploy - dev
         id: dev-deploy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,8 @@ jobs:
 
       - name: Build
         run: npm run build
+        env:
+          GITHUB_TOKEN: ${{ secrets.HIDEOUT_BOT_TOKEN }}
 
       - name: deploy
         uses: cloudflare/wrangler-action@4c10c1822abba527d820b29e6333e7f5dac2cabd # pin@2.0.0

--- a/scripts/get-contributors.js
+++ b/scripts/get-contributors.js
@@ -15,19 +15,22 @@ const repositories = [
     'TarkovTracker/tarkovdata',
 ];
 
+// If a GitHub token is provided, use it to increase the rate limit
+const token = process.env.GITHUB_TOKEN;
+const headers = {};
+if (token) {
+    headers.authorization = `token ${token}`;
+    console.log("Using provided GitHub token to increase rate limit")
+} else {
+    console.log("No GitHub token provided, rate limit may be reached")
+}
+
 (async () => {
     console.log('Loading contributors');
     let allContributors = [];
 
     for (const repository of repositories) {
         console.time(`contributors-${repository}`);
-
-        // If a GitHub token is provided, use it to increase the rate limit
-        const token = process.env.GITHUB_TOKEN;
-        const headers = {};
-        if (token) {
-            headers.authorization = `token ${token}`;
-        }
 
         const response = await got(`https://api.github.com/repos/${repository}/contributors`, {
             responseType: 'json',

--- a/scripts/get-contributors.js
+++ b/scripts/get-contributors.js
@@ -19,14 +19,23 @@ const repositories = [
     console.log('Loading contributors');
     let allContributors = [];
 
-    for(const repository of repositories){
+    for (const repository of repositories) {
         console.time(`contributors-${repository}`);
+
+        // If a GitHub token is provided, use it to increase the rate limit
+        const token = process.env.GITHUB_TOKEN;
+        const headers = {};
+        if (token) {
+            headers.authorization = `token ${token}`;
+        }
+
         const response = await got(`https://api.github.com/repos/${repository}/contributors`, {
             responseType: 'json',
+            headers,
         });
         console.timeEnd(`contributors-${repository}`);
 
-        for(const contributor of response.body){
+        for (const contributor of response.body) {
             allContributors.push({
                 login: contributor.login,
                 html_url: contributor.html_url,

--- a/scripts/get-version.js
+++ b/scripts/get-version.js
@@ -5,12 +5,23 @@ const got = require('got');
 
 const COMMIT_URL = 'https://api.github.com/repos/the-hideout/tarkov-dev/commits/main';
 
+// Use a GitHub token to increase the rate limit
+const token = process.env.GITHUB_TOKEN;
+const headers = {};
+if (token) {
+    headers.authorization = `token ${token}`;
+    console.log("Using provided GitHub token to increase rate limit")
+} else {
+    console.log("No GitHub token provided, rate limit may be reached")
+}
+
 const getVersion = async function getVersion() {
     console.time(`Get version url ${COMMIT_URL}`);
     try {
         const response = await got(COMMIT_URL, {
             responseType: 'json',
             timeout: 5000,
+            headers,
         }).json();
         console.timeEnd(`Get version url ${COMMIT_URL}`);
 


### PR DESCRIPTION
# GitHub Ratelimit Fixes

This pull request uses a token from our new @hideout-bot account. This allows us to have a ratelimit of 5,000 requests instead of 60. This will help prevent CI failures due to GitHub ratelimits when fetching contributors during the `npm build` stage of our CI and branch deployments

resolves: https://github.com/the-hideout/tarkov-dev/issues/290