### PR TITLE
Default table sort and fixes

### DIFF
--- a/src/components/barters-table/index.js
+++ b/src/components/barters-table/index.js
@@ -56,6 +56,7 @@ function BartersTable({ selectedTrader, nameFilter, itemFilter, showAll }) {
         () => [
             {
                 Header: t('Reward'),
+                id: 'reward',
                 accessor: 'reward',
                 Cell: ({ value }) => {
                     return <RewardCell {...value} />;
@@ -63,6 +64,7 @@ function BartersTable({ selectedTrader, nameFilter, itemFilter, showAll }) {
             },
             {
                 Header: t('Cost'),
+                id: 'costItems',
                 accessor: 'costItems',
                 Cell: ({ value }) => {
                     return <CostItemsCell costItems={value} />;
@@ -70,6 +72,7 @@ function BartersTable({ selectedTrader, nameFilter, itemFilter, showAll }) {
             },
             {
                 Header: t('Cost ₽'),
+                id: 'cost',
                 accessor: 'cost',
                 Cell: (props) => {
                     if (props.row.original.cached) {
@@ -84,7 +87,14 @@ function BartersTable({ selectedTrader, nameFilter, itemFilter, showAll }) {
             },
             {
                 Header: t('Estimated savings'),
+                id: 'savings',
                 accessor: (d) => Number(d.savings),
+                sortType: (a, b, columnId, desc) => {
+                    const aSell = a.values.savings || (desc ? Number.MIN_SAFE_INTEGER : Number.MAX_SAFE_INTEGER);
+                    const bSell = b.values.savings || (desc ? Number.MIN_SAFE_INTEGER : Number.MAX_SAFE_INTEGER);
+                    
+                    return aSell - bSell;
+                },
                 Cell: (props) => {
                     if (props.row.original.cached) {
                         return (
@@ -95,21 +105,12 @@ function BartersTable({ selectedTrader, nameFilter, itemFilter, showAll }) {
                     }
                     return <ValueCell value={props.value} highlightProfit valueDetails={props.row.original.savingsParts} />;
                 },
-                sortType: (a, b) => {
-                    if (a.sellValue > b.sellValue) {
-                        return 1;
-                    }
-
-                    if (a.sellValue < b.sellValue) {
-                        return -1;
-                    }
-
-                    return 0;
-                },
             },
             {
                 Header: t('InstaProfit'),
+                id: 'instaProfit',
                 accessor: 'instaProfit',
+                sortType: 'basic',
                 Cell: (props) => {
                     if (props.row.original.cached) {
                         return (
@@ -121,12 +122,11 @@ function BartersTable({ selectedTrader, nameFilter, itemFilter, showAll }) {
                     return (
                         <ValueCell value={props.value} highlightProfit valueDetails={props.row.original.instaProfitDetails}>
                             <div className="duration-wrapper">
-                                {props.row.original.instaProfitSource.vendor.name}
+                                {props.row.original.instaProfitSource.vendor.normalizedName!=='unknown' ? props.row.original.instaProfitSource.vendor.name : ''}
                             </div>
                         </ValueCell>
                     );
                 },
-                sortType: 'basic',
             },
         ],
         [t],
@@ -458,10 +458,12 @@ function BartersTable({ selectedTrader, nameFilter, itemFilter, showAll }) {
 
     return (
         <DataTable
-            columns={columns}
-            extraRow={extraRow}
             key="barters-table"
+            columns={columns}
             data={data}
+            extraRow={extraRow}
+            sortBy={'instaProfit'}
+            sortByDesc={true}
         />
     );
 }

--- a/src/components/crafts-table/index.js
+++ b/src/components/crafts-table/index.js
@@ -372,6 +372,7 @@ function CraftTable({ selectedStation, freeFuel, nameFilter, itemFilter, showAll
         () => [
             {
                 Header: t('Reward'),
+                id: 'reward',
                 accessor: 'reward',
                 Cell: ({ value }) => {
                     return <RewardCell {...value} />;
@@ -379,14 +380,23 @@ function CraftTable({ selectedStation, freeFuel, nameFilter, itemFilter, showAll
             },
             {
                 Header: t('Cost'),
+                id: 'costItems',
                 accessor: 'costItems',
+                sortType: (a, b, columnId, desc) => {
+                    const aCostItems = a.original.cost || (desc ? Number.MIN_SAFE_INTEGER : Number.MAX_SAFE_INTEGER);
+                    const bCostItems = b.original.cost || (desc ? Number.MIN_SAFE_INTEGER : Number.MAX_SAFE_INTEGER);
+                    
+                    return aCostItems - bCostItems;
+                },
                 Cell: ({ value }) => {
                     return <CostItemsCell costItems={value} />;
                 },
             },
             {
                 Header: t('Duration') + '\n' + t('Finishes'),
+                id: 'craftTime',
                 accessor: 'craftTime',
+                sortType: 'basic',
                 Cell: ({ value }) => {
                     return (
                         <CenterCell nowrap>
@@ -401,10 +411,10 @@ function CraftTable({ selectedStation, freeFuel, nameFilter, itemFilter, showAll
                         </CenterCell>
                     );
                 },
-                sortType: 'basic',
             },
             {
                 Header: t('Cost ₽'),
+                id: 'cost',
                 accessor: (d) => Number(d.cost),
                 Cell: (props) => {
                     if (props.row.original.cached) {
@@ -416,14 +426,15 @@ function CraftTable({ selectedStation, freeFuel, nameFilter, itemFilter, showAll
                     }
                     return <ValueCell value={props.value} valueCount={props.row.original.reward.count}/>;
                 },
-                id: 'cost',
             },
             ...(includeFlea
                 ? [
-                      {
-                          Header: t('Flea throughput/h'),
-                          accessor: 'fleaThroughput',
-                          Cell: (props) => {
+                    {
+                        Header: t('Flea throughput/h'),
+                        id: 'fleaThroughput',
+                        accessor: 'fleaThroughput',
+                        sortType: 'basic',
+                        Cell: (props) => {
                             if (props.row.original.cached) {
                                 return (
                                     <div className="center-content">
@@ -433,13 +444,14 @@ function CraftTable({ selectedStation, freeFuel, nameFilter, itemFilter, showAll
                             }
                             return <ValueCell value={props.value}/>;
                         },
-                          sortType: 'basic',
-                      },
+                    },
                   ]
                 : []),
             {
                 Header: t('Estimated profit'),
+                id: 'profit',
                 accessor: 'profit',
+                sortType: 'basic',
                 Cell: (props) => {
                     if (props.row.original.cached) {
                         return (
@@ -450,11 +462,12 @@ function CraftTable({ selectedStation, freeFuel, nameFilter, itemFilter, showAll
                     }
                     return <ValueCell value={props.value} valueDetails={props.row.original.profitParts} highlightProfit />;
                 },
-                sortType: 'basic',
             },
             {
                 Header: t('Estimated profit/h'),
+                id: 'profitPerHour',
                 accessor: 'profitPerHour',
+                sortType: 'basic',
                 Cell: (props) => {
                     if (props.row.original.cached) {
                         return (
@@ -465,7 +478,6 @@ function CraftTable({ selectedStation, freeFuel, nameFilter, itemFilter, showAll
                     }
                     return <ValueCell value={props.value} highlightProfit />;
                 },
-                sortType: 'basic',
             },
         ],
         [t, includeFlea],

--- a/src/components/data-table/index.js
+++ b/src/components/data-table/index.js
@@ -9,34 +9,43 @@ import formatPrice from '../../modules/format-price';
 import './index.css';
 
 function DataTable({
-    columns,
-    data,
-    autoResetSortBy,
     className,
-    maxItems,
+    columns,
+    sumColumns,
+    data,
     extraRow,
+    sortBy,
+    sortByDesc,
+    disableSortBy,
+    autoResetSortBy,
+    maxItems,
     nameFilter,
     autoScroll,
-    disableSortBy,
-    sumColumns,
 }) {
     // Use the state and functions returned from useTable to build your UI
     // const [data, setData] = React.useState([])
 
     const storageKey = columns
-        .map(({ Header }) => {
+        .map(({ Header, id }) => {
+            if (typeof id === 'string') {
+                return id;
+            }
+
             if (!Header || typeof Header !== 'string') {
                 return '';
             }
 
             return Header.toLowerCase()
-                .replace(/\s/, '-')
-                .replace(/[^a-z-]/g, '');
+                         .replace(/\s/, '-')
+                         .replace(/[^a-zа-я-]/g, '');
         })
         .join(',');
     const [initialSortBy, storageSetSortBy] = useStateWithLocalStorage(
         storageKey,
-        [],
+        [{
+            "id": sortBy,
+            "desc": sortByDesc
+        }],
     );
     const { ref, inView } = useInView({
         threshold: 0,

--- a/src/components/footer/index.js
+++ b/src/components/footer/index.js
@@ -141,7 +141,7 @@ function Footer() {
                     <a href="https://tarkovtracker.io/" target="_blank" rel="noopener noreferrer">TarkovTracker</a>
                 </p>
                 <p>
-                    <iframe className='discord' title="discord-iframe" src="https://discord.com/widget?id=956236955815907388&theme=dark" allowtransparency="true" frameBorder="0" sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"></iframe>
+                    <iframe className='discord' title="discord-iframe" src="https://discord.com/widget?id=956236955815907388&theme=dark" allowtransparency="true" frameborder="0" sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"></iframe>
                 </p>
             </div>
             <div className="copyright-wrapper">

--- a/src/components/footer/index.js
+++ b/src/components/footer/index.js
@@ -141,7 +141,7 @@ function Footer() {
                     <a href="https://tarkovtracker.io/" target="_blank" rel="noopener noreferrer">TarkovTracker</a>
                 </p>
                 <p>
-                    <iframe className='discord' title="discord-iframe" src="https://discord.com/widget?id=956236955815907388&theme=dark" allowtransparency="true" frameborder="0" sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"></iframe>
+                    <iframe className='discord' title="discord-iframe" src="https://discord.com/widget?id=956236955815907388&theme=dark" allowtransparency="true" frameBorder="0" sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"></iframe>
                 </p>
             </div>
             <div className="copyright-wrapper">

--- a/src/components/items-summary-table/index.js
+++ b/src/components/items-summary-table/index.js
@@ -84,28 +84,31 @@ function ItemsSummaryTable(props) {
         const useColumns = [
             {
                 Header: t('Name'),
+                id: 'name',
                 accessor: 'name',
                 Cell: ItemNameCell,
             },
             {
                 Header: t('Amount'),
+                id: 'quantity',
                 accessor: 'quantity',
                 Cell: CenterCell,
             },
             {
                 Header: t('Buy on Flea'),
+                id: 'fleaBuy',
                 accessor: (d) => Number(d.buyOnFleaPrice?.price),
                 Cell: FleaPriceCell,
-                id: 'fleaBuyPrice',
             },
             {
                 Header: t('Trader buy'),
+                id: 'traderBuy',
                 accessor: (d) => Number(d.instaProfit),
                 Cell: TraderPriceCell,
-                id: 'traderBuyCell',
             },
             {
                 Header: t('Cost'),
+                id: 'totalPrice',
                 accessor: 'totalPrice',
                 Cell: (props) => {
                     if (!props.value && props.row.original.cached) {
@@ -117,7 +120,6 @@ function ItemsSummaryTable(props) {
                     }
                     return <ValueCell value={props.value}/>;
                 },
-                id: 'totalPriceCell',
             },
         ];
 
@@ -138,10 +140,10 @@ function ItemsSummaryTable(props) {
     return (
         <DataTable
             className="data-table"
-            columns={displayColumns}
-            extraRow={extraRow}
             key="item-summary-table"
+            columns={displayColumns}
             data={data}
+            extraRow={extraRow}
             autoResetSortBy={false}
         />
     );

--- a/src/components/quest-table/index.js
+++ b/src/components/quest-table/index.js
@@ -299,6 +299,7 @@ function QuestTable({
         const useColumns = [
             {
                 Header: t('Task'),
+                id: 'name',
                 accessor: 'name',
                 Cell: (props) => {
                     const questData = props.row.original;
@@ -339,6 +340,7 @@ function QuestTable({
         if (requiredItems) {
             useColumns.push({
                 Header: t('Required items'),
+                id: 'requiredItems',
                 accessor: (quest) => {
                     return quest.requiredItems[0]?.item.name;
                 },
@@ -357,6 +359,7 @@ function QuestTable({
         if (rewardItems) {
             useColumns.push({
                 Header: t('Reward items'),
+                id: 'rewardItems',
                 accessor: (quest) => {
                     return quest.rewardItems[0]?.item.name;
                 },
@@ -375,6 +378,7 @@ function QuestTable({
         if (questRequirements) {
             useColumns.push({
                 Header: t('Required tasks'),
+                id: 'questRequirements',
                 accessor: (questData) => {
                     return quests.find(quest => quest.id === questData.taskRequirements[0]?.task.id)?.name;
                 },
@@ -423,13 +427,14 @@ function QuestTable({
                         );
                     });
                 },
-                position: rewardItems,
+                position: questRequirements,
             });
         }
 
         if (minimumLevel) {
             useColumns.push({
                 Header: t('Minimum level'),
+                id: 'minimumLevel',
                 accessor: 'minPlayerLevel',
                 Cell: (props) => {
                     if (!props.value) {
@@ -446,6 +451,7 @@ function QuestTable({
         if (minimumTraderLevel) {
             useColumns.push({
                 Header: t('Minimum trader level'),
+                id: 'minimumTraderLevel',
                 accessor: (questData) => {
                     return questData.traderLevelRequirements[0]?.level;
                 },
@@ -461,7 +467,11 @@ function QuestTable({
         if (reputationRewards) {
             useColumns.push({
                 Header: t('Reputation rewards'),
+                id: 'reputationRewards',
                 accessor: 'totalRepReward',
+                sortType: (a, b, columnId, desc) => {
+                    return a.original.totalRepReward - b.original.totalRepReward;
+                },
                 Cell: (props) => {
                     return (
                         <CenterCell value={props.row.original.finishRewards.traderStanding?.reduce((standings, current) => {
@@ -476,10 +486,7 @@ function QuestTable({
                         }, [])}/>
                     );
                 },
-                sortType: (a, b, columnId, desc) => {
-                    return a.original.totalRepReward - b.original.totalRepReward;
-                },
-                position: minimumTraderLevel,
+                position: reputationRewards,
             });
         }
 
@@ -525,21 +532,18 @@ function QuestTable({
     if (allQuestData.length <= 0) {
         extraRow = t('No quests found');
     } else if (allQuestData.length !== shownQuests.length) {
-        extraRow = (
-            <>
-                {t('Some tasks hidden by filter settings')}
-            </>
-        );
+        extraRow = t('Some tasks hidden by filter settings');
     }
 
     return (
         <DataTable
             className={`quest-table ${hideBorders ? 'no-borders' : ''}`}
-            columns={columns}
-            extraRow={extraRow}
             key="small-item-table"
+            columns={columns}
             data={shownQuests}
+            extraRow={extraRow}
             autoResetSortBy={false}
+            sortBy='progression'
         />
     );
 }

--- a/src/components/task-objective-table/index.js
+++ b/src/components/task-objective-table/index.js
@@ -131,16 +131,15 @@ function TaskObjectiveTable({ objectives }) {
                     </span>
                 ) : null,
         });
-        useColumns.push(
-            {
-                Header: t('Objective'),
-                accessor: 'description',
-                Cell: (props) => {
-                    //console.log(props.row.original)
-                    return props.value;
-                },
+        useColumns.push({
+            Header: t('Objective'),
+            id: 'description',
+            accessor: 'description',
+            Cell: (props) => {
+                //console.log(props.row.original)
+                return props.value;
             },
-        );
+        });
 
         const claimedPositions = [];
         for (let i = 1; i < useColumns.length; i++) {
@@ -187,10 +186,10 @@ function TaskObjectiveTable({ objectives }) {
     return (
         <DataTable
             className={`small-data-table`}
-            extraRow={extraRow}
-            columns={columns}
             key="small-item-table"
+            columns={columns}
             data={data}
+            extraRow={extraRow}
             autoResetSortBy={false}
         />
     );

--- a/src/pages/bosses/boss/index.js
+++ b/src/pages/bosses/boss/index.js
@@ -227,14 +227,14 @@ function BossPage(params) {
                             />
                         </h1>
                         {bossJsonData &&
-                            <span className="wiki-link-wrapper">
-                                <a href={bossJsonData.wikiLink} target="_blank" rel="noopener noreferrer">
-                                    {t('Wiki')}
-                                </a>
-                            </span>
-                        }
-                        {bossJsonData &&
-                            <p className='boss-details'>{bossJsonData.details}</p>
+                            <>
+                                <span className="wiki-link-wrapper">
+                                    <a href={bossJsonData.wikiLink} target="_blank" rel="noopener noreferrer">
+                                        {t('Wiki')}
+                                    </a>
+                                </span>
+                                <p className='boss-details'>{bossJsonData.details}</p>
+                            </>
                         }
                     </div>
                     <div className="icon-and-link-wrapper">
@@ -257,26 +257,26 @@ function BossPage(params) {
                 <PropertyList properties={bossProperties} />
 
                 {bossJsonData &&
-                    <h2 className='item-h2' key={'boss-loot-header'}>
-                        {t('Special Boss Loot')}
-                        <Icon
-                            path={mdiDiamondStone}
-                            size={1.5}
-                            className="icon-with-text"
-                        />
-                    </h2>
-                }
-                {bossJsonData &&
-                    <div className='loot-table-boss'>
-                        <SmallItemTable
-                            idFilter={bossJsonData.loot.reduce((prev, current) => {
-                                prev.push(current.id);
-                                return prev;
-                            }, [])}
-                            fleaValue
-                            traderValue
-                        />
-                    </div>
+                    <>
+                        <h2 className='item-h2' key={'boss-loot-header'}>
+                            {t('Special Boss Loot')}
+                            <Icon
+                                path={mdiDiamondStone}
+                                size={1.5}
+                                className="icon-with-text"
+                            />
+                        </h2>
+                        <div className='loot-table-boss'>
+                            <SmallItemTable
+                                idFilter={bossJsonData.loot.reduce((prev, current) => {
+                                    prev.push(current.id);
+                                    return prev;
+                                }, [])}
+                                fleaValue
+                                traderValue
+                            />
+                        </div>
+                    </>
                 }
 
                 <h2 className='item-h2' key={'boss-spawn-table-header'}>
@@ -310,7 +310,7 @@ function BossPage(params) {
                         className="icon-with-text"
                     />
                 </h2>
-                {escorts.length > 0 &&
+                {escorts.length > 0 ?
                     <DataTable
                         columns={columnsEscorts}
                         data={escorts}
@@ -320,9 +320,8 @@ function BossPage(params) {
                         sortByDesc={true}
                         autoResetSortBy={false}
                     />
-                }
-                {escorts.length === 0 &&
-                    <p>This boss does not have any escorts</p>
+                    :
+                    <p>{t('This boss does not have any escorts')}</p>
                 }
 
                 {/* cheeki breeki */}

--- a/src/pages/items/armors/index.js
+++ b/src/pages/items/armors/index.js
@@ -133,6 +133,7 @@ function Armors(props) {
                 weight
                 stats
                 showAllSources={showAllArmorSources}
+                sortBy='armorClass'
             />
             
             <div className="page-wrapper items-page-wrapper">

--- a/src/pages/items/backpacks/index.js
+++ b/src/pages/items/backpacks/index.js
@@ -57,6 +57,7 @@ function Backpacks() {
                 weight={3}
                 cheapestPrice={4}
                 pricePerSlot={5}
+                sortBy='pricePerSlot'
             />
             
             <div className="page-wrapper items-page-wrapper">

--- a/src/pages/items/containers/index.js
+++ b/src/pages/items/containers/index.js
@@ -42,6 +42,7 @@ function Containers(props) {
                 pricePerSlot
                 showContainedItems
                 showNetPPS={showNetPPS}
+                sortBy='pricePerSlot'
             />
 
             <div className="page-wrapper items-page-wrapper">

--- a/src/pages/items/glasses/index.js
+++ b/src/pages/items/glasses/index.js
@@ -47,6 +47,7 @@ function Glasses() {
                 blindnessProtection={2}
                 stats={3}
                 cheapestPrice={4}
+                sortBy='armorClass'
             />
 
             <div className="page-wrapper items-page-wrapper">

--- a/src/pages/items/headsets/index.js
+++ b/src/pages/items/headsets/index.js
@@ -74,6 +74,7 @@ function Headsets() {
                 traderValue={2}
                 fleaValue={3}
                 cheapestPrice={4}
+                sortBy={'traderPrice'}
             />
 
             <div className="page-wrapper items-page-wrapper">

--- a/src/pages/items/helmets/index.js
+++ b/src/pages/items/helmets/index.js
@@ -119,6 +119,7 @@ function Helmets() {
                 maxDurability={5}
                 stats={6}
                 cheapestPrice={7}
+                sortBy='armorClass'
             />
 
             <div className="page-wrapper items-page-wrapper">

--- a/src/pages/items/pistol-grips/index.js
+++ b/src/pages/items/pistol-grips/index.js
@@ -80,6 +80,8 @@ function PistolGrips() {
                 ergonomics={1}
                 cheapestPrice={2}
                 ergoCost={2}
+                sortBy='ergonomics'
+                sortByDesc={true}
             />
 
             <div className="page-wrapper items-page-wrapper">

--- a/src/pages/items/provisions/index.js
+++ b/src/pages/items/provisions/index.js
@@ -92,6 +92,7 @@ function Provisions() {
                 hydrationCost={6}
                 energyCost={7}
                 provisionValue={8}
+                sortBy='provisionValue'
             />
 
             <div className="page-wrapper items-page-wrapper">

--- a/src/pages/traders/trader/index.js
+++ b/src/pages/traders/trader/index.js
@@ -176,6 +176,8 @@ function Trader() {
                     fleaPrice={selectedTable === 'spending' ? 2 : 1}
                     traderPrice={selectedTable === 'spending' ? false : 2}
                     traderBuyback={selectedTable === 'spending' ? 3 : false}
+                    sortBy={selectedTable === 'spending' ? 'traderBuyback' : null}
+                    sortByDesc={true}
                 />
             )}
             {selectedTable === 'tasks' && (


### PR DESCRIPTION
# Default table sort and fixes

- Sorting by pricePerSlot, if they have no value the items will be sorted to last position;
- Sorting by armor class, if they are equal we'll look to effectiveDurability, blindnessProtection and maxDurability;
- Sorting by ergonomics, if they are equal we'll look to ergoCost;
- Refactoring some sort functions
- Added default sortBy on spending on trader page when selected spending table
- Added default sortBy to some items pages
- Refactoring
- Added column ids in quest table;
- Fixed some typos
- Barters are now sort by default by instaProfit;
- When sorting by savings items with unknown value will be always last
- In crafts sorting cost items column will sort using total craft cost;
- Added column ids to different tables
- Added ability to set initial sort on a DataTable column;
- Storage key is now generated from column ids, if present
