### PR TITLE
Removed unneeded image borders

### DIFF
--- a/src/components/data-table/index.css
+++ b/src/components/data-table/index.css
@@ -63,8 +63,6 @@ td.data-cell:last-child {
 .data-table .table-image {
     max-width: 64px;
     max-height: 64px;
-    outline: 1px solid #4a5154;
-    outline-offset: -1px;
 }
 
 .data-table tr td {

--- a/src/components/item-image/index.css
+++ b/src/components/item-image/index.css
@@ -1,7 +1,7 @@
 .item-image-text {
     position: absolute;
-    top: 2px;
-    right: 5px;
+    top: 4px;
+    right: 7px;
     cursor: default;
     color: #a4aeb4;
     font-weight: bold;

--- a/src/components/item-image/index.js
+++ b/src/components/item-image/index.js
@@ -32,7 +32,8 @@ function ItemImage({ item }) {
             </svg>')`,
         //backgroundSize: '2px 2px',
         position: 'relative',
-        border: '2px solid #495154',
+        outline: '2px solid #495154',
+        outlineOffset: '-2px',
     };
 
     if (item.types?.includes('loading')) {

--- a/src/components/items-for-hideout/index.css
+++ b/src/components/items-for-hideout/index.css
@@ -46,8 +46,6 @@
 }
 
 .hideout-item-image-wrapper img {
-    outline: 1px solid #4a5154;
-    outline-offset: -1px;
     width: 32px;
     height: 32px;
 }

--- a/src/components/quest-items-cell/index.css
+++ b/src/components/quest-items-cell/index.css
@@ -9,8 +9,6 @@
 }
 
 .quest-image-wrapper img {
-    outline: 1px solid #4a5154;
-    outline-offset: -1px;
     width: 32px;
     height: 32px;
 }

--- a/src/components/quest-table/index.css
+++ b/src/components/quest-table/index.css
@@ -20,8 +20,6 @@
 }
 
 .quest-image-wrapper img {
-    outline: 1px solid #4a5154;
-    outline-offset: -1px;
     width: 48px;
     height: 48px;
 }

--- a/src/components/small-item-table/index.css
+++ b/src/components/small-item-table/index.css
@@ -24,11 +24,6 @@
     height: 32px;
 }
 
-.small-data-table .table-image {
-    outline: 1px solid #4a5154;
-    outline-offset: -1px;
-}
-
 .small-data-table .trader-icon {
     max-width: 40px;
 }


### PR DESCRIPTION
Now that all item icons have borders built in, we don't need the styling to manually add the borders.