### PR TITLE
Fix gauge ammo

### DIFF
--- a/scripts/build-sitemap.js
+++ b/scripts/build-sitemap.js
@@ -4,7 +4,7 @@ const path = require('path');
 const got = require('got');
 
 const maps = require('../src/data/maps.json');
-const { caliberMap } = require('../src/modules/format-ammo');
+const { caliberArrayWithSplit } = require('../src/modules/format-ammo');
 
 const standardPaths = [
     '',
@@ -94,7 +94,7 @@ const addPath = (sitemap, url) => {
             sitemap = addPath(sitemap, `/boss/${bossName}`);
         }
 
-        let ammoTypes = Object.values(caliberMap).sort();
+        const ammoTypes = caliberArrayWithSplit();
 
         for (const ammoType of ammoTypes) {
             sitemap = addPath(sitemap, `/ammo/${ammoType.replace(/ /g, '%20')}`);

--- a/scripts/cache-api-data.mjs
+++ b/scripts/cache-api-data.mjs
@@ -183,15 +183,23 @@ try {
                 });
             }
 
-            /*const groupedItemsDic = items.reduce((acc, item) => {
-                if (!acc[item.bsgCategoryId]) {
-                    acc[item.bsgCategoryId] = []
+            const groupedAmmoDic = items.reduce((acc, item) => {
+                if (!item.categories.some(cat => cat.id === '5485a8684bdc2da71d8b4567'))
+                    return acc;
+                
+                if (filteredItems.some(i => i.id === item.id))
+                    return acc;
+                
+                const caliberType = item.properties.caliber + item.properties.ammoType;
+                if (!acc[caliberType]) {
+                    acc[caliberType] = []
                 }
-                acc[item.bsgCategoryId].push(item);
+                acc[caliberType].push(item);
                 return acc;
             }, {});
-            const filteredItemsDic = Object.values(groupedItemsDic).map(group => group.slice(0, 7));
-            const filteredItems = [].concat(...filteredItemsDic);*/
+            const filteredAmmoDic = Object.values(groupedAmmoDic).map(group => group.sort((a, b) => b.properties.damage - a.properties.damage).slice(0, 2));
+            const filteredAmmo = [].concat(...filteredAmmoDic);
+            filteredItems.push(...filteredAmmo);
 
             for (const item of filteredItems) {
                 item.lastLowPrice = 0;

--- a/src/components/menu/MenuItem.jsx
+++ b/src/components/menu/MenuItem.jsx
@@ -4,12 +4,10 @@ import { Link, useNavigate, useMatch } from 'react-router-dom';
 function MenuItem(props) {
     const routeMatch = useMatch('/ammo/:currentAmmo');
     let currentAmmo = '';
+    let ammoTypes = [];
     if (routeMatch) {
         currentAmmo = routeMatch.params.currentAmmo;
-    }
-    let ammoTypes = currentAmmo?.split(',');
-    if (!ammoTypes) {
-        ammoTypes = [];
+        ammoTypes = currentAmmo.split(',');
     }
 
     const [checked, setChecked] = useState(
@@ -33,6 +31,9 @@ function MenuItem(props) {
     useEffect(() => {
         if (currentAmmo) {
             setChecked(currentAmmo.split(',').includes(props.displayText));
+        }
+        else {
+            setChecked(false);
         }
     }, [currentAmmo, props.displayText]);
 

--- a/src/components/menu/index.js
+++ b/src/components/menu/index.js
@@ -14,7 +14,7 @@ import UkraineButton from '../ukraine-button';
 //import LoadingSmall from '../loading-small';
 //import { BossListNav } from '../boss-list';
 
-import { caliberMap } from '../../modules/format-ammo';
+import { caliberArrayWithSplit } from '../../modules/format-ammo';
 import itemsData from '../../data/category-pages.json';
 import { useBossDetails } from '../../features/bosses/queries';
 
@@ -31,10 +31,9 @@ import './index.css';
 // }
 // End of banner alert toggle
 
-const ammoTypes = Object.values(caliberMap).sort();
+const ammoTypes = caliberArrayWithSplit();
 
 const getAmmoMenu = (setIsOpen) => {
-    const shotIndex = ammoTypes.findIndex(ammoType => ammoType === '12 Gauge Shot');
     const ammoMenu = ammoTypes.map((ammoType) => (
         <MenuItem
             checkbox
@@ -42,16 +41,6 @@ const getAmmoMenu = (setIsOpen) => {
             key={`menu-item-${ammoType}`}
             prefix="/ammo"
             to={`/ammo/${ammoType}`}
-            //onClick={setIsOpen.bind(this, false)}
-        />
-    ));
-    ammoMenu.splice(shotIndex+1, 0, (
-        <MenuItem
-            checkbox
-            displayText="12 Gauge Slug"
-            key="menu-item-12 Gauge Slug"
-            prefix="/ammo"
-            to="/ammo/12 Gauge Slug"
             //onClick={setIsOpen.bind(this, false)}
         />
     ));

--- a/src/components/small-item-table/index.js
+++ b/src/components/small-item-table/index.js
@@ -696,16 +696,22 @@ function SmallItemTable(props) {
             returnData = returnData.filter(item => {
                 if (caliberFilter.length < 1) 
                     return true;
-                let caliber = formatCaliber(item.properties.caliber);
+                let caliber = formatCaliber(item.properties.caliber, item.properties.ammoType);
                 if (!caliber) {
                     return false;
                 }
-                if (caliber === '12 Gauge Shot' && item.properties.ammoType === 'bullet') {
-                    caliber = caliber.replace('Shot', 'Slug');
-                }
                 return caliberFilter.includes(caliber);
             }).sort((a, b) => {
-                return formatCaliber(a.properties.caliber).localeCompare(formatCaliber(b.properties.caliber));
+                const caliberA = formatCaliber(a.properties.caliber, a.properties.ammoType);
+                const caliberB = formatCaliber(b.properties.caliber, b.properties.ammoType);
+                if (caliberA === caliberB) {
+                    const damageA = a.properties.damage;
+                    const damageB = b.properties.damage;
+                    if (damageA == damageB)
+                        return a.name.localeCompare(b.name);
+                    return damageB - damageA;
+                }
+                return caliberA.localeCompare(caliberB);
             });
         }
 
@@ -1292,10 +1298,7 @@ function SmallItemTable(props) {
                     let caliber = item.properties.caliber;
                     if (!caliber) 
                         return '-';
-                    caliber = formatCaliber(caliber);
-                    if (caliber === '12 Gauge Shot' && item.properties.ammoType === 'bullet') {
-                        caliber = caliber.replace('Shot', 'Slug');
-                    }
+                    caliber = formatCaliber(caliber, item.properties.ammoType);
                     return caliber;
                 },
                 Cell: CenterCell,

--- a/src/components/small-item-table/index.js
+++ b/src/components/small-item-table/index.js
@@ -707,7 +707,7 @@ function SmallItemTable(props) {
                 if (caliberA === caliberB) {
                     const damageA = a.properties.damage;
                     const damageB = b.properties.damage;
-                    if (damageA == damageB)
+                    if (damageA === damageB)
                         return a.name.localeCompare(b.name);
                     return damageB - damageA;
                 }

--- a/src/modules/format-ammo.js
+++ b/src/modules/format-ammo.js
@@ -18,15 +18,38 @@ const caliberMap = {
     Caliber9x21: '9x21 mm',
     Caliber9x39: '9x39 mm',
     Caliber20g: '20 Gauge',
-    Caliber12g: '12 Gauge Shot',
+    Caliber12g: '12 Gauge',
     Caliber9x33R: '.357 Magnum'
 };
 
-const formatCaliber = (caliber) => {
-    return caliberMap[caliber] || caliber.replace('Caliber', '');
+function caliberArrayWithSplit() {
+    const ammoTypes = Object.values(caliberMap).sort();
+
+    let gaugeIndex = ammoTypes.findIndex(ammoType => ammoType === '12 Gauge');
+    let gaugeShot = `${ammoTypes[gaugeIndex]} Shot`;
+    let slugShot = `${ammoTypes[gaugeIndex]} Slug`;
+    ammoTypes.splice(gaugeIndex, 1, gaugeShot, slugShot);
+
+    gaugeIndex = ammoTypes.findIndex(ammoType => ammoType === '20 Gauge');
+    gaugeShot = `${ammoTypes[gaugeIndex]} Shot`;
+    slugShot = `${ammoTypes[gaugeIndex]} Slug`;
+    ammoTypes.splice(gaugeIndex, 1, gaugeShot, slugShot);
+
+    return ammoTypes;
+}
+
+const formatCaliber = (caliber, type) => {
+    let formattedCaliber = caliberMap[caliber] || caliber.replace('Caliber', '');
+
+    if (formattedCaliber === '12 Gauge' || formattedCaliber === '20 Gauge') {
+        if (type)
+            formattedCaliber += (type === 'bullet' ? ' Slug' : ' Shot');
+    }
+
+    return formattedCaliber;
 };
 
 module.exports = {
-    caliberMap: caliberMap,
+    caliberArrayWithSplit: caliberArrayWithSplit,
     formatCaliber: formatCaliber
 };

--- a/src/pages/ammo/index.js
+++ b/src/pages/ammo/index.js
@@ -48,7 +48,7 @@ function Ammo() {
     }
     const navigate = useNavigate();
 
-    // if the name we got from the params is 12/20 Gauge, redirect to a nice looking path
+    // if the name we got from the params is 12/20 Gauge, redirect to a nice looking path 
     useEffect(() => {
         if (redirect) {
             navigate(`/ammo/${currentAmmoList.join(',')}`);

--- a/src/pages/ammo/index.js
+++ b/src/pages/ammo/index.js
@@ -35,19 +35,33 @@ const skipTypes = [
 
 function Ammo() {
     const { currentAmmo } = useParams();
-    let currentAmmoList = [];
+    let currentAmmoList = useMemo(() => [], []);
+    let redirect = false;
     if (currentAmmo) {
-        currentAmmoList = currentAmmo.split(',');
+        if (currentAmmo === '12 Gauge' || currentAmmo === '20 Gauge') {
+            currentAmmoList = [`${currentAmmo} Shot`, `${currentAmmo} Slug`];
+            redirect = true;
+        }
+        else {
+            currentAmmoList = currentAmmo.split(',');
+        }
     }
     const navigate = useNavigate();
-    const [selectedLegendName, setSelectedLegendName] =
-        useState(currentAmmoList);
+
+    // if the name we got from the params is 12/20 Gauge, redirect to a nice looking path
+    useEffect(() => {
+        if (redirect) {
+            navigate(`/ammo/${currentAmmoList.join(',')}`);
+        }
+    }, [redirect, currentAmmoList, navigate]);
+    
+    const [selectedLegendName, setSelectedLegendName] = useState(currentAmmoList);
     const [showAllTraderPrices, setShowAllTraderPrices] = useState(false);
     const [useAllProjectileDamage, setUseAllProjectileDamage] = useState(false);
     const shiftPress = useKeyPress('Shift');
-    const { t } = useTranslation();
     const { data: items } = useItemsQuery();
     const settings = useSelector((state) => state.settings);
+    const { t } = useTranslation();
 
     useEffect(() => {
         if (currentAmmo === []) {
@@ -66,18 +80,17 @@ function Ammo() {
     let typeCache = [];
     const legendData = [];
     const formattedData = items.filter(item => {
-        return item.categories.some(cat => cat.id === '5485a8684bdc2da71d8b4567') &&
-            !skipTypes.includes(item.properties.caliber)
+        return item.categories.some(cat => cat.id === '5485a8684bdc2da71d8b4567') && !skipTypes.includes(item.properties.caliber)
     }).map(ammoData => {
         const returnData = {
             ...ammoData,
             ...ammoData.properties,
-            type: formatCaliber(ammoData.properties.caliber) || ammoData.properties.caliber.replace('Caliber', ''),
+            type: formatCaliber(ammoData.properties.caliber, ammoData.properties.ammoType),
             displayDamage: useAllProjectileDamage ? ammoData.properties.projectileCount * ammoData.properties.damage : ammoData.properties.damage,
             displayPenetration: ammoData.properties.penetrationPower,
         };
-        if (!returnData.type) console.log(returnData);
-        if (returnData.type === '12 Gauge Shot' && returnData.ammoType === 'bullet') returnData.type = returnData.type.replace('Shot', 'Slug');
+        if (!returnData.type) 
+            console.log(returnData);
 
         if (returnData.displayDamage > MAX_DAMAGE) {
             returnData.name = `${ammoData.name} (${returnData.displayDamage})`;

--- a/src/pages/control/index.js
+++ b/src/pages/control/index.js
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 
 import SEO from '../../components/SEO';
 
-import { caliberMap } from '../../modules/format-ammo';
+import { caliberArrayWithSplit } from '../../modules/format-ammo';
 
 import { useItemsQuery } from '../../features/items/queries.js';
 import { useMapImages } from '../../features/maps/queries.js';
@@ -14,7 +14,7 @@ import Connect from './Connect.jsx';
 
 import './index.css';
 
-const ammoTypes = Object.values(caliberMap).sort();
+const ammoTypes = caliberArrayWithSplit();
 
 const selectFilterStyle = {
     menu: (provided) => ({


### PR DESCRIPTION
# Fix to 12/20 gauge split

- Adding to cached data at least 2 ammo per caliber/type;
- Ammo page uses new split logic;
- Fixed seeing Shot in caliber property of a Slug ammo on item page;
- When coming from 12/20 gauge ammo item page expand gauge to select both slug and shot;
- Ammo with the same caliber sorted by damage, and with same damage by name;
- Menu, control and sitemap uses already split ammo array;
- Now gauge ammo is split by format ammo in shot and slug;
- Fix menu not in sync with filter.
