### PR TITLE
Use flea when ignoring settings

### DIFF
--- a/src/components/price-graph/index.js
+++ b/src/components/price-graph/index.js
@@ -14,7 +14,14 @@ import formatPrice from '../../modules/format-price';
 
 import './index.css';
 
-function PriceGraph({ itemId, itemChange24 }) {
+function PriceGraph({ item, itemId, itemChange24 }) {
+    if (item && !itemId) {
+        itemId = item.id;
+        if (item.properties?.baseItem?.properties?.defaultPreset?.id === item.id) {
+            itemId = item.properties.baseItem.id;
+        }
+    }
+
     const dataQuery = JSON.stringify({
         query: `{
             historicalItemPrices(id:"${itemId}"){

--- a/src/modules/format-cost-items.js
+++ b/src/modules/format-cost-items.js
@@ -106,7 +106,7 @@ function getCheapestBarter(item, barters, settings, allowAllSources) {
 }
 
 function getCheapestItemPriceWithBarters(item, barters, settings, allowAllSources) {
-    const useFlea = settings.useFlea;
+    const useFlea = settings.useFlea || allowAllSources;
     const bestPrice = getCheapestItemPrice(item, settings, allowAllSources);
 
     const itemBarters = getItemBarters(item, barters, settings, allowAllSources);

--- a/src/pages/item/index.js
+++ b/src/pages/item/index.js
@@ -781,7 +781,7 @@ The max profitable price is impacted by the intel center and hideout management 
                     <div>
                         <h2>{t('Flea price last 7 days')}</h2>
                         <PriceGraph
-                            itemId={currentItemData.id}
+                            item={currentItemData}
                             itemChange24={currentItemData.changeLast48h}
                         />
                         <br />


### PR DESCRIPTION
Previously, when the ignore settings option was turned on, finding the cheapest price would still not use the flea market:
![image](https://user-images.githubusercontent.com/35779878/218527854-0857edfe-9e1b-4431-b57c-c68d38004c11.png)

But now, it does use the flea market:
![image](https://user-images.githubusercontent.com/35779878/218527978-60d85f58-4e3b-4444-a559-d0ed8248c669.png)

Also adds the price graph to the default preset pages since they share prices with the base items.