### PR TITLE
Better sorting of crafts

### DIFF
--- a/src/components/crafts-table/index.js
+++ b/src/components/crafts-table/index.js
@@ -445,13 +445,16 @@ function CraftTable({ selectedStation, freeFuel, nameFilter, itemFilter, showAll
                 };
                 if (sortState.length > 0) {
                     sortField = sortState[0].id;
-                    desc = sortState[0].desc;
+                    //desc = sortState[0].desc;
                 }
                 if (columnSwap[sortField]) {
                     sortField = columnSwap[sortField];
                 }
+                if (sortField === 'craftTime' || sortField === 'cost') {
+                    desc = false;
+                }
                 if (!desc) {
-                    //return itemA[sortField] - itemB[sortField];
+                    return itemA[sortField] - itemB[sortField];
                 }
                 return itemB[sortField] - itemA[sortField];
             })

--- a/src/components/crafts-table/index.js
+++ b/src/components/crafts-table/index.js
@@ -463,7 +463,9 @@ function CraftTable({ selectedStation, freeFuel, nameFilter, itemFilter, showAll
                 if (selectedStation !== 'top') {
                     return true;
                 }
-
+                if (!craft.cost && !craft.profit && !craft.profitPerHour) {
+                    return false;
+                }
                 if (!addedStations[craft.stationId]) {
                     addedStations[craft.stationId] = 0;
                 }

--- a/src/components/crafts-table/index.js
+++ b/src/components/crafts-table/index.js
@@ -1,4 +1,4 @@
-import { useMemo, useEffect, useRef } from 'react';
+import { useMemo, useEffect, useRef, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
@@ -33,7 +33,7 @@ import { useQuestsQuery } from '../../features/quests/queries';
 
 import FleaMarketLoadingIcon from '../FleaMarketLoadingIcon';
 
-function CraftTable({ selectedStation, freeFuel, nameFilter, itemFilter, showAll, averagePrices }) {
+function CraftTable({ selectedStation, freeFuel, nameFilter, itemFilter, showAll, averagePrices, excludeBarterIngredients }) {
     const dispatch = useDispatch();
     const { t } = useTranslation();
     const settings = useSelector((state) => state.settings);
@@ -45,6 +45,8 @@ function CraftTable({ selectedStation, freeFuel, nameFilter, itemFilter, showAll
     // const [skippedByLevel, setSkippedByLevel] = useState(false);
     const skippedByLevelRef = useRef();
     const feeReduction = stations['intelligence-center'] === 3 ? 0.7 - (0.003 * skills['hideout-management']) : 1;
+
+    const [sortState, setSortState] = useState([{id: 'profit', desc: true}]);
 
     const items = useSelector(selectAllItems);
     const itemsStatus = useSelector((state) => {
@@ -105,8 +107,9 @@ function CraftTable({ selectedStation, freeFuel, nameFilter, itemFilter, showAll
                     };
                 }).filter(Boolean),
             };
-        }).filter(barter => barter.rewardItems.length > 0 && barter.requiredItems.length > 0);
-    }, [barterSelector, items]);
+        }).filter(() => !excludeBarterIngredients)
+        .filter(barter => barter.rewardItems.length > 0 && barter.requiredItems.length > 0);
+    }, [barterSelector, items, excludeBarterIngredients]);
 
     const crafts = useMemo(() => {
         return craftSelector.map(c => {
@@ -183,7 +186,7 @@ function CraftTable({ selectedStation, freeFuel, nameFilter, itemFilter, showAll
     }, [craftsStatus, dispatch]);
 
     const data = useMemo(() => {
-        let addedStations = [];
+        let addedStations = {};
 
         skippedByLevelRef.current = false;
         return crafts
@@ -349,6 +352,7 @@ function CraftTable({ selectedStation, freeFuel, nameFilter, itemFilter, showAll
                         isFIR: true,
                     },
                     cached: craftRow.cached || craftRow.rewardItems[0].item.cached,
+                    stationId: craftRow.station.id,
                 };
 
                 let fleaFeeSingle = 0;
@@ -433,7 +437,23 @@ function CraftTable({ selectedStation, freeFuel, nameFilter, itemFilter, showAll
             })
             .filter(Boolean)
             .sort((itemA, itemB) => {
-                return itemB.profit - itemA.profit;
+                let sortField = 'profit';
+                let desc = true;
+                const columnSwap = {
+                    costItems: 'cost',
+                    reward: 'profit',
+                };
+                if (sortState.length > 0) {
+                    sortField = sortState[0].id;
+                    desc = sortState[0].desc;
+                }
+                if (columnSwap[sortField]) {
+                    sortField = columnSwap[sortField];
+                }
+                if (!desc) {
+                    //return itemA[sortField] - itemB[sortField];
+                }
+                return itemB[sortField] - itemA[sortField];
             })
             .filter((craft) => {
                 // This is done after profit sorting
@@ -441,11 +461,14 @@ function CraftTable({ selectedStation, freeFuel, nameFilter, itemFilter, showAll
                     return true;
                 }
 
-                if (addedStations.includes(craft.reward.source)) {
+                if (!addedStations[craft.stationId]) {
+                    addedStations[craft.stationId] = 0;
+                }
+                if (addedStations[craft.stationId] >= 2) {
                     return false;
                 }
 
-                addedStations.push(craft.reward.source);
+                addedStations[craft.stationId]++;
 
                 return true;
             });
@@ -466,7 +489,8 @@ function CraftTable({ selectedStation, freeFuel, nameFilter, itemFilter, showAll
         showAll,
         averagePrices,
         meta,
-        settings
+        settings,
+        sortState,
     ]);
 
     const columns = useMemo(
@@ -621,6 +645,9 @@ function CraftTable({ selectedStation, freeFuel, nameFilter, itemFilter, showAll
             sortBy={'profit'}
             sortByDesc={true}
             autoResetSortBy={false}
+            onSort={newSortState => {
+                setSortState(newSortState);
+            }}
         />
     );
 }

--- a/src/components/data-table/index.js
+++ b/src/components/data-table/index.js
@@ -21,6 +21,7 @@ function DataTable({
     maxItems,
     nameFilter,
     autoScroll,
+    onSort,
 }) {
     // Use the state and functions returned from useTable to build your UI
     // const [data, setData] = React.useState([])
@@ -78,7 +79,10 @@ function DataTable({
 
     useEffect(() => {
         storageSetSortBy(sortByState);
-    }, [storageSetSortBy, sortByState]);
+        if (typeof onSort === 'function') {
+            onSort(sortByState);
+        }
+    }, [storageSetSortBy, sortByState, onSort]);
 
     useEffect(() => {
         if (nameFilter && (sortByState[0]?.id === 'name' || sortByState[0]?.id === undefined)) {

--- a/src/pages/barters/index.js
+++ b/src/pages/barters/index.js
@@ -62,7 +62,7 @@ function Barters() {
     const { t } = useTranslation();
 
     const traders = useMemo(() => {
-        return allTraders.filter(trader => trader.normalizedName !== 'fence');
+        return allTraders.filter(trader => trader.normalizedName !== 'fence' && trader.normalizedName !== 'lightkeeper');
     }, [allTraders]);
 
     return [

--- a/src/pages/crafts/index.js
+++ b/src/pages/crafts/index.js
@@ -32,7 +32,7 @@ function Crafts() {
     const [freeFuel, setFreeFuel] = useState(false);
     const [averagePrices, setAveragePrices] = useStateWithLocalStorage(
         'averageCraftingPrices',
-        true,
+        false,
     );
     const [selectedStation, setSelectedStation] = useStateWithLocalStorage(
         'selectedStation',

--- a/src/pages/crafts/index.js
+++ b/src/pages/crafts/index.js
@@ -34,6 +34,10 @@ function Crafts() {
         'averageCraftingPrices',
         false,
     );
+    const [excludeBarterIngredients, setExcludeBarterIngredients] = useStateWithLocalStorage(
+        'excludeBarterIngredients',
+        false,
+    );
     const [selectedStation, setSelectedStation] = useStateWithLocalStorage(
         'selectedStation',
         'top',
@@ -112,6 +116,16 @@ function Crafts() {
                             </>
                         }
                     />
+                    <ToggleFilter
+                        checked={excludeBarterIngredients}
+                        label={t('Exclude barters')}
+                        onChange={(e) => setExcludeBarterIngredients(!excludeBarterIngredients)}
+                        tooltipContent={
+                            <>
+                                {t('Exclude barter trades as item sources')}
+                            </>
+                        }
+                    />
                     <ButtonGroupFilter>
                         {stations.map((station) => {
                             return (
@@ -173,6 +187,7 @@ function Crafts() {
                 showAll={showAll}
                 averagePrices={averagePrices}
                 selectedStation={selectedStation}
+                excludeBarterIngredients={excludeBarterIngredients}
                 key="crafts-page-crafts-table"
             />
 


### PR DESCRIPTION
Previously, the "best" crafts would display the best crafts by net profit _per station level_. That doesn't make a lot of sense, so now it displays the two best crafts per station.

Also improved it so that  sorting the table by profit/hour will show the best crafts by profit/hour. The table can also be sorted by the other columns to see the best crafts according to other measures.

https://preview.tarkov-dev.pages.dev/