### PR TITLE
Nice message for no-flea cheapest price

### DIFF
--- a/src/components/small-item-table/index.js
+++ b/src/components/small-item-table/index.js
@@ -1698,8 +1698,21 @@ function SmallItemTable(props) {
                                     {t('This item can\'t be sold on the Flea Market')}
                                 </div>
                             ));
-                        } 
-                        else {
+                        } else if (!settings.hasFlea) {
+                            priceContent.push((
+                                <Icon
+                                    path={mdiCloseOctagon}
+                                    size={1}
+                                    className="icon-with-text"
+                                    key="no-prices-icon"
+                                />
+                            ));
+                            tipContent.push((
+                                <div key={'no-flea-tooltip'}>
+                                    {t('Flea Market not available')}
+                                </div>
+                            ));
+                        } else {
                             let tipText = t('Not scanned on the Flea Market');
                             let icon = mdiHelpRhombus;
                             if (props.row.original.cached) {


### PR DESCRIPTION
Previously, cheapest price column would show an inaccurate tip for users who don't have the flea:
![image](https://user-images.githubusercontent.com/35779878/228254460-183f2103-2709-4a21-9458-ee91f21ef5ad.png)

This shows a more accurate message:
![image](https://user-images.githubusercontent.com/35779878/228254627-1c407a66-5ae0-46db-a2cf-efb1dce1223a.png)
