### PR TITLE
Cheapeast price used craft for fallback

### DIFF
--- a/src/components/barter-tooltip/index.css
+++ b/src/components/barter-tooltip/index.css
@@ -40,3 +40,12 @@
     width: 14px;
     margin-right: 3px;
 }
+
+.barter-required-item-image {
+    margin-right: 10px;
+}
+
+.barter-required-item-image img {
+    width: 48px;
+    height: 48px;
+}

--- a/src/components/barter-tooltip/index.js
+++ b/src/components/barter-tooltip/index.js
@@ -3,7 +3,6 @@ import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 
-import RewardImage from '../reward-image';
 import ItemImage from '../item-image';
 import formatPrice from '../../modules/format-price';
 import { isAnyDogtag, getDogTagCost } from '../../modules/dogtags';

--- a/src/components/barter-tooltip/index.js
+++ b/src/components/barter-tooltip/index.js
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 
 import RewardImage from '../reward-image';
+import ItemImage from '../item-image';
 import formatPrice from '../../modules/format-price';
 import { isAnyDogtag, getDogTagCost } from '../../modules/dogtags';
 import { getCheapestItemPrice } from '../../modules/format-cost-items';
@@ -40,7 +41,7 @@ function BarterTooltip({ barter, showTitle = true, title, allowAllSources }) {
     if (!barter) {
         return t('No barters found for this item');
     }
-    if (!barter.trader) {
+    if (!barter.trader && !barter.station) {
         // Should never happen
         return "Missing trader for this barter";
     }
@@ -50,9 +51,15 @@ function BarterTooltip({ barter, showTitle = true, title, allowAllSources }) {
     }
 
     let titleElement = '';
-    let trader = `${barter.trader.name} ${t('LL{{level}}', { level: barter.level })}`;
+    let trader = barter.trader ? 
+        `${barter.trader.name} ${t('LL{{level}}', { level: barter.level })}` :
+        `${barter.station.name} ${barter.level}`;
 
     if (showTitle) {
+        const tipTitle = barter.trader ?
+            t('Barter at {{trader}}', { trader: trader }) : 
+            t('Craft at {{station}}', {station: trader});
+            
         titleElement = (
             <h3>
                 <Icon
@@ -60,7 +67,7 @@ function BarterTooltip({ barter, showTitle = true, title, allowAllSources }) {
                     size={1}
                     className="icon-with-text"
                 />
-                {t('Barter at {{trader}}', { trader: trader })}
+                {tipTitle}
             </h3>
         );
         if (title) {
@@ -89,10 +96,16 @@ function BarterTooltip({ barter, showTitle = true, title, allowAllSources }) {
                         className="barter-tooltip-item-wrapper"
                         key={`reward-tooltip-item-${requiredItem.item.id}`}
                     >
-                        <RewardImage
-                            count={requiredItem.count}
-                            iconLink={requiredItem.item.iconLink}
-                        />
+                        <div className="barter-required-item-image">
+                            <ItemImage
+                                item={requiredItem.item}
+                                attributes={requiredItem.attributes}
+                                count={requiredItem.count}
+                                imageField="iconLink"
+                                nonFunctionalOverlay={false}
+                                linkToItem={true}
+                            />
+                        </div>
                         <div className="barter-tooltip-details-wrapper">
                             <div>
                                 <Link

--- a/src/components/barter-tooltip/index.js
+++ b/src/components/barter-tooltip/index.js
@@ -7,6 +7,7 @@ import ItemImage from '../item-image';
 import formatPrice from '../../modules/format-price';
 import { isAnyDogtag, getDogTagCost } from '../../modules/dogtags';
 import { getCheapestItemPrice } from '../../modules/format-cost-items';
+import { getDurationDisplay } from '../../modules/format-duration';
 
 import Icon from '@mdi/react';
 import {
@@ -132,6 +133,12 @@ function BarterTooltip({ barter, showTitle = true, title, allowAllSources }) {
                     </div>
                 );
             })}
+            {barter.station && <div
+                className="barter-tooltip-item-wrapper"
+                key={`reward-tooltip-details`}
+            >
+                {t('Crafts {{count}} in {{duration}}', {count: barter.rewardItems[0].count, duration: getDurationDisplay(barter.duration * 1000)})}
+            </div>}
         </div>
     );
 }

--- a/src/components/small-item-table/index.js
+++ b/src/components/small-item-table/index.js
@@ -1742,7 +1742,6 @@ function SmallItemTable(props) {
                                 />
                             );
                         } else if (cheapestObtainInfo.craft) {
-                            console.log(props.row.original)
                             const craft = cheapestObtainInfo.craft;
                             priceSource = `${craft.station.name} ${craft.level}`;
                             let barterTipTitle = '';

--- a/src/pages/quest/index.js
+++ b/src/pages/quest/index.js
@@ -20,6 +20,13 @@ import { useMapsQuery, useMapImages } from '../../features/maps/queries';
 
 import './index.css';
 
+const intelCashMultiplier = {
+    0: 1,
+    1: 1.05,
+    2: 1.1,
+    3: 1.1,
+};
+
 function Quest() {
     const settings = useSelector((state) => state.settings);
     const { taskIdentifier } = useParams();
@@ -911,6 +918,11 @@ function Quest() {
                                 const item = items.find((it) => it.id === rewardItem.item.id);
                                 if (!item)
                                     return null;
+                                let itemCount = rewardItem.count;
+                                if (item.categories.some(cat => cat.normalizedName === 'money')) {
+                                    const multiplier = intelCashMultiplier[settings['intelligence-center']];
+                                    itemCount = Math.round(itemCount * multiplier);
+                                }
                                 return (
                                     <li
                                         key={`reward-index-${rewardItem.item.id}-${index}`}
@@ -921,7 +933,7 @@ function Quest() {
                                             imageField="baseImageLink"
                                             nonFunctionalOverlay={false}
                                             linkToItem={true}
-                                            count={rewardItem.count > 1 ? rewardItem.count : false}
+                                            count={rewardItem.count > 1 ? itemCount : false}
                                             isFIR={true}
                                         />
                                     </li>

--- a/src/pages/quest/index.js
+++ b/src/pages/quest/index.js
@@ -967,7 +967,7 @@ function Quest() {
                             {currentQuest.finishRewards.skillLevelReward.map((skillReward) => {
                                 return (
                                     <li className="quest-list-item" key={skillReward.name}>
-                                        {`${skillReward.name} +${skillReward.level}`};
+                                        {`${skillReward.name} +${skillReward.level}`}
                                     </li>
                                 )
                             })}


### PR DESCRIPTION
The "cheapest price" column in the items table now uses the craft price as a fallback if no other prices are available. Particularly useful on the ammo page to compare the cost of craft-only ammo to others.