### PR TITLE
add dependabot and combine-prs workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -1,0 +1,14 @@
+name: Combine PRs
+
+on:
+  schedule:
+    - cron: "0 1 * * 3" # Wednesday at 01:00
+  workflow_dispatch:
+
+jobs:
+  combine-prs:
+    uses: the-hideout/reusable-workflows/.github/workflows/combine-prs.yml@main
+    secrets:
+      COMBINE_PRS_APP_ID: ${{ secrets.COMBINE_PRS_APP_ID }}
+      COMBINE_PRS_PRIVATE_KEY: ${{ secrets.COMBINE_PRS_PRIVATE_KEY }}
+      fallback: ${{ secrets.GITHUB_TOKEN }} # fall back to the default token if the app token is not available


### PR DESCRIPTION
This pull request uses the new [`the-hideout/reusable-workflows`](https://github.com/the-hideout/reusable-workflows) repo to call reusable GitHub Action workflows. The goal is to add dependabot for ease of dependency management and **also** add the `combine-prs` workflow to bundle all PRs into a single one for deployment.

This relies on a new GitHub App which I have done the following:

- Created the GitHub App
- Transferred it to `the-hideout` organization
- Setup private keys
- Setup org level secrets for the tokens
- Installed the GitHub App on all `the-hideout` repositories