### PR TITLE
Query rework

### DIFF
--- a/scripts/custom-loader.mjs
+++ b/scripts/custom-loader.mjs
@@ -12,8 +12,6 @@ export async function load(url, context, defaultLoad) {
 
     const forceConvert = [
         'do-fetch-items.js',
-        'flea-market-fee.js',
-        'camelcase-to-dashes.js',
         'do-fetch-barters.js',
         'do-fetch-crafts.js',
         'do-fetch-hideout.js',
@@ -22,7 +20,10 @@ export async function load(url, context, defaultLoad) {
         'do-fetch-traders.js',
         'do-fetch-quests.js',
         'do-fetch-bosses.js',
+        'flea-market-fee.js',
+        'camelcase-to-dashes.js',
         'graphql-request.js',
+        'api-query.js',
     ];
 
     for (const fileName of forceConvert) {

--- a/src/components/contained-items-list/index.js
+++ b/src/components/contained-items-list/index.js
@@ -2,13 +2,11 @@ import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
-import { useItemsQuery } from '../../features/items/queries';
 import { useMetaQuery } from '../../features/meta/queries';
 
 import './index.css';
 
-const ContainedItemsList = ({ item, showRestrictedType }) => {
-    const { data: items } = useItemsQuery();
+const ContainedItemsList = ({ item, showRestrictedType, items }) => {
     const { data: meta, isFetched: metaFetched } = useMetaQuery();
     const { t } = useTranslation();
 
@@ -42,7 +40,7 @@ const ContainedItemsList = ({ item, showRestrictedType }) => {
         ) {
             return [];
         }
-        let sorted = items.filter(linkedItem => {
+        let sorted = items?.filter(linkedItem => {
             for (const slot of containers) {
                 /*const included = slot.filters.allowedItems.includes(linkedItem.id) ||
                     linkedItem.categoryIds.some(catId => slot.filters.allowedCategories.includes(catId));
@@ -59,13 +57,13 @@ const ContainedItemsList = ({ item, showRestrictedType }) => {
             meta.categories.forEach(category => {
                 for (const slot of containers) {
                     if (slot.filters.allowedCategories.includes(category.id)) {
-                        sorted.push(category);
+                        sorted?.push(category);
                     }
                 }
             });
         }
 
-        return sorted.reduce((allItems, current) => {
+        return sorted?.reduce((allItems, current) => {
             if (!allItems.some(item => item.id === current.id))
                 allItems.push(current);
             return allItems;

--- a/src/components/item-name-cell/index.js
+++ b/src/components/item-name-cell/index.js
@@ -5,7 +5,7 @@ import ContainedItemsList from '../contained-items-list';
 import './index.css';
 
 function ItemNameCell(props) {
-    let {item, showContainedItems, showRestrictedType} = props;
+    let {item, showContainedItems, showRestrictedType, items} = props;
     if (!item) {
         item = props.row.original;
     }
@@ -31,12 +31,12 @@ function ItemNameCell(props) {
                 </Link>
                 {showRestrictedType && (
                     <cite>
-                        <ContainedItemsList item={item} showRestrictedType={showRestrictedType} />
+                        <ContainedItemsList item={item} showRestrictedType={showRestrictedType} items={items} />
                     </cite>
                 )}
                 {showContainedItems && (item.properties?.grids || item.properties?.slots) && (
                     <cite>
-                        <ContainedItemsList item={item} />
+                        <ContainedItemsList item={item} items={items} />
                     </cite>
                 )}
             </div>

--- a/src/components/items-summary-table/index.js
+++ b/src/components/items-summary-table/index.js
@@ -75,7 +75,14 @@ function ItemsSummaryTable(props) {
                 Header: t('Name'),
                 id: 'name',
                 accessor: 'name',
-                Cell: ItemNameCell,
+                Cell: (props) => {
+                    return (
+                        <ItemNameCell
+                            item={props.row.original}
+                            items={items}
+                        />
+                    );
+                },
             },
             {
                 Header: t('Amount'),
@@ -113,7 +120,7 @@ function ItemsSummaryTable(props) {
         ];
 
         return useColumns;
-    }, [t]);
+    }, [t, items]);
 
     const extraRow = (
         <>

--- a/src/components/quest-table/index.js
+++ b/src/components/quest-table/index.js
@@ -209,7 +209,7 @@ function QuestTable({
                         ...req,
                         item: items.find(i => i.id === req.item.id)
                     };
-                });
+                }).filter(req => req.item);
                 if (requiredItemFilter && questData.requiredItems.length === 0) {
                     return false;
                 }
@@ -343,6 +343,7 @@ function QuestTable({
                 Header: t('Required items'),
                 id: 'requiredItems',
                 accessor: (quest) => {
+                    console.log(quest.requiredItems[0]);
                     return quest.requiredItems[0]?.item.name;
                 },
                 Cell: (props) => {

--- a/src/components/small-item-table/index.js
+++ b/src/components/small-item-table/index.js
@@ -1020,6 +1020,7 @@ function SmallItemTable(props) {
                         item={props.row.original}
                         showContainedItems={showContainedItems}
                         showRestrictedType={showRestrictedType}
+                        items={items}
                     />
                 );
             },
@@ -1916,6 +1917,7 @@ function SmallItemTable(props) {
         showRestrictedType,
         attachmentMap,
         settings,
+        items,
     ]);
 
     let extraRow = false;

--- a/src/features/barters/bartersSlice.js
+++ b/src/features/barters/bartersSlice.js
@@ -99,7 +99,9 @@ const bartersSlice = createSlice({
     extraReducers: (builder) => {
         builder.addCase(fetchBarters.pending, (state, action) => {
             state.status = 'loading';
-            state.barters = bartersSlice.getInitialState().barters;
+            if (!state.barters) {
+                state.barters = bartersSlice.getInitialState().barters;
+            }
         });
         builder.addCase(fetchBarters.fulfilled, (state, action) => {
             state.status = 'succeeded';

--- a/src/features/barters/do-fetch-barters.js
+++ b/src/features/barters/do-fetch-barters.js
@@ -1,75 +1,87 @@
-import graphqlRequest from '../../modules/graphql-request.js';
+import APIQuery from '../../modules/api-query.js';
 
-const doFetchBarters = async (language, prebuild = false) => {
-    const query = `{
-        barters(lang: ${language}) {
-            rewardItems {
-                item {
-                    id
-                }
-                count
-            }
-            requiredItems {
-                item {
-                    id
-                }
-                count
-                attributes {
-                    name
-                    value
-                }
-            }
-            trader {
-                id
-                name
-                normalizedName
-            }
-            level
-            taskUnlock {
-                id
-                tarkovDataId
-                name
-                normalizedName
-            }
-        }
-    }`;
-
-    const bartersData = await graphqlRequest(query);
-
-    if (bartersData.errors) {
-        if (bartersData.data) {
-            for (const error of bartersData.errors) {
-                let badItem = false;
-                if (error.path) {
-                    badItem = bartersData.data;
-                    for (let i = 0; i < 2; i++) {
-                        badItem = badItem[error.path[i]];
-                    }
-                }
-                console.log(`Error in barters API query: ${error.message}`);
-                if (badItem) {
-                    console.log(badItem)
-                }
-            }
-        }
-        // only throw error if this is for prebuild or data wasn't returned
-        if (
-            prebuild || !bartersData.data || 
-            !bartersData.data.barters || !bartersData.data.barters.length
-        ) {
-            return Promise.reject(new Error(bartersData.errors[0].message));
-        }
+class BartersQuery extends APIQuery {
+    constructor() {
+        super('barters');
     }
 
-    // validate to make sure barters all have valid requirements and rewards
-    return bartersData.data.barters.reduce((barters, barter) => {
-        barter.requiredItems = barter.requiredItems.filter(Boolean);
-        barter.rewardItems = barter.rewardItems.filter(Boolean);
-        if (barter.requiredItems.length > 0 && barter.rewardItems.length > 0) {
-            barters.push(barter);
+    async query(language, prebuild = false) {
+        const query = `{
+            barters(lang: ${language}) {
+                rewardItems {
+                    item {
+                        id
+                    }
+                    count
+                }
+                requiredItems {
+                    item {
+                        id
+                    }
+                    count
+                    attributes {
+                        name
+                        value
+                    }
+                }
+                trader {
+                    id
+                    name
+                    normalizedName
+                }
+                level
+                taskUnlock {
+                    id
+                    tarkovDataId
+                    name
+                    normalizedName
+                }
+            }
+        }`;
+    
+        const bartersData = await this.graphqlRequest(query);
+    
+        if (bartersData.errors) {
+            if (bartersData.data) {
+                for (const error of bartersData.errors) {
+                    let badItem = false;
+                    if (error.path) {
+                        badItem = bartersData.data;
+                        for (let i = 0; i < 2; i++) {
+                            badItem = badItem[error.path[i]];
+                        }
+                    }
+                    console.log(`Error in barters API query: ${error.message}`);
+                    if (badItem) {
+                        console.log(badItem)
+                    }
+                }
+            }
+            // only throw error if this is for prebuild or data wasn't returned
+            if (
+                prebuild || !bartersData.data || 
+                !bartersData.data.barters || !bartersData.data.barters.length
+            ) {
+                return Promise.reject(new Error(bartersData.errors[0].message));
+            }
         }
-        return barters;
-    }, []);
+    
+        // validate to make sure barters all have valid requirements and rewards
+        return bartersData.data.barters.reduce((barters, barter) => {
+            barter.requiredItems = barter.requiredItems.filter(Boolean);
+            barter.rewardItems = barter.rewardItems.filter(Boolean);
+            if (barter.requiredItems.length > 0 && barter.rewardItems.length > 0) {
+                barters.push(barter);
+            }
+            return barters;
+        }, []);
+    }
+}
+
+const bartersQuery = new BartersQuery();
+
+const doFetchBarters = async (language, prebuild = false) => {
+    return bartersQuery.run(language, prebuild);
 };
 
 export default doFetchBarters;

--- a/src/features/bosses/do-fetch-bosses.js
+++ b/src/features/bosses/do-fetch-bosses.js
@@ -1,64 +1,76 @@
-import graphqlRequest from '../../modules/graphql-request.js';
+import APIQuery from '../../modules/api-query.js';
 
-const doFetchBosses = async (language = 'en', prebuild = false) => {
-    const query = `{
-        bosses(lang: ${language}) {
-            name
-            normalizedName
-            imagePortraitLink
-            imagePosterLink
-            health {
-                id
-                max
-            }
-            equipment {
-                item {
-                    id
-                    containsItems {
-                        item {
-                            id
-                        }
-                    }
-                }
-                attributes {
-                    name
-                    value
-                }
-            }
-            items {
-                id
-            }
-        }
-    }`;
-
-    const bossesData = await graphqlRequest(query);
-
-    if (bossesData.errors) {
-        if (bossesData.data) {
-            for (const error of bossesData.errors) {
-                let badItem = false;
-                if (error.path) {
-                    badItem = bossesData.data;
-                    for (let i = 0; i < 2; i++) {
-                        badItem = badItem[error.path[i]];
-                    }
-                }
-                console.log(`Error in maps API query: ${error.message}`);
-                if (badItem) {
-                    console.log(badItem)
-                }
-            }
-        }
-        // only throw error if this is for prebuild or data wasn't returned
-        if (
-            prebuild || !bossesData.data || 
-            !bossesData.data.maps || !bossesData.data.maps.length
-        ) {
-            return Promise.reject(new Error(bossesData.errors[0].message));
-        }
+class BossesQuery extends APIQuery {
+    constructor() {
+        super('bosses');
     }
 
-    return bossesData.data.bosses;
+    async query(language, prebuild = false) {
+        const query = `{
+            bosses(lang: ${language}) {
+                name
+                normalizedName
+                imagePortraitLink
+                imagePosterLink
+                health {
+                    id
+                    max
+                }
+                equipment {
+                    item {
+                        id
+                        containsItems {
+                            item {
+                                id
+                            }
+                        }
+                    }
+                    attributes {
+                        name
+                        value
+                    }
+                }
+                items {
+                    id
+                }
+            }
+        }`;
+    
+        const bossesData = await this.graphqlRequest(query);
+    
+        if (bossesData.errors) {
+            if (bossesData.data) {
+                for (const error of bossesData.errors) {
+                    let badItem = false;
+                    if (error.path) {
+                        badItem = bossesData.data;
+                        for (let i = 0; i < 2; i++) {
+                            badItem = badItem[error.path[i]];
+                        }
+                    }
+                    console.log(`Error in maps API query: ${error.message}`);
+                    if (badItem) {
+                        console.log(badItem)
+                    }
+                }
+            }
+            // only throw error if this is for prebuild or data wasn't returned
+            if (
+                prebuild || !bossesData.data || 
+                !bossesData.data.maps || !bossesData.data.maps.length
+            ) {
+                return Promise.reject(new Error(bossesData.errors[0].message));
+            }
+        }
+    
+        return bossesData.data.bosses;
+    }
+}
+
+const bossesQuery = new BossesQuery();
+
+const doFetchBosses = async (language = 'en', prebuild = false) => {
+    return bossesQuery.run(language, prebuild);
 };
 
 export default doFetchBosses;

--- a/src/features/crafts/craftsSlice.js
+++ b/src/features/crafts/craftsSlice.js
@@ -92,7 +92,9 @@ const craftsSlice = createSlice({
     extraReducers: (builder) => {
         builder.addCase(fetchCrafts.pending, (state, action) => {
             state.status = 'loading';
-            state.crafts = craftsSlice.getInitialState().crafts;
+            if (!state.crafts) {
+                state.crafts = craftsSlice.getInitialState().crafts;
+            }
         });
         builder.addCase(fetchCrafts.fulfilled, (state, action) => {
             state.status = 'succeeded';

--- a/src/features/crafts/do-fetch-crafts.js
+++ b/src/features/crafts/do-fetch-crafts.js
@@ -1,72 +1,84 @@
-import graphqlRequest from '../../modules/graphql-request.js';
+import APIQuery from '../../modules/api-query.js';
 
-export default async function doFetchCrafts(language, prebuild = false) {
-    const query = `{
-        crafts(lang: ${language}) {
-            station {
-                id
-                name
-                normalizedName
-            }
-            level
-            duration
-            rewardItems {
-                item {
-                    id
-                }
-                count
-            }
-            requiredItems {
-                item {
-                    id
-                }
-                count
-                attributes {
-                    type
-                    name
-                    value
-                }
-            }
-            taskUnlock {
-                id
-            }
-        }
-    }`;
-
-    const craftsData = await graphqlRequest(query);
-    
-    if (craftsData.errors) {
-        if (craftsData.data) {
-            for (const error of craftsData.errors) {
-                let badItem = false;
-                if (error.path) {
-                    badItem = craftsData.data;
-                    for (let i = 0; i < 2; i++) {
-                        badItem = badItem[error.path[i]];
-                    }
-                }
-                console.log(`Error in crafts API query: ${error.message}`);
-                if (badItem) {
-                    console.log(badItem)
-                }
-            }
-        }
-        // only throw error if this is for prebuild or data wasn't returned
-        if (
-            prebuild || !craftsData.data || 
-            !craftsData.data.crafts || !craftsData.data.crafts.length
-        ) {
-            return Promise.reject(new Error(craftsData.errors[0].message));
-        }
+class CraftsQuery extends APIQuery {
+    constructor() {
+        super('crafts');
     }
 
-    // validate to make sure crafts all have valid requirements and rewards
-    return craftsData.data.crafts.reduce((crafts, craft) => {
-        craft.requiredItems = craft.requiredItems.filter(Boolean);
-        craft.rewardItems = craft.rewardItems.filter(Boolean);
-        if (craft.requiredItems.length > 0 && craft.rewardItems.length > 0) {
-            crafts.push(craft);
+    async query(language, prebuild = false) {
+        const query = `{
+            crafts(lang: ${language}) {
+                station {
+                    id
+                    name
+                    normalizedName
+                }
+                level
+                duration
+                rewardItems {
+                    item {
+                        id
+                    }
+                    count
+                }
+                requiredItems {
+                    item {
+                        id
+                    }
+                    count
+                    attributes {
+                        type
+                        name
+                        value
+                    }
+                }
+                taskUnlock {
+                    id
+                }
+            }
+        }`;
+    
+        const craftsData = await this.graphqlRequest(query);
+        
+        if (craftsData.errors) {
+            if (craftsData.data) {
+                for (const error of craftsData.errors) {
+                    let badItem = false;
+                    if (error.path) {
+                        badItem = craftsData.data;
+                        for (let i = 0; i < 2; i++) {
+                            badItem = badItem[error.path[i]];
+                        }
+                    }
+                    console.log(`Error in crafts API query: ${error.message}`);
+                    if (badItem) {
+                        console.log(badItem)
+                    }
+                }
+            }
+            // only throw error if this is for prebuild or data wasn't returned
+            if (
+                prebuild || !craftsData.data || 
+                !craftsData.data.crafts || !craftsData.data.crafts.length
+            ) {
+                return Promise.reject(new Error(craftsData.errors[0].message));
+            }
         }
-        return crafts;
-    }, []);
+    
+        // validate to make sure crafts all have valid requirements and rewards
+        return craftsData.data.crafts.reduce((crafts, craft) => {
+            craft.requiredItems = craft.requiredItems.filter(Boolean);
+            craft.rewardItems = craft.rewardItems.filter(Boolean);
+            if (craft.requiredItems.length > 0 && craft.rewardItems.length > 0) {
+                crafts.push(craft);
+            }
+            return crafts;
+        }, []);
+    }
+}
+
+const craftsQuery = new CraftsQuery();
+
+export default async function doFetchCrafts(language, prebuild = false) {
+    return craftsQuery.run(language, prebuild);
 };

--- a/src/features/items/do-fetch-items.js
+++ b/src/features/items/do-fetch-items.js
@@ -1,702 +1,717 @@
 import fetch  from 'cross-fetch';
 
+import APIQuery from '../../modules/api-query.js';
 import fleaMarketFee from '../../modules/flea-market-fee.js';
-import graphqlRequest from '../../modules/graphql-request.js';
 
-const doFetchItems = async (language, prebuild = false) => {
-    const itemLimit = 2000;
-    const QueryBody = offset => {
-        return `{
-            items(lang: ${language}, limit: ${itemLimit}, offset: ${offset}) {
-                id
-                bsgCategoryId
-                categories {
+class ItemsQuery extends APIQuery {
+    constructor() {
+        super('items');
+    }
+
+    async query(language, prebuild = false) {
+        const itemLimit = 2000;
+        const QueryBody = offset => {
+            return `{
+                items(lang: ${language}, limit: ${itemLimit}, offset: ${offset}) {
                     id
-                    name
-                    normalizedName
-                }
-                name
-                shortName
-                basePrice
-                normalizedName
-                backgroundColor
-                types
-                width
-                height
-                weight
-                avg24hPrice
-                wikiLink
-                changeLast48h
-                changeLast48hPercent
-                low24hPrice
-                high24hPrice
-                lastLowPrice
-                gridImageLink
-                iconLink
-                baseImageLink
-                image512pxLink
-                image8xLink
-                updated
-                sellFor {
-                    vendor {
-                        name
-                        normalizedName
-                        __typename
-                        ...on TraderOffer {
-                            trader {
-                                id
-                            }
-                            minTraderLevel
-                            taskUnlock {
-                                id
-                                tarkovDataId
-                                name
-                            }
-                        }
-                    }
-                    price
-                    currency
-                    priceRUB
-                    requirements {
-                        type
-                        value
-                    }
-                }
-                buyFor {
-                    vendor {
-                        name
-                        normalizedName
-                        __typename
-                        ...on TraderOffer {
-                            trader {
-                                id
-                            }
-                            minTraderLevel
-                            taskUnlock {
-                                id
-                                tarkovDataId
-                                name
-                                normalizedName
-                            }
-                        }
-                    }
-                    price
-                    currency
-                    priceRUB
-                    requirements {
-                        type
-                        value
-                    }
-                }
-                containsItems {
-                    count
-                    item {
+                    bsgCategoryId
+                    categories {
                         id
+                        name
+                        normalizedName
                     }
-                }
-                properties {
-                    __typename
-                    ...on ItemPropertiesAmmo {
-                        caliber
-                        damage
-                        projectileCount
-                        penetrationPower
-                        armorDamage
-                        fragmentationChance
-                        ammoType
-                    }
-                    ...on ItemPropertiesArmor {
-                        class
-                        material {
-                            id
-                            name
-                        }
-                        zones
-                        durability
-                        ergoPenalty
-                        speedPenalty
-                        turnPenalty
-                    }
-                    ...on ItemPropertiesArmorAttachment {
-                        class
-                        material {
-                            id
-                            name
-                        }
-                        headZones
-                        durability
-                        ergoPenalty
-                        speedPenalty
-                        turnPenalty
-                    }
-                    ...on ItemPropertiesBackpack {
-                        capacity
-                        grids {
-                            width
-                            height
-                            filters {
-                                allowedCategories {
-                                    id
-                                }
-                                allowedItems {
-                                    id
-                                }
-                                excludedCategories {
-                                    id
-                                }
-                                excludedItems {
-                                    id
-                                }
-                            }
-                        }
-                        speedPenalty
-                        turnPenalty
-                        ergoPenalty
-                    }
-                    ...on ItemPropertiesChestRig {
-                        capacity
-                        class
-                        material {
-                            id
-                            name
-                        }
-                        zones
-                        durability
-                        ergoPenalty
-                        speedPenalty
-                        turnPenalty
-                        grids {
-                            width
-                            height
-                            filters {
-                                allowedCategories {
-                                    id
-                                }
-                                allowedItems {
-                                    id
-                                }
-                                excludedCategories {
-                                    id
-                                }
-                                excludedItems {
-                                    id
-                                }
-                            }
-                        }
-                    }
-                    ...on ItemPropertiesContainer {
-                        capacity
-                        grids {
-                            width
-                            height
-                            filters {
-                                allowedCategories {
-                                    id
-                                }
-                                allowedItems {
-                                    id
-                                }
-                                excludedCategories {
-                                    id
-                                }
-                                excludedItems {
-                                    id
-                                }
-                            }
-                        }
-                    }
-                    ...on ItemPropertiesFoodDrink {
-                        energy
-                        hydration
-                        units
-                        stimEffects {
-                            type
-                            chance
-                            delay
-                            duration
-                            value
-                            percent
-                            skillName
-                        }
-                    }
-                    ...on ItemPropertiesGlasses {
-                        class
-                        durability
-                        blindnessProtection
-                        material {
-                            id
-                            name
-                        }
-                    }
-                    ...on ItemPropertiesGrenade {
-                        type
-                        fuse
-                        maxExplosionDistance
-                        fragments
-                    }
-                    ...on ItemPropertiesHelmet {
-                        class
-                        material {
-                            id
-                            name
-                        }
-                        headZones
-                        durability
-                        ergoPenalty
-                        speedPenalty
-                        turnPenalty
-                        deafening
-                        blocksHeadset
-                        ricochetY
-                        slots {
-                            filters {
-                                allowedCategories {
-                                    id
-                                }
-                                allowedItems {
-                                    id
-                                }
-                                excludedCategories {
-                                    id
-                                }
-                                excludedItems {
-                                    id
-                                }
-                            }
-                        }
-                    }
-                    ...on ItemPropertiesKey {
-                        uses
-                    }
-                    ...on ItemPropertiesMagazine {
-                        capacity
-                        malfunctionChance
-                        ergonomics
-                        recoilModifier
-                        capacity
-                        loadModifier
-                        ammoCheckModifier
-                    }
-                    ...on ItemPropertiesMedicalItem {
-                        uses
-                        useTime
-                        cures
-                    }
-                    ...on ItemPropertiesMedKit {
-                        hitpoints
-                        useTime
-                        maxHealPerUse
-                        cures
-                        hpCostLightBleeding
-                        hpCostHeavyBleeding
-                    }
-                    ...on ItemPropertiesPainkiller {
-                        uses
-                        useTime
-                        cures
-                        painkillerDuration
-                        energyImpact
-                        hydrationImpact
-                    }
-                    ...on ItemPropertiesPreset {
-                        baseItem {
-                            id
+                    name
+                    shortName
+                    basePrice
+                    normalizedName
+                    backgroundColor
+                    types
+                    width
+                    height
+                    weight
+                    avg24hPrice
+                    wikiLink
+                    changeLast48h
+                    changeLast48hPercent
+                    low24hPrice
+                    high24hPrice
+                    lastLowPrice
+                    gridImageLink
+                    iconLink
+                    baseImageLink
+                    image512pxLink
+                    image8xLink
+                    updated
+                    sellFor {
+                        vendor {
                             name
                             normalizedName
-                            properties {
-                                ...on ItemPropertiesWeapon {
-                                    defaultPreset {
+                            __typename
+                            ...on TraderOffer {
+                                trader {
+                                    id
+                                }
+                                minTraderLevel
+                                taskUnlock {
+                                    id
+                                    tarkovDataId
+                                    name
+                                }
+                            }
+                        }
+                        price
+                        currency
+                        priceRUB
+                        requirements {
+                            type
+                            value
+                        }
+                    }
+                    buyFor {
+                        vendor {
+                            name
+                            normalizedName
+                            __typename
+                            ...on TraderOffer {
+                                trader {
+                                    id
+                                }
+                                minTraderLevel
+                                taskUnlock {
+                                    id
+                                    tarkovDataId
+                                    name
+                                    normalizedName
+                                }
+                            }
+                        }
+                        price
+                        currency
+                        priceRUB
+                        requirements {
+                            type
+                            value
+                        }
+                    }
+                    containsItems {
+                        count
+                        item {
+                            id
+                        }
+                    }
+                    properties {
+                        __typename
+                        ...on ItemPropertiesAmmo {
+                            caliber
+                            damage
+                            projectileCount
+                            penetrationPower
+                            armorDamage
+                            fragmentationChance
+                            ammoType
+                        }
+                        ...on ItemPropertiesArmor {
+                            class
+                            material {
+                                id
+                                name
+                            }
+                            zones
+                            durability
+                            ergoPenalty
+                            speedPenalty
+                            turnPenalty
+                        }
+                        ...on ItemPropertiesArmorAttachment {
+                            class
+                            material {
+                                id
+                                name
+                            }
+                            headZones
+                            durability
+                            ergoPenalty
+                            speedPenalty
+                            turnPenalty
+                        }
+                        ...on ItemPropertiesBackpack {
+                            capacity
+                            grids {
+                                width
+                                height
+                                filters {
+                                    allowedCategories {
+                                        id
+                                    }
+                                    allowedItems {
+                                        id
+                                    }
+                                    excludedCategories {
+                                        id
+                                    }
+                                    excludedItems {
+                                        id
+                                    }
+                                }
+                            }
+                            speedPenalty
+                            turnPenalty
+                            ergoPenalty
+                        }
+                        ...on ItemPropertiesChestRig {
+                            capacity
+                            class
+                            material {
+                                id
+                                name
+                            }
+                            zones
+                            durability
+                            ergoPenalty
+                            speedPenalty
+                            turnPenalty
+                            grids {
+                                width
+                                height
+                                filters {
+                                    allowedCategories {
+                                        id
+                                    }
+                                    allowedItems {
+                                        id
+                                    }
+                                    excludedCategories {
+                                        id
+                                    }
+                                    excludedItems {
                                         id
                                     }
                                 }
                             }
                         }
-                        ergonomics
-                        recoilVertical
-                        recoilHorizontal
-                    }
-                    ...on ItemPropertiesScope {
-                        ergonomics
-                        recoilModifier
-                        zoomLevels
-                    }
-                    ...on ItemPropertiesStim {
-                        cures
-                        useTime
-                        stimEffects {
+                        ...on ItemPropertiesContainer {
+                            capacity
+                            grids {
+                                width
+                                height
+                                filters {
+                                    allowedCategories {
+                                        id
+                                    }
+                                    allowedItems {
+                                        id
+                                    }
+                                    excludedCategories {
+                                        id
+                                    }
+                                    excludedItems {
+                                        id
+                                    }
+                                }
+                            }
+                        }
+                        ...on ItemPropertiesFoodDrink {
+                            energy
+                            hydration
+                            units
+                            stimEffects {
+                                type
+                                chance
+                                delay
+                                duration
+                                value
+                                percent
+                                skillName
+                            }
+                        }
+                        ...on ItemPropertiesGlasses {
+                            class
+                            durability
+                            blindnessProtection
+                            material {
+                                id
+                                name
+                            }
+                        }
+                        ...on ItemPropertiesGrenade {
                             type
-                            chance
-                            delay
-                            duration
-                            value
-                            percent
-                            skillName
+                            fuse
+                            maxExplosionDistance
+                            fragments
                         }
-                    }
-                    ...on ItemPropertiesSurgicalKit {
-                        uses
-                        useTime
-                        cures
-                        minLimbHealth
-                        maxLimbHealth
-                    }
-                    ...on ItemPropertiesWeapon {
-                        caliber
-                        effectiveDistance
-                        ergonomics
-                        fireModes
-                        fireRate
-                        recoilVertical
-                        recoilHorizontal
-                        sightingRange
-                        recoilAngle
-                        recoilDispersion
-                        convergence
-                        cameraRecoil
-                        slots {
-                            filters {
-                                allowedCategories {
-                                    id
-                                }
-                                allowedItems {
-                                    id
-                                }
-                                excludedCategories {
-                                    id
-                                }
-                                excludedItems {
-                                    id
+                        ...on ItemPropertiesHelmet {
+                            class
+                            material {
+                                id
+                                name
+                            }
+                            headZones
+                            durability
+                            ergoPenalty
+                            speedPenalty
+                            turnPenalty
+                            deafening
+                            blocksHeadset
+                            ricochetY
+                            slots {
+                                filters {
+                                    allowedCategories {
+                                        id
+                                    }
+                                    allowedItems {
+                                        id
+                                    }
+                                    excludedCategories {
+                                        id
+                                    }
+                                    excludedItems {
+                                        id
+                                    }
                                 }
                             }
                         }
-                        defaultPreset {
-                            id
+                        ...on ItemPropertiesKey {
+                            uses
                         }
-                        presets {
-                            id
+                        ...on ItemPropertiesMagazine {
+                            capacity
+                            malfunctionChance
+                            ergonomics
+                            recoilModifier
+                            capacity
+                            loadModifier
+                            ammoCheckModifier
                         }
-                    }
-                    ...on ItemPropertiesWeaponMod {
-                        ergonomics
-                        recoilModifier
-                        slots {
-                            filters {
-                                allowedCategories {
-                                    id
+                        ...on ItemPropertiesMedicalItem {
+                            uses
+                            useTime
+                            cures
+                        }
+                        ...on ItemPropertiesMedKit {
+                            hitpoints
+                            useTime
+                            maxHealPerUse
+                            cures
+                            hpCostLightBleeding
+                            hpCostHeavyBleeding
+                        }
+                        ...on ItemPropertiesPainkiller {
+                            uses
+                            useTime
+                            cures
+                            painkillerDuration
+                            energyImpact
+                            hydrationImpact
+                        }
+                        ...on ItemPropertiesPreset {
+                            baseItem {
+                                id
+                                name
+                                normalizedName
+                                properties {
+                                    ...on ItemPropertiesWeapon {
+                                        defaultPreset {
+                                            id
+                                        }
+                                    }
                                 }
-                                allowedItems {
-                                    id
+                            }
+                            ergonomics
+                            recoilVertical
+                            recoilHorizontal
+                        }
+                        ...on ItemPropertiesResource {
+                            units
+                        }
+                        ...on ItemPropertiesScope {
+                            ergonomics
+                            recoilModifier
+                            zoomLevels
+                        }
+                        ...on ItemPropertiesStim {
+                            cures
+                            useTime
+                            stimEffects {
+                                type
+                                chance
+                                delay
+                                duration
+                                value
+                                percent
+                                skillName
+                            }
+                        }
+                        ...on ItemPropertiesSurgicalKit {
+                            uses
+                            useTime
+                            cures
+                            minLimbHealth
+                            maxLimbHealth
+                        }
+                        ...on ItemPropertiesWeapon {
+                            caliber
+                            effectiveDistance
+                            ergonomics
+                            fireModes
+                            fireRate
+                            recoilVertical
+                            recoilHorizontal
+                            sightingRange
+                            recoilAngle
+                            recoilDispersion
+                            convergence
+                            cameraRecoil
+                            slots {
+                                filters {
+                                    allowedCategories {
+                                        id
+                                    }
+                                    allowedItems {
+                                        id
+                                    }
+                                    excludedCategories {
+                                        id
+                                    }
+                                    excludedItems {
+                                        id
+                                    }
                                 }
-                                excludedCategories {
-                                    id
-                                }
-                                excludedItems {
-                                    id
+                            }
+                            defaultPreset {
+                                id
+                            }
+                            presets {
+                                id
+                            }
+                        }
+                        ...on ItemPropertiesWeaponMod {
+                            ergonomics
+                            recoilModifier
+                            slots {
+                                filters {
+                                    allowedCategories {
+                                        id
+                                    }
+                                    allowedItems {
+                                        id
+                                    }
+                                    excludedCategories {
+                                        id
+                                    }
+                                    excludedItems {
+                                        id
+                                    }
                                 }
                             }
                         }
                     }
                 }
-            }
-        }`;
-    };
-    //console.time('items query');
-    const [itemData, miscData, itemGrids] = await Promise.all([
-        new Promise(async resolve => {
-            let offset = 0;
-            const retrievedItems = {
-                data: {
-                    items: [],
-                },
-            };
-            while (true) {
-                const itemBatch = await graphqlRequest(QueryBody(offset));
-                if (itemBatch.errors) {
-                    if (!retrievedItems.errors) {
-                        retrievedItems.errors = [];
-                    }
-                    retrievedItems.errors.concat(itemBatch.errors);
-                }
-                if (itemBatch.data && itemBatch.data.items) {
-                    if (itemBatch.data.items.length === 0) {
-                        break;
-                    }
-                    retrievedItems.data.items = retrievedItems.data.items.concat(itemBatch.data.items);
-                    if (itemBatch.data.items.length < itemLimit) {
-                        break;
-                    }
-                }
-                if (!itemBatch.errors) {
-                    if (!itemBatch.data || !itemBatch.data.items || !itemBatch.data.items.length) {
-                        break;
-                    }
-                }
-                offset += itemLimit;
-            }
-            resolve(retrievedItems);
-        }),
-        graphqlRequest(`{
-            fleaMarket {
-                sellOfferFeeRate
-                sellRequirementFeeRate
-            }
-            traders {
-                normalizedName
-                levels {
-                    payRate
-                }
-            }
-            currencies: items(categoryNames: [Money]) {
-                shortName
-                basePrice
-            }
-        }`),
-        new Promise(resolve => {
-            if (prebuild) {
-                return resolve({});
-            }
-            return resolve(fetch(`${process.env.PUBLIC_URL}/data/item-grids.min.json`).then(
-                (response) => response.json(),
-            )).catch(error => {
-                console.log('Error retrieving item grids', error);
-                return {};
-            });
-        })
-    ]);
-    //console.timeEnd('items query');
-    if (itemData.errors) {
-        if (itemData.data) {
-            for (const error of itemData.errors) {
-                let badItem = false;
-                if (error.path) {
-                    let traverseLimit = 2;
-                    if (error.path[0] === 'fleaMarket') {
-                        traverseLimit = 1;
-                    }
-                    badItem = itemData.data;
-                    for (let i = 0; i < traverseLimit; i++) {
-                        badItem = badItem[error.path[i]];
-                    }
-                }
-                console.log(`Error in items API query: ${error.message}`, error.path);
-                if (badItem) {
-                    console.log(badItem)
-                }
-            }
-        }
-        // only throw error if this is for prebuild or data wasn't returned
-        if (
-            prebuild || !itemData.data || 
-            !itemData.data.items || !itemData.data.items.length
-        ) {
-            return Promise.reject(new Error(itemData.errors[0].message));
-        }
-    }
-
-    if (miscData.errors) {
-        if (miscData.data) {
-            for (const error of miscData.errors) {
-                let badItem = false;
-                if (error.path) {
-                    let traverseLimit = 2;
-                    if (error.path[0] === 'fleaMarket') {
-                        traverseLimit = 1;
-                    }
-                    badItem = miscData.data;
-                    for (let i = 0; i < traverseLimit; i++) {
-                        badItem = badItem[error.path[i]];
-                    }
-                }
-                console.log(`Error in items API query: ${error.message}`, error.path);
-                if (badItem) {
-                    console.log(badItem)
-                }
-            }
-        }
-        // only throw error if this is for prebuild or data wasn't returned
-        if (
-            prebuild || !miscData.data || 
-            !miscData.data.fleaMarket || 
-            !miscData.data.traders || !miscData.data.traders.length || 
-            !miscData.data.currencies || !miscData.data.currencies.length
-        ) {
-            return Promise.reject(new Error(miscData.errors[0].message));
-        }
-    }
-
-    const flea = miscData.data.fleaMarket;
-
-    const currencies = {};
-    for (const currency of miscData.data.currencies) {
-        currencies[currency.shortName] = currency.basePrice;
-    }
-
-    const allItems = itemData.data.items.map((rawItem) => {
-        let grid = false;
-
-        if (rawItem.properties?.grids) {
-            let gridPockets = [];
-            for (const grid of rawItem.properties.grids) {
-                gridPockets.push({
-                    row: gridPockets.length,
-                    col: 0,
-                    width: grid.width,
-                    height: grid.height,
-                });
-            }
-            /*let gridPockets = [
-                {
-                    row: 0,
-                    col: 0,
-                    width: rawItem.properties.grids[0].width,
-                    height: rawItem.properties.grids[0].height,
-                },
-            ];*/
-
-            if (itemGrids[rawItem.id]) {
-                gridPockets = itemGrids[rawItem.id];
-            }
-
-            grid = {
-                height: rawItem.properties.grids[0].height,
-                width: rawItem.properties.grids[0].width,
-                pockets: gridPockets,
-            };
-
-            if (gridPockets.length > 1) {
-                grid.height = Math.max(
-                    ...gridPockets.map((pocket) => pocket.row + pocket.height),
-                );
-                grid.width = Math.max(
-                    ...gridPockets.map((pocket) => pocket.col + pocket.width),
-                );
-            }
-
-            // Rigs we haven't configured shouldn't break
-            if (!itemGrids[rawItem.id] && !rawItem.types.includes('backpack')) {
-                grid = false;
-            }
-        }
-
-        const container = rawItem.properties?.slots || rawItem.properties?.grids;
-        if (container) {
-            for (const slot of container) {
-                slot.filters.allowedCategories = slot.filters.allowedCategories.map(cat => cat.id);
-                slot.filters.allowedItems = slot.filters.allowedItems.map(it => it.id);
-                slot.filters.excludedCategories = slot.filters.excludedCategories.map(cat => cat.id);
-                slot.filters.excludedItems = slot.filters.excludedItems.map(it => it.id);
-            }
-        }
-        rawItem.categoryIds = rawItem.categories.map(cat => cat.id);
-
-        return {
-            ...rawItem,
-            fee: fleaMarketFee(rawItem.basePrice, rawItem.lastLowPrice, 1, flea.sellOfferFeeRate, flea.sellRequirementFeeRate),
-            slots: rawItem.width * rawItem.height,
-            iconLink: rawItem.iconLink,
-            grid: grid,
-            properties: {
-                weight: rawItem.weight,
-                ...rawItem.properties
-            },
-            containsItems: rawItem.types.includes('gun') ? [] : rawItem.containsItems,
+            }`;
         };
-    });
+        //console.time('items query');
+        const [itemData, miscData, itemGrids] = await Promise.all([
+            new Promise(async resolve => {
+                let offset = 0;
+                const retrievedItems = {
+                    data: {
+                        items: [],
+                    },
+                };
+                while (true) {
+                    const itemBatch = await this.graphqlRequest(QueryBody(offset));
+                    if (itemBatch.errors) {
+                        if (!retrievedItems.errors) {
+                            retrievedItems.errors = [];
+                        }
+                        retrievedItems.errors.concat(itemBatch.errors);
+                    }
+                    if (itemBatch.data && itemBatch.data.items) {
+                        if (itemBatch.data.items.length === 0) {
+                            break;
+                        }
+                        retrievedItems.data.items = retrievedItems.data.items.concat(itemBatch.data.items);
+                        if (itemBatch.data.items.length < itemLimit) {
+                            break;
+                        }
+                    }
+                    if (!itemBatch.errors) {
+                        if (!itemBatch.data || !itemBatch.data.items || !itemBatch.data.items.length) {
+                            break;
+                        }
+                    }
+                    offset += itemLimit;
+                }
+                resolve(retrievedItems);
+            }),
+            this.graphqlRequest(`{
+                fleaMarket {
+                    sellOfferFeeRate
+                    sellRequirementFeeRate
+                }
+                traders {
+                    normalizedName
+                    levels {
+                        payRate
+                    }
+                }
+                currencies: items(categoryNames: [Money]) {
+                    shortName
+                    basePrice
+                }
+            }`),
+            new Promise(resolve => {
+                if (prebuild) {
+                    return resolve({});
+                }
+                return resolve(fetch(`${process.env.PUBLIC_URL}/data/item-grids.min.json`).then(
+                    (response) => response.json(),
+                )).catch(error => {
+                    console.log('Error retrieving item grids', error);
+                    return {};
+                });
+            })
+        ]);
+        //console.timeEnd('items query');
+        if (itemData.errors) {
+            if (itemData.data) {
+                for (const error of itemData.errors) {
+                    let badItem = false;
+                    if (error.path) {
+                        let traverseLimit = 2;
+                        if (error.path[0] === 'fleaMarket') {
+                            traverseLimit = 1;
+                        }
+                        badItem = itemData.data;
+                        for (let i = 0; i < traverseLimit; i++) {
+                            badItem = badItem[error.path[i]];
+                        }
+                    }
+                    console.log(`Error in items API query: ${error.message}`, error.path);
+                    if (badItem) {
+                        console.log(badItem)
+                    }
+                }
+            }
+            // only throw error if this is for prebuild or data wasn't returned
+            if (
+                prebuild || !itemData.data || 
+                !itemData.data.items || !itemData.data.items.length
+            ) {
+                return Promise.reject(new Error(itemData.errors[0].message));
+            }
+        }
 
-    for (const item of allItems) {
-        /*if (item.types.includes('gun') && item.containsItems?.length > 0) {
-            item.sellFor = item.sellFor.map((sellFor) => {
-                if (sellFor.vendor.normalizedName === 'flea-market') {
+        if (miscData.errors) {
+            if (miscData.data) {
+                for (const error of miscData.errors) {
+                    let badItem = false;
+                    if (error.path) {
+                        let traverseLimit = 2;
+                        if (error.path[0] === 'fleaMarket') {
+                            traverseLimit = 1;
+                        }
+                        badItem = miscData.data;
+                        for (let i = 0; i < traverseLimit; i++) {
+                            badItem = badItem[error.path[i]];
+                        }
+                    }
+                    console.log(`Error in items API query: ${error.message}`, error.path);
+                    if (badItem) {
+                        console.log(badItem)
+                    }
+                }
+            }
+            // only throw error if this is for prebuild or data wasn't returned
+            if (
+                prebuild || !miscData.data || 
+                !miscData.data.fleaMarket || 
+                !miscData.data.traders || !miscData.data.traders.length || 
+                !miscData.data.currencies || !miscData.data.currencies.length
+            ) {
+                return Promise.reject(new Error(miscData.errors[0].message));
+            }
+        }
+
+        const flea = miscData.data.fleaMarket;
+
+        const currencies = {};
+        for (const currency of miscData.data.currencies) {
+            currencies[currency.shortName] = currency.basePrice;
+        }
+
+        const allItems = itemData.data.items.map((rawItem) => {
+            let grid = false;
+
+            if (rawItem.properties?.grids) {
+                let gridPockets = [];
+                for (const grid of rawItem.properties.grids) {
+                    gridPockets.push({
+                        row: gridPockets.length,
+                        col: 0,
+                        width: grid.width,
+                        height: grid.height,
+                    });
+                }
+                /*let gridPockets = [
+                    {
+                        row: 0,
+                        col: 0,
+                        width: rawItem.properties.grids[0].width,
+                        height: rawItem.properties.grids[0].height,
+                    },
+                ];*/
+
+                if (itemGrids[rawItem.id]) {
+                    gridPockets = itemGrids[rawItem.id];
+                }
+
+                grid = {
+                    height: rawItem.properties.grids[0].height,
+                    width: rawItem.properties.grids[0].width,
+                    pockets: gridPockets,
+                };
+
+                if (gridPockets.length > 1) {
+                    grid.height = Math.max(
+                        ...gridPockets.map((pocket) => pocket.row + pocket.height),
+                    );
+                    grid.width = Math.max(
+                        ...gridPockets.map((pocket) => pocket.col + pocket.width),
+                    );
+                }
+
+                // Rigs we haven't configured shouldn't break
+                if (!itemGrids[rawItem.id] && !rawItem.types.includes('backpack')) {
+                    grid = false;
+                }
+            }
+
+            const container = rawItem.properties?.slots || rawItem.properties?.grids;
+            if (container) {
+                for (const slot of container) {
+                    slot.filters.allowedCategories = slot.filters.allowedCategories.map(cat => cat.id);
+                    slot.filters.allowedItems = slot.filters.allowedItems.map(it => it.id);
+                    slot.filters.excludedCategories = slot.filters.excludedCategories.map(cat => cat.id);
+                    slot.filters.excludedItems = slot.filters.excludedItems.map(it => it.id);
+                }
+            }
+            rawItem.categoryIds = rawItem.categories.map(cat => cat.id);
+
+            return {
+                ...rawItem,
+                fee: fleaMarketFee(rawItem.basePrice, rawItem.lastLowPrice, 1, flea.sellOfferFeeRate, flea.sellRequirementFeeRate),
+                slots: rawItem.width * rawItem.height,
+                iconLink: rawItem.iconLink,
+                grid: grid,
+                properties: {
+                    weight: rawItem.weight,
+                    ...rawItem.properties
+                },
+                containsItems: rawItem.types.includes('gun') ? [] : rawItem.containsItems,
+            };
+        });
+
+        for (const item of allItems) {
+            /*if (item.types.includes('gun') && item.containsItems?.length > 0) {
+                item.sellFor = item.sellFor.map((sellFor) => {
+                    if (sellFor.vendor.normalizedName === 'flea-market') {
+                        return {
+                            ...sellFor,
+                            totalPriceRUB: sellFor.priceRUB,
+                            totalPrice: sellFor.price
+                        };
+                    }
+                    const trader = miscData.data.traders.find(t => t.normalizedName === sellFor.vendor.normalizedName);
+                    const totalPrices = item.containsItems.reduce(
+                        (previousValue, currentValue) => {
+                            const part = allItems.find(innerItem => innerItem.id === currentValue.item.id);
+                            const partFromSellFor = part.sellFor.find(innerSellFor => innerSellFor.vendor.normalizedName === sellFor.vendor.normalizedName);
+
+                            if (!partFromSellFor) {
+                                const thisPartPriceRUB = Math.floor(part.basePrice * trader.levels[0].payRate);
+                                previousValue.priceRUB += thisPartPriceRUB;
+                                previousValue.price += Math.round(thisPartPriceRUB / currencies[sellFor.currency]);
+                                return previousValue;
+                            }
+
+                            previousValue.price += partFromSellFor.price;
+                            previousValue.priceRUB += partFromSellFor.priceRUB;
+
+                            return previousValue;
+                        },
+                        {price: sellFor.price, priceRUB: sellFor.priceRUB}
+                    );
+                    
+                    //sellFor.price = totalPrices.price;
+
                     return {
                         ...sellFor,
-                        totalPriceRUB: sellFor.priceRUB,
-                        totalPrice: sellFor.price
+                        totalPrice: totalPrices.price,
+                        totalPriceRUB: totalPrices.priceRUB
                     };
-                }
-                const trader = miscData.data.traders.find(t => t.normalizedName === sellFor.vendor.normalizedName);
-                const totalPrices = item.containsItems.reduce(
-                    (previousValue, currentValue) => {
-                        const part = allItems.find(innerItem => innerItem.id === currentValue.item.id);
-                        const partFromSellFor = part.sellFor.find(innerSellFor => innerSellFor.vendor.normalizedName === sellFor.vendor.normalizedName);
-
-                        if (!partFromSellFor) {
-                            const thisPartPriceRUB = Math.floor(part.basePrice * trader.levels[0].payRate);
-                            previousValue.priceRUB += thisPartPriceRUB;
-                            previousValue.price += Math.round(thisPartPriceRUB / currencies[sellFor.currency]);
-                            return previousValue;
-                        }
-
-                        previousValue.price += partFromSellFor.price;
-                        previousValue.priceRUB += partFromSellFor.priceRUB;
-
-                        return previousValue;
-                    },
-                    {price: sellFor.price, priceRUB: sellFor.priceRUB}
-                );
-                
-                //sellFor.price = totalPrices.price;
-
-                return {
-                    ...sellFor,
-                    totalPrice: totalPrices.price,
-                    totalPriceRUB: totalPrices.priceRUB
+                });
+            } else {
+                item.sellFor = item.sellFor.map((sellFor) => {
+                    return {
+                        ...sellFor,
+                        totalPrice: sellFor.price,
+                        totalPriceRUB: sellFor.priceRUB
+                    };
+                });
+            }*/
+            /*if (item.types.includes('gun') && item.properties.defaultPreset) {
+                // use default preset images for item
+                item.receiverImages = {
+                    iconLink: item.iconLInk,
+                    gridImageLink: item.gridImageLink,
+                    image512pxLink: item.image512pxLink
                 };
-            });
-        } else {
-            item.sellFor = item.sellFor.map((sellFor) => {
-                return {
-                    ...sellFor,
-                    totalPrice: sellFor.price,
-                    totalPriceRUB: sellFor.priceRUB
-                };
-            });
-        }*/
-        /*if (item.types.includes('gun') && item.properties.defaultPreset) {
-            // use default preset images for item
-            item.receiverImages = {
-                iconLink: item.iconLInk,
-                gridImageLink: item.gridImageLink,
-                image512pxLink: item.image512pxLink
-            };
-            item.iconLink = item.properties.defaultPreset.iconLink;
-            item.gridImageLink = item.properties.defaultPreset.gridImageLink;
-            item.image512pxLink = item.properties.defaultPreset.image512pxLink;
-        }*/
+                item.iconLink = item.properties.defaultPreset.iconLink;
+                item.gridImageLink = item.properties.defaultPreset.gridImageLink;
+                item.image512pxLink = item.properties.defaultPreset.image512pxLink;
+            }*/
 
-        const noneTrader = {
-            price: 0,
-            priceRUB: 0,
-            currency: 'RUB',
-            vendor: {
-                name: 'unknown',
-                normalizedName: 'unknown',
-            },
+            const noneTrader = {
+                price: 0,
+                priceRUB: 0,
+                currency: 'RUB',
+                vendor: {
+                    name: 'unknown',
+                    normalizedName: 'unknown',
+                },
+            }
+
+            // cheapest first
+            item.buyFor = item.buyFor.sort((a, b) => {
+                return a.priceRUB - b.priceRUB;
+            });
+
+            item.buyForBest = item.buyFor[0];
+
+            const buyForTraders = item.buyFor.filter(buyFor => buyFor.vendor.normalizedName !== 'flea-market');
+
+            item.buyForTradersBest = buyForTraders[0] || noneTrader;
+
+            // most profitable first
+            item.sellFor = item.sellFor.sort((a, b) => {
+                return b.priceRUB - a.priceRUB;
+            });
+
+            item.sellForBest = item.sellFor[0];
+
+            const sellForTraders = item.sellFor.filter(sellFor => sellFor.vendor.normalizedName !== 'flea-market');
+
+            item.sellForTradersBest = sellForTraders[0] || noneTrader;
         }
 
-        // cheapest first
-        item.buyFor = item.buyFor.sort((a, b) => {
-            return a.priceRUB - b.priceRUB;
-        });
-
-        item.buyForBest = item.buyFor[0];
-
-        const buyForTraders = item.buyFor.filter(buyFor => buyFor.vendor.normalizedName !== 'flea-market');
-
-        item.buyForTradersBest = buyForTraders[0] || noneTrader;
-
-        // most profitable first
-        item.sellFor = item.sellFor.sort((a, b) => {
-            return b.priceRUB - a.priceRUB;
-        });
-
-        item.sellForBest = item.sellFor[0];
-
-        const sellForTraders = item.sellFor.filter(sellFor => sellFor.vendor.normalizedName !== 'flea-market');
-
-        item.sellForTradersBest = sellForTraders[0] || noneTrader;
+        return allItems;
     }
+}
 
-    return allItems;
+const itemsQuery = new ItemsQuery();
+
+const doFetchItems = async (language, prebuild = false) => {
+    return itemsQuery.run(language, prebuild);
 };
 
 export default doFetchItems;

--- a/src/features/items/itemsSlice.js
+++ b/src/features/items/itemsSlice.js
@@ -72,7 +72,6 @@ const itemsSlice = createSlice({
             }
         });
         builder.addCase(fetchItems.fulfilled, (state, action) => {
-            console.log('items fetched')
             state.status = 'succeeded';
             const items = addPresets(action.payload);
             if (!equal(state.items, items)) {

--- a/src/features/maps/do-fetch-maps.js
+++ b/src/features/maps/do-fetch-maps.js
@@ -1,68 +1,80 @@
-import graphqlRequest from '../../modules/graphql-request.js';
+import APIQuery from '../../modules/api-query.js';
 
-const doFetchMaps = async (language, prebuild = false) => {
-    const query = `{
-        maps(lang: ${language}) {
-            id
-            tarkovDataId
-            name
-            normalizedName
-            wiki
-            description
-            enemies
-            raidDuration
-            players
-            bosses {
-                name
-                normalizedName
-                spawnChance
-                spawnLocations {
-                    name
-                    chance
-                }
-                escorts {
-                    name
-                    normalizedName
-                    amount {
-                        count
-                        chance
-                    }
-                }
-                spawnTime
-                spawnTimeRandom
-                spawnTrigger
-            }
-        }
-    }`;
-
-    const mapsData = await graphqlRequest(query);
-
-    if (mapsData.errors) {
-        if (mapsData.data) {
-            for (const error of mapsData.errors) {
-                let badItem = false;
-                if (error.path) {
-                    badItem = mapsData.data;
-                    for (let i = 0; i < 2; i++) {
-                        badItem = badItem[error.path[i]];
-                    }
-                }
-                console.log(`Error in maps API query: ${error.message}`);
-                if (badItem) {
-                    console.log(badItem)
-                }
-            }
-        }
-        // only throw error if this is for prebuild or data wasn't returned
-        if (
-            prebuild || !mapsData.data || 
-            !mapsData.data.maps || !mapsData.data.maps.length
-        ) {
-            return Promise.reject(new Error(mapsData.errors[0].message));
-        }
+class MapsQuery extends APIQuery {
+    constructor() {
+        super('maps');
     }
 
-    return mapsData.data.maps;
+    async query(language, prebuild = false) {
+        const query = `{
+            maps(lang: ${language}) {
+                id
+                tarkovDataId
+                name
+                normalizedName
+                wiki
+                description
+                enemies
+                raidDuration
+                players
+                bosses {
+                    name
+                    normalizedName
+                    spawnChance
+                    spawnLocations {
+                        name
+                        chance
+                    }
+                    escorts {
+                        name
+                        normalizedName
+                        amount {
+                            count
+                            chance
+                        }
+                    }
+                    spawnTime
+                    spawnTimeRandom
+                    spawnTrigger
+                }
+            }
+        }`;
+    
+        const mapsData = await this.graphqlRequest(query);
+    
+        if (mapsData.errors) {
+            if (mapsData.data) {
+                for (const error of mapsData.errors) {
+                    let badItem = false;
+                    if (error.path) {
+                        badItem = mapsData.data;
+                        for (let i = 0; i < 2; i++) {
+                            badItem = badItem[error.path[i]];
+                        }
+                    }
+                    console.log(`Error in maps API query: ${error.message}`);
+                    if (badItem) {
+                        console.log(badItem)
+                    }
+                }
+            }
+            // only throw error if this is for prebuild or data wasn't returned
+            if (
+                prebuild || !mapsData.data || 
+                !mapsData.data.maps || !mapsData.data.maps.length
+            ) {
+                return Promise.reject(new Error(mapsData.errors[0].message));
+            }
+        }
+    
+        return mapsData.data.maps;
+    }
+}
+
+const mapsQuery = new MapsQuery();
+
+const doFetchMaps = async (language, prebuild = false) => {
+    return mapsQuery.run(language, prebuild);
 };
 
 export default doFetchMaps;

--- a/src/features/meta/do-fetch-meta.js
+++ b/src/features/meta/do-fetch-meta.js
@@ -1,68 +1,80 @@
-import graphqlRequest from '../../modules/graphql-request.js';
+import APIQuery from '../../modules/api-query.js';
 
-const doFetchMeta = async (language, prebuild = false) => {
-    const query = `{
-        fleaMarket(lang: ${language}) {
-            name
-            normalizedName
-            enabled
-            minPlayerLevel
-            sellOfferFeeRate
-            sellRequirementFeeRate
-        }
-        armorMaterials(lang: ${language}) {
-            id
-            name
-            destructibility
-            minRepairDegradation
-            maxRepairDegradation
-            minRepairKitDegradation
-            maxRepairKitDegradation
-        }
-        itemCategories(lang: ${language}) {
-            id
-            name
-            normalizedName
-            parent {
-                id
-            }
-        }
-    }`;
-
-    const metaData = await graphqlRequest(query);
-
-    if (metaData.errors) {
-        if (metaData.data) {
-            for (const error of metaData.errors) {
-                let badItem = false;
-                if (error.path) {
-                    let traverseLimit = 2;
-                    if (error.path[0] === 'fleaMarket') {
-                        traverseLimit = 1;
-                    }
-                    badItem = metaData.data;
-                    for (let i = 0; i < traverseLimit; i++) {
-                        badItem = badItem[error.path[i]];
-                    }
-                }
-                console.log(`Error in meta API query: ${error.message}`, error.path);
-                if (badItem) {
-                    console.log(badItem)
-                }
-            }
-        }
-        // only throw error if this is for prebuild or data wasn't returned
-        if (
-            prebuild || !metaData.data || 
-            !metaData.data.fleaMarket || 
-            !metaData.data.armorMaterials || !metaData.data.armorMaterials.length || 
-            !metaData.data.itemCategories || !metaData.data.itemCategories.length
-        ) {
-            return Promise.reject(new Error(metaData.errors[0].message));
-        }
+class MetaQuery extends APIQuery {
+    constructor() {
+        super('meta');
     }
 
-    return {flea: metaData.data.fleaMarket, armor: metaData.data.armorMaterials, categories: metaData.data.itemCategories};
+    async query(language, prebuild = false) {
+        const query = `{
+            fleaMarket(lang: ${language}) {
+                name
+                normalizedName
+                enabled
+                minPlayerLevel
+                sellOfferFeeRate
+                sellRequirementFeeRate
+            }
+            armorMaterials(lang: ${language}) {
+                id
+                name
+                destructibility
+                minRepairDegradation
+                maxRepairDegradation
+                minRepairKitDegradation
+                maxRepairKitDegradation
+            }
+            itemCategories(lang: ${language}) {
+                id
+                name
+                normalizedName
+                parent {
+                    id
+                }
+            }
+        }`;
+    
+        const metaData = await this.graphqlRequest(query);
+    
+        if (metaData.errors) {
+            if (metaData.data) {
+                for (const error of metaData.errors) {
+                    let badItem = false;
+                    if (error.path) {
+                        let traverseLimit = 2;
+                        if (error.path[0] === 'fleaMarket') {
+                            traverseLimit = 1;
+                        }
+                        badItem = metaData.data;
+                        for (let i = 0; i < traverseLimit; i++) {
+                            badItem = badItem[error.path[i]];
+                        }
+                    }
+                    console.log(`Error in meta API query: ${error.message}`, error.path);
+                    if (badItem) {
+                        console.log(badItem)
+                    }
+                }
+            }
+            // only throw error if this is for prebuild or data wasn't returned
+            if (
+                prebuild || !metaData.data || 
+                !metaData.data.fleaMarket || 
+                !metaData.data.armorMaterials || !metaData.data.armorMaterials.length || 
+                !metaData.data.itemCategories || !metaData.data.itemCategories.length
+            ) {
+                return Promise.reject(new Error(metaData.errors[0].message));
+            }
+        }
+    
+        return {flea: metaData.data.fleaMarket, armor: metaData.data.armorMaterials, categories: metaData.data.itemCategories};
+    }
+}
+
+const metaQuery = new MetaQuery();
+
+const doFetchMeta = async (language, prebuild = false) => {
+    return metaQuery.run(language, prebuild);
 };
 
 export default doFetchMeta;

--- a/src/features/quests/do-fetch-quests.js
+++ b/src/features/quests/do-fetch-quests.js
@@ -1,319 +1,331 @@
-import graphqlRequest from '../../modules/graphql-request.js';
+import APIQuery from '../../modules/api-query.js';
 
-const doFetchQuests = async (language, prebuild = false) => {
-    const query = `{
-        tasks(lang: ${language}) {
+class QuestsQuery extends APIQuery {
+    constructor() {
+        super('quests');
+    }
+
+    async query(language, prebuild = false) {
+        const query = `{
+            tasks(lang: ${language}) {
+                id
+                tarkovDataId
+                name
+                normalizedName
+                trader {
+                    id
+                    name
+                    normalizedName
+                }
+                map {
+                    id
+                    name
+                    normalizedName
+                }
+                experience
+                wikiLink
+                minPlayerLevel
+                taskRequirements {
+                    task {
+                        id
+                    }
+                    status
+                }
+                traderRequirements {
+                    trader {
+                        id
+                        name
+                    }
+                    requirementType
+                    compareMethod
+                    value
+                }
+                restartable
+                objectives {
+                    ...TaskObjectiveInfo
+                }
+                failConditions {
+                    ...TaskObjectiveInfo
+                }
+                startRewards {
+                    traderStanding {
+                        trader {
+                            id
+                        }
+                        standing
+                    }
+                    items {
+                        item {
+                            id
+                            containsItems {
+                                item {
+                                    id
+                                }
+                                count
+                            }
+                        }
+                        count
+                        attributes {
+                            name
+                            value
+                        }
+                    }
+                    offerUnlock {
+                        trader {
+                            id
+                        }
+                        level
+                        item {
+                            id
+                        }
+                    }
+                    skillLevelReward {
+                        name
+                        level
+                    }
+                    traderUnlock {
+                        id
+                    }
+                }
+                finishRewards {
+                    traderStanding {
+                        trader {
+                            id
+                        }
+                        standing
+                    }
+                    items {
+                        item {
+                            id
+                            containsItems {
+                                item {
+                                    id
+                                }
+                                count
+                            }
+                        }
+                        count
+                        attributes {
+                            name
+                            value
+                        }
+                    }
+                    offerUnlock {
+                        trader {
+                            id
+                        }
+                        level
+                        item {
+                            id
+                        }
+                    }
+                    skillLevelReward {
+                        name
+                        level
+                    }
+                    traderUnlock {
+                        id
+                    }
+                }
+                factionName
+                neededKeys {
+                    keys {
+                        id
+                    }
+                    map {
+                        id
+                    }
+                }
+            }
+        }
+        fragment TaskObjectiveInfo on TaskObjective {
+            __typename
             id
-            tarkovDataId
-            name
-            normalizedName
-            trader {
+            type
+            description
+            maps {
                 id
                 name
-                normalizedName
             }
-            map {
-                id
-                name
-                normalizedName
+            optional
+            ...on TaskObjectiveBuildItem {
+                item {
+                    id
+                }
+                containsAll {
+                    id
+                }
+                containsCategory {
+                    id
+                    name
+                    normalizedName
+                }
+                attributes {
+                    name
+                    requirement {
+                        compareMethod
+                        value
+                    }
+                }
             }
-            experience
-            wikiLink
-            minPlayerLevel
-            taskRequirements {
+            ...on TaskObjectiveExperience {
+                healthEffect {
+                    bodyParts
+                    effects
+                    time {
+                        compareMethod
+                        value
+                    }
+                }
+            }
+            ...on TaskObjectiveExtract {
+                exitStatus
+                exitName
+            }
+            ...on TaskObjectiveItem {
+                item {
+                    id
+                }
+                count
+                foundInRaid
+                dogTagLevel
+                maxDurability
+                minDurability
+            }
+            ...on TaskObjectiveMark {
+                markerItem {
+                    id
+                }
+            }
+            ...on TaskObjectivePlayerLevel {
+                playerLevel
+            }
+            ...on TaskObjectiveQuestItem {
+                questItem {
+                    id
+                    name
+                    shortName
+                    width
+                    height
+                    iconLink
+                    gridImageLink
+                    image512pxLink
+                    baseImageLink
+                    image8xLink
+                }
+                count
+            }
+            ...on TaskObjectiveShoot {
+                target
+                count
+                shotType
+                zoneNames
+                bodyParts
+                timeFromHour
+                timeUntilHour
+                usingWeapon {
+                    id
+                }
+                usingWeaponMods {
+                    id
+                }
+                wearing {
+                    id
+                }
+                notWearing {
+                    id
+                }
+                distance {
+                    compareMethod
+                    value
+                }
+                playerHealthEffect {
+                    bodyParts
+                    effects
+                    time {
+                        compareMethod
+                        value
+                    }
+                }
+                enemyHealthEffect {
+                    bodyParts
+                    effects
+                    time {
+                        compareMethod
+                        value
+                    }
+                }
+            }
+            ...on TaskObjectiveSkill {
+                skillLevel {
+                    name
+                    level
+                }
+            }
+            ...on TaskObjectiveTaskStatus {
                 task {
                     id
                 }
                 status
             }
-            traderRequirements {
+            ...on TaskObjectiveTraderLevel {
                 trader {
                     id
-                    name
                 }
-                requirementType
-                compareMethod
-                value
-            }
-            restartable
-            objectives {
-                ...TaskObjectiveInfo
-            }
-            failConditions {
-                ...TaskObjectiveInfo
-            }
-            startRewards {
-                traderStanding {
-                    trader {
-                        id
-                    }
-                    standing
-                }
-                items {
-                    item {
-                        id
-                        containsItems {
-                            item {
-                                id
-                            }
-                            count
-                        }
-                    }
-                    count
-                    attributes {
-                        name
-                        value
-                    }
-                }
-                offerUnlock {
-                    trader {
-                        id
-                    }
-                    level
-                    item {
-                        id
-                    }
-                }
-                skillLevelReward {
-                    name
-                    level
-                }
-                traderUnlock {
-                    id
-                }
-            }
-            finishRewards {
-                traderStanding {
-                    trader {
-                        id
-                    }
-                    standing
-                }
-                items {
-                    item {
-                        id
-                        containsItems {
-                            item {
-                                id
-                            }
-                            count
-                        }
-                    }
-                    count
-                    attributes {
-                        name
-                        value
-                    }
-                }
-                offerUnlock {
-                    trader {
-                        id
-                    }
-                    level
-                    item {
-                        id
-                    }
-                }
-                skillLevelReward {
-                    name
-                    level
-                }
-                traderUnlock {
-                    id
-                }
-            }
-            factionName
-            neededKeys {
-                keys {
-                    id
-                }
-                map {
-                    id
-                }
-            }
-        }
-    }
-    fragment TaskObjectiveInfo on TaskObjective {
-        __typename
-        id
-        type
-        description
-        maps {
-            id
-            name
-        }
-        optional
-        ...on TaskObjectiveBuildItem {
-            item {
-                id
-            }
-            containsAll {
-                id
-            }
-            containsCategory {
-                id
-                name
-                normalizedName
-            }
-            attributes {
-                name
-                requirement {
-                    compareMethod
-                    value
-                }
-            }
-        }
-        ...on TaskObjectiveExperience {
-            healthEffect {
-                bodyParts
-                effects
-                time {
-                    compareMethod
-                    value
-                }
-            }
-        }
-        ...on TaskObjectiveExtract {
-            exitStatus
-            exitName
-        }
-        ...on TaskObjectiveItem {
-            item {
-                id
-            }
-            count
-            foundInRaid
-            dogTagLevel
-            maxDurability
-            minDurability
-        }
-        ...on TaskObjectiveMark {
-            markerItem {
-                id
-            }
-        }
-        ...on TaskObjectivePlayerLevel {
-            playerLevel
-        }
-        ...on TaskObjectiveQuestItem {
-            questItem {
-                id
-                name
-                shortName
-                width
-                height
-                iconLink
-                gridImageLink
-                image512pxLink
-                baseImageLink
-                image8xLink
-            }
-            count
-        }
-        ...on TaskObjectiveShoot {
-            target
-            count
-            shotType
-            zoneNames
-            bodyParts
-            timeFromHour
-            timeUntilHour
-            usingWeapon {
-                id
-            }
-            usingWeaponMods {
-                id
-            }
-            wearing {
-                id
-            }
-            notWearing {
-                id
-            }
-            distance {
-                compareMethod
-                value
-            }
-            playerHealthEffect {
-                bodyParts
-                effects
-                time {
-                    compareMethod
-                    value
-                }
-            }
-            enemyHealthEffect {
-                bodyParts
-                effects
-                time {
-                    compareMethod
-                    value
-                }
-            }
-        }
-        ...on TaskObjectiveSkill {
-            skillLevel {
-                name
                 level
             }
-        }
-        ...on TaskObjectiveTaskStatus {
-            task {
-                id
+            ...on TaskObjectiveTraderStanding {
+                trader {
+                    id
+                }
+                compareMethod
+                value
             }
-            status
-        }
-        ...on TaskObjectiveTraderLevel {
-            trader {
-                id
+            ...on TaskObjectiveUseItem {
+                useAny {
+                    id
+                }
+                compareMethod
+                count
+                zoneNames
             }
-            level
-        }
-        ...on TaskObjectiveTraderStanding {
-            trader {
-                id
-            }
-            compareMethod
-            value
-        }
-        ...on TaskObjectiveUseItem {
-            useAny {
-                id
-            }
-            compareMethod
-            count
-            zoneNames
-        }
-    }`;
-
-    const questsData = await graphqlRequest(query);
-
-    if (questsData.errors) {
-        if (questsData.data) {
-            for (const error of questsData.errors) {
-                let badItem = false;
-                if (error.path) {
-                    badItem = questsData.data;
-                    for (let i = 0; i < 2; i++) {
-                        badItem = badItem[error.path[i]];
+        }`;
+    
+        const questsData = await this.graphqlRequest(query);
+    
+        if (questsData.errors) {
+            if (questsData.data) {
+                for (const error of questsData.errors) {
+                    let badItem = false;
+                    if (error.path) {
+                        badItem = questsData.data;
+                        for (let i = 0; i < 2; i++) {
+                            badItem = badItem[error.path[i]];
+                        }
+                    }
+                    console.log(`Error in tasks API query: ${error.message}`);
+                    if (badItem) {
+                        console.log(badItem)
                     }
                 }
-                console.log(`Error in tasks API query: ${error.message}`);
-                if (badItem) {
-                    console.log(badItem)
-                }
+            }
+            // only throw error if this is for prebuild or data wasn't returned
+            if (
+                prebuild || !questsData.data || 
+                !questsData.data.tasks || !questsData.data.tasks.length
+            ) {
+                return Promise.reject(new Error(questsData.errors[0].message));
             }
         }
-        // only throw error if this is for prebuild or data wasn't returned
-        if (
-            prebuild || !questsData.data || 
-            !questsData.data.tasks || !questsData.data.tasks.length
-        ) {
-            return Promise.reject(new Error(questsData.errors[0].message));
-        }
+    
+        return questsData.data.tasks;
     }
+}
 
-    return questsData.data.tasks;
+const questsQuery = new QuestsQuery();
+
+const doFetchQuests = async (language, prebuild = false) => {
+    return questsQuery.run(language, prebuild);
 };
 
 export default doFetchQuests;

--- a/src/features/quests/questsSlice.js
+++ b/src/features/quests/questsSlice.js
@@ -21,7 +21,9 @@ const questsSlice = createSlice({
     extraReducers: (builder) => {
         builder.addCase(fetchQuests.pending, (state, action) => {
             state.status = 'loading';
-            state.quests = questsSlice.getInitialState().quests;
+            if (!state.quests) {
+                state.quests = questsSlice.getInitialState().quests;
+            }
         });
         builder.addCase(fetchQuests.fulfilled, (state, action) => {
             state.status = 'succeeded';

--- a/src/modules/api-query.js
+++ b/src/modules/api-query.js
@@ -1,0 +1,39 @@
+import graphqlRequest from './graphql-request.js';
+
+class APIQuery {
+    constructor(queryName) {
+        this.name = queryName;
+        this.pendingQuery = false;
+    }
+
+    graphqlRequest(queryString) {
+        return graphqlRequest(queryString);
+    }
+
+    async query() {
+        return Promise.reject('Not implemented');
+    }
+
+    async run(language, prebuild = false) {
+        if (this.pendingQuery) {
+            return this.pendingQuery;
+        }
+        let resolvePending, rejectPending;
+        this.pendingQuery = new Promise((resolve, reject) => {
+            resolvePending = resolve;
+            rejectPending = reject;
+        });
+        try {
+            const result = await this.query(language, prebuild);
+            resolvePending(result);
+            this.pendingQuery = false;
+            return result;
+        } catch (error) {
+            rejectPending(error);
+            this.pendingQuery = false;
+            return Promise.reject(error);
+        }
+    }
+}
+
+export default APIQuery;

--- a/src/pages/bitcoin-farm-calculator/data.js
+++ b/src/pages/bitcoin-farm-calculator/data.js
@@ -1,5 +1,6 @@
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { useItemByIdQuery } from '../../features/items/queries';
+import { selectAllItems } from '../../features/items/itemsSlice';
 import {
     selectAllSkills,
     selectAllStations,
@@ -73,13 +74,17 @@ export const getMinBuyFor = (item) => {
 export const useFuelPricePerDay = () => {
     const skills = useSelector(selectAllSkills);
     const stations = useSelector(selectAllStations);
+    const items = useSelector(selectAllItems);
 
-    const { data: metalFuelTankItem } = useItemByIdQuery(MetalFuelTankItemId);
-    const { data: expeditionaryFuelTankItem } = useItemByIdQuery(
-        ExpeditionaryFuelTankItemId,
-    );
+    const metalFuelTankItem = useMemo(() => {
+        return items.find(item => item.id === MetalFuelTankItemId);
+    }, [items]);
 
-    if (!metalFuelTankItem || !expeditionaryFuelTankItem) {
+    const expeditionaryFuelTankItem = useMemo(() => {
+        return items.find(item => item.id === ExpeditionaryFuelTankItemId);
+    }, [items]);
+
+    if (!metalFuelTankItem?.buyFor.length || !expeditionaryFuelTankItem?.buyFor.length) {
         return undefined;
     }
 

--- a/src/pages/bitcoin-farm-calculator/data.js
+++ b/src/pages/bitcoin-farm-calculator/data.js
@@ -71,6 +71,20 @@ export const getMinBuyFor = (item) => {
     return min;
 };
 
+const getBestFuelItem = (items) => {
+    return items.reduce((best, current) => {
+        if (!best) {
+            return current;
+        }
+        const currBuy = getMinBuyFor(current);
+        const bestBuy = getMinBuyFor(best);
+        if (currBuy.priceRUB / current.properties.units < bestBuy.priceRUB / best.properties.units) {
+            return current;
+        }
+        return best;
+    }, false)
+}
+
 export const useFuelPricePerDay = () => {
     const skills = useSelector(selectAllSkills);
     const stations = useSelector(selectAllStations);
@@ -88,7 +102,7 @@ export const useFuelPricePerDay = () => {
         return undefined;
     }
 
-    const fuelItem = metalFuelTankItem;
+    const fuelItem = getBestFuelItem([metalFuelTankItem, expeditionaryFuelTankItem]);
 
     const fuelBuyFor = getMinBuyFor(fuelItem);
     const durationObj = FuelDurations[fuelItem.id];
@@ -107,5 +121,5 @@ export const useFuelPricePerDay = () => {
         durationMs = durationMs * 2;
     }
 
-    return (fuelBuyFor.priceRUB / durationMs) * 1000 * 60 * 60 * 24;
+    return (fuelBuyFor?.priceRUB / durationMs) * 1000 * 60 * 60 * 24;
 };

--- a/src/pages/bitcoin-farm-calculator/profit-info.js
+++ b/src/pages/bitcoin-farm-calculator/profit-info.js
@@ -2,7 +2,7 @@ import { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector, useDispatch } from 'react-redux';
 
-import { fetchItems, selectAllItems } from '../../features/items/itemsSlice'
+import { selectAllItems } from '../../features/items/itemsSlice'
 import { BitcoinItemId, GraphicCardItemId, ProduceBitcoinData } from './data';
 import DataTable from '../../components/data-table';
 import formatPrice from '../../modules/format-price';
@@ -48,26 +48,6 @@ const ProfitInfo = ({ profitForNumCards, showDays = 100, fuelPricePerDay, useBui
     const { t } = useTranslation();
 
     const items = useSelector(selectAllItems);
-    const itemsStatus = useSelector((state) => {
-        return state.items.status;
-    });
-
-    useEffect(() => {
-        let timer = false;
-        if (itemsStatus === 'idle') {
-            dispatch(fetchItems());
-        }
-
-        if (!timer) {
-            timer = setInterval(() => {
-                dispatch(fetchItems());
-            }, 600000);
-        }
-
-        return () => {
-            clearInterval(timer);
-        };
-    }, [itemsStatus, dispatch]);
 
     const bitcoinItem = useMemo(() => {
         return items.find(i => i.id === BitcoinItemId);

--- a/src/pages/bitcoin-farm-calculator/profit-info.js
+++ b/src/pages/bitcoin-farm-calculator/profit-info.js
@@ -8,7 +8,6 @@ import DataTable from '../../components/data-table';
 import formatPrice from '../../modules/format-price';
 import CenterCell from '../../components/center-cell';
 import { getDurationDisplay } from '../../modules/format-duration';
-import { useItemsQuery } from '../../features/items/queries';
 import { selectAllHideoutModules, fetchHideout } from '../../features/hideout/hideoutSlice';
 import { selectAllStations } from '../../features/settings/settingsSlice';
 import { averageWipeLength, currentWipeLength } from '../../modules/wipe-length';
@@ -22,11 +21,6 @@ const cardSlots = {
 
 const ProfitInfo = ({ profitForNumCards, showDays = 100, fuelPricePerDay, useBuildCosts, wipeDaysRemaining }) => {
     const stations = useSelector(selectAllStations);
-
-    const itemsResult = useItemsQuery();
-    const items = useMemo(() => {
-        return itemsResult.data;
-    }, [itemsResult]);
 
     const dispatch = useDispatch();
     const hideout = useSelector(selectAllHideoutModules);
@@ -53,7 +47,7 @@ const ProfitInfo = ({ profitForNumCards, showDays = 100, fuelPricePerDay, useBui
     
     const { t } = useTranslation();
 
-    const itemsSelector = useSelector(selectAllItems);
+    const items = useSelector(selectAllItems);
     const itemsStatus = useSelector((state) => {
         return state.items.status;
     });
@@ -76,12 +70,12 @@ const ProfitInfo = ({ profitForNumCards, showDays = 100, fuelPricePerDay, useBui
     }, [itemsStatus, dispatch]);
 
     const bitcoinItem = useMemo(() => {
-        return itemsSelector.find(i => i.id === BitcoinItemId);
-    }, [itemsSelector]);
+        return items.find(i => i.id === BitcoinItemId);
+    }, [items]);
 
     const graphicCardItem = useMemo(() => {
-        return itemsSelector.find(i => i.id === GraphicCardItemId);
-    }, [itemsSelector]);
+        return items.find(i => i.id === GraphicCardItemId);
+    }, [items]);
 
     const solarCost = useMemo(() => {
         const solar = hideout.find(station => station.normalizedName === 'solar-power');


### PR DESCRIPTION
This PR starts the process of streamlining API queries. Some queries exist both as react-redux selectors (e.g., features/items/itemsSlice.js) and as react-query queries (e.g., features/items/queries.js). If there's a page that uses multiple components and some of them use the react-query method and some use selectors, that could result in multiple API calls of the same query. This PR solves that issue.

I think we should try to standardize to a single way of querying the API. Selectors seem beneficial because they can be aware of the output from other queries and update results as necessary. But completely removing all instances of react-query will require a significant re-work.