### PR TITLE
Cleaner navigation

### DIFF
--- a/src/components/footer/index.js
+++ b/src/components/footer/index.js
@@ -48,17 +48,13 @@ function Footer() {
                     We encourage everyone who can to donate to support the people of Ukraine using the button below.
                 </p>
                 </Trans>
-                <UkraineButton
-                    linkStyle={{
-                        width: '100%',
-                    }}
-                />
+                <UkraineButton large={true}/>
                 <Trans i18nKey={'about-support-collective-p'}>
                 <p>
                     If you'd also like to support this project, you can make a donation and/or become a backer on <a href="https://opencollective.com/tarkov-dev" target="_blank" rel="noopener noreferrer">Open Collective</a>.
                 </p>
                 </Trans>
-                <OpenCollectiveButton />
+                <OpenCollectiveButton large={true}/>
                 <h3>{t('Item Data')}</h3>
                 <p>
                     {t(
@@ -74,26 +70,6 @@ function Footer() {
                         <span>SPT-AKI</span>
                     </a>
                 </p>
-
-                {/*{supporters.map((supporter) => {*/}
-                {/*    if (supporter.name === 'kokarn') {*/}
-                {/*        return null;*/}
-                {/*    }*/}
-
-                {/*    if (!supporter.patreon) {*/}
-                {/*        return null;*/}
-                {/*    }*/}
-
-                {/*    return (*/}
-                {/*        <Supporter*/}
-                {/*            key={`supporter-${supporter.name}`}*/}
-                {/*            name={supporter.name}*/}
-                {/*            github={supporter.github}*/}
-                {/*            patreon={supporter.patreon}*/}
-                {/*            link={supporter.link}*/}
-                {/*        />*/}
-                {/*    );*/}
-                {/*})}*/}
             </div>
             <div className="footer-section-wrapper">
                 <h3>{t('Resources')}</h3>

--- a/src/components/menu/index.js
+++ b/src/components/menu/index.js
@@ -15,11 +15,7 @@ import Collapse from '@mui/material/Collapse';
 import CloseIcon from '@mui/icons-material/Close';
 
 import MenuItem from './MenuItem';
-//import SubMenu from './SubMenu';
-// import PatreonButton from '../patreon-button';
-import UkraineButton from '../ukraine-button';
-//import LoadingSmall from '../loading-small';
-//import { BossListNav } from '../boss-list';
+// import SubMenu from './SubMenu';
 
 import { caliberArrayWithSplit } from '../../modules/format-ammo';
 import categoryPages from '../../data/category-pages.json';
@@ -151,28 +147,6 @@ const Menu = () => {
                             <Icon path={mdiRemote} size={1} className="icon-with-text" />
                         </Link>
                     </li>
-                    <li className="submenu-wrapper" key="menu-ua-donate" data-targetid="ua-donate">
-                        <UkraineButton />
-                    </li>
-                    {/*<li className="only-large">
-                        <PatreonButton
-                            wrapperStyle={{
-                                margin: 0,
-                            }}
-                            linkStyle={{
-                                color: '#fff',
-                                padding: '5px 20px',
-                                alignItems: 'center',
-                            }}
-                        >
-                            {t('Support on Patreon')}
-                            <Icon
-                                path={mdiHeartFlash}
-                                size={1}
-                                className="icon-with-text"
-                            />
-                        </PatreonButton>
-                    </li>*/}
                     <li className="submenu-wrapper" key="menu-ammo" data-targetid="ammo">
                         <Link to="/ammo/">{t('Ammo')}</Link>
                         <ul>

--- a/src/components/open-collective-button/index.js
+++ b/src/components/open-collective-button/index.js
@@ -2,15 +2,16 @@ import { useTranslation } from 'react-i18next';
 import Button from '@mui/material/Button';
 import './index.css';
 
-function OpenCollectiveButton({ linkStyle={width: "100%"} }) {
+function OpenCollectiveButton({ large=false, linkStyle }) {
     const { t } = useTranslation();
 
     return (
         <Button
-            style={linkStyle}
+            style={{...linkStyle, ...(large ? {width: "100%"} : '')}}
             className={'oc-button'}
             variant="contained"
             href="https://opencollective.com/tarkov-dev"
+            target="_blank" rel="noopener noreferrer"
         >
             {t('Donate')}
         </Button>

--- a/src/components/ukraine-button/index.js
+++ b/src/components/ukraine-button/index.js
@@ -2,12 +2,12 @@ import { useTranslation } from 'react-i18next';
 import Button from '@mui/material/Button';
 import './index.css';
 
-function UkraineButton({ onlyLarge, linkStyle, wrapperStyle, text, children }) {
+function UkraineButton({ large=false, linkStyle }) {
     const { t } = useTranslation();
 
     return (
         <Button
-            style={linkStyle}
+            style={{...linkStyle, ...(large ? {width: "100%"} : '')}}
             className={'ua-button'}
             variant="contained"
             href="https://www.icrc.org/en/donate/ukraine"
@@ -16,17 +16,6 @@ function UkraineButton({ onlyLarge, linkStyle, wrapperStyle, text, children }) {
             {t('Support Ukraine')}
         </Button>
     );
-
-    // return (
-    //     <p
-    //         className={`ukraine-wrapper ${onlyLarge ? 'only-large' : ''}`}
-    //         style={wrapperStyle}
-    //     >
-    //         <a href="https://www.icrc.org/en/donate/ukraine" style={linkStyle} target="_blank" rel="noopener noreferrer">
-    //             {children ? children : t('Support Ukraine')}
-    //         </a>
-    //     </p>
-    // );
 }
 
 export default UkraineButton;

--- a/src/pages/about/index.js
+++ b/src/pages/about/index.js
@@ -9,6 +9,7 @@ import { ReactComponent as DiscordIcon } from '../../components/supporter/Discor
 
 import SEO from '../../components/SEO';
 import UkraineButton from '../../components/ukraine-button';
+import OpenCollectiveButton from "../../components/open-collective-button";
 import Contributors from '../../components/contributors';
 
 import './index.css';
@@ -41,12 +42,13 @@ function About() {
                 We encourage everyone who can to donate to support the people of Ukraine using the button below.
             </p>
             </Trans>
-            <UkraineButton />
+            <UkraineButton large={false}/>
             <Trans i18nKey={'about-support-collective-p'}>
             <p>
                 If you'd also like to support this project, you can make a donation and/or become a backer on <a href="https://opencollective.com/tarkov-dev" target="_blank" rel="noopener noreferrer">Open Collective</a>.
             </p>
             </Trans>
+            <OpenCollectiveButton large={false}/>
             <Trans i18nKey={'about-support-more-p'}>
             <p>
                 You can also help by posting bugs, suggesting or implementing new features, improving maps or anything else you can think of that would improve the site.


### PR DESCRIPTION
# Cleaner navigation bar

- Removed support button from nav menu
- Cleanup buttons style
- Added OpenCollectiveButton to the about page

Removed the Support Ukraine button from the navigation menu. It still visible in the footer:
![Screenshot 2023-04-20 at 10 06 57](https://user-images.githubusercontent.com/10927011/233313376-96240c03-aaf1-48c4-bbad-8d5bac7e484d.png)
