### PR TITLE
Cash-sell marking

### DIFF
--- a/src/components/item-cost/index.css
+++ b/src/components/item-cost/index.css
@@ -2,6 +2,10 @@
     display: none;
 }
 
+.item-cost-cash-sell {
+    color: #c89898;
+}
+
 .item-cost-custom-price {
     background-color: #292727;
     border: #9a8866 2px solid;

--- a/src/components/item-cost/index.js
+++ b/src/components/item-cost/index.js
@@ -153,8 +153,7 @@ function ItemCost({
             />
         );
     }
-
-    if (priceType === 'craft') {
+    else if (priceType === 'craft') {
         displayImage = (
             <Icon
                 path={mdiProgressWrench}
@@ -170,6 +169,10 @@ function ItemCost({
                 crafts={crafts}
             />
         );
+    }
+    else if (priceType === 'cash-sell' && !isTool && price !== 0) {
+        displayPrice = <span className='item-cost-cash-sell'>{displayPrice}</span>
+        tooltip = t('This item can only be sold to trader');
     }
 
     return (


### PR DESCRIPTION
# Cash-sell

We now emphasize with a slightly red font and a tooltip that a source for a barter or craft is a cash-sell to trader only (can't be obtained other than in raid)

![Screenshot 2023-05-18 at 12 26 43](https://github.com/the-hideout/tarkov-dev/assets/10927011/1ee71ccf-8dfe-407c-a99c-21aaef1e308a)
