### PR TITLE
Update deployment workflows

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
 
-      - uses: github/branch-deploy@v5.2.2
+      - uses: github/branch-deploy@v6.0.0
         id: branch-deploy
         with:
           admins: the-hideout/core-contributors

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: deployment check
-        uses: github/branch-deploy@v5.2.2
+        uses: github/branch-deploy@v6.0.0
         id: deployment-check
         with:
           merge_deploy_mode: "true" # tells the Action to use the merge commit workflow strategy

--- a/.github/workflows/unlock-on-merge.yml
+++ b/.github/workflows/unlock-on-merge.yml
@@ -1,0 +1,20 @@
+name: Unlock On Merge
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  unlock-on-merge:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: unlock on merge
+        uses: github/branch-deploy@v6.0.0
+        id: unlock-on-merge
+        with:
+          unlock_on_merge_mode: "true" # <-- indicates that this is the "Unlock on Merge Mode" workflow
+          environment_targets: production,development


### PR DESCRIPTION
# Branch Deploy Updates

This pull request updates the **branch-deploy** Action to version [`v6.0.0`](https://github.com/github/branch-deploy/releases/tag/v6.0.0) which now supports auto-releasing "sticky" locks on pull request merge events.