### PR TITLE
Fix to no buyFor trader price

### DIFF
--- a/src/components/small-item-table/index.js
+++ b/src/components/small-item-table/index.js
@@ -1089,7 +1089,7 @@ function SmallItemTable(props) {
             useColumns.push({
                 Header: t('Trader buy'),
                 id: 'traderPrice',
-                accessor: (d) => Number(d.buyFor[0].priceRUB),
+                accessor: (d) => Number(d.buyFor[0]?.priceRUB || 0),
                 Cell: TraderPriceCell,
                 position: traderPrice,
             });


### PR DESCRIPTION
Fix to trader price on item page components section when there is no buy options because either no trader sell the component and (flea is disabled or component is flea banned)