### PR TITLE
Add min price line to price history chart

### DIFF
--- a/src/components/price-graph/index.js
+++ b/src/components/price-graph/index.js
@@ -5,6 +5,7 @@ import {
     VictoryAxis,
     // VictoryTooltip,
     VictoryVoronoiContainer,
+    VictoryLegend,
 } from 'victory';
 import { useTranslation } from 'react-i18next';
 
@@ -14,7 +15,7 @@ import { useQuery } from '../../modules/graphql-request';
 
 import './index.css';
 
-function PriceGraph({ item, itemId, itemChange24 }) {
+function PriceGraph({ item, itemId }) {
     if (item && !itemId) {
         itemId = item.id;
         if (item.properties?.baseItem?.properties?.defaultPreset?.id === item.id) {
@@ -28,6 +29,7 @@ function PriceGraph({ item, itemId, itemChange24 }) {
         `{
             historicalItemPrices(id:"${itemId}"){
                 price
+                priceMin
                 timestamp
             }
         }`,
@@ -38,7 +40,7 @@ function PriceGraph({ item, itemId, itemChange24 }) {
         height = 1280;
     }
 
-    if (status !== 'success') {
+    if (status !== 'success' || !data?.data?.historicalItemPrices) {
         return null;
     }
 
@@ -48,20 +50,21 @@ function PriceGraph({ item, itemId, itemChange24 }) {
 
     let max = 0;
 
-    data.data.historicalItemPrices.map((price) => {
+    data.data.historicalItemPrices.forEach((price) => {
         if (price.price > max) {
             max = price.price;
         }
-
-        return true;
     });
+
+    const avgDown = data.data.historicalItemPrices[0].price > data.data.historicalItemPrices[data.data.historicalItemPrices.length-1].price;
+    const minDown = data.data.historicalItemPrices[0].priceMin > data.data.historicalItemPrices[data.data.historicalItemPrices.length-1].priceMin;
 
     return (
         <div className="price-history-wrapper">
             <VictoryChart
                 height={height}
                 width={1280}
-                padding={{ top: 20, left: 15, right: -100, bottom: 30 }}
+                padding={{ top: 20, left: 15, right: 15, bottom: 30 }}
                 minDomain={{ y: 0 }}
                 maxDomain={{ y: max + max * 0.1 }}
                 theme={VictoryTheme.material}
@@ -93,7 +96,7 @@ function PriceGraph({ item, itemId, itemChange24 }) {
                     }}
                     style={{
                         data: {
-                            stroke: itemChange24 < 0.0 ? '#c43a31' : '#3b9c3a',
+                            stroke: avgDown ? '#c43a31' : '#3b9c3a',
                         },
                         parent: { border: '1px solid #ccc' },
                     }}
@@ -101,6 +104,26 @@ function PriceGraph({ item, itemId, itemChange24 }) {
                         return {
                             x: new Date(Number(pricePoint.timestamp)),
                             y: pricePoint.price,
+                        };
+                    })}
+                />
+                <VictoryLine
+                    padding={{ right: -120 }}
+                    scale={{
+                        x: 'time',
+                        y: 'linear',
+                    }}
+                    style={{
+                        data: {
+                            stroke: minDown ? '#c43a31' : '#3b9c3a',
+                            strokeDasharray: 5
+                        },
+                        parent: { border: '1px solid #ccc' },
+                    }}
+                    data={data.data.historicalItemPrices.map((pricePoint) => {
+                        return {
+                            x: new Date(Number(pricePoint.timestamp)),
+                            y: pricePoint.priceMin,
                         };
                     })}
                 />

--- a/src/components/price-graph/index.js
+++ b/src/components/price-graph/index.js
@@ -5,7 +5,6 @@ import {
     VictoryAxis,
     // VictoryTooltip,
     VictoryVoronoiContainer,
-    VictoryLegend,
 } from 'victory';
 import { useTranslation } from 'react-i18next';
 
@@ -56,6 +55,13 @@ function PriceGraph({ item, itemId }) {
         }
     });
 
+    const min = data.data.historicalItemPrices.reduce((curMin, p) => {
+        if (p.priceMin < curMin) {
+            return p.priceMin;
+        }
+        return curMin;
+    }, Number.MAX_SAFE_INTEGER);
+
     const avgDown = data.data.historicalItemPrices[0].price > data.data.historicalItemPrices[data.data.historicalItemPrices.length-1].price;
     const minDown = data.data.historicalItemPrices[0].priceMin > data.data.historicalItemPrices[data.data.historicalItemPrices.length-1].priceMin;
 
@@ -65,7 +71,7 @@ function PriceGraph({ item, itemId }) {
                 height={height}
                 width={1280}
                 padding={{ top: 20, left: 15, right: 15, bottom: 30 }}
-                minDomain={{ y: 0 }}
+                minDomain={{ y: min - min * 0.1 }}
                 maxDomain={{ y: max + max * 0.1 }}
                 theme={VictoryTheme.material}
                 containerComponent={

--- a/src/pages/item/index.js
+++ b/src/pages/item/index.js
@@ -607,7 +607,6 @@ The max profitable price is impacted by the intel center and hideout management 
                         <h2>{t('Flea price last 7 days')}</h2>
                         <PriceGraph
                             item={currentItemData}
-                            itemChange24={currentItemData.changeLast48h}
                         />
                         <br />
                         <div className={`text-and-image-information-wrapper price-info-wrapper`}>


### PR DESCRIPTION
![image](https://github.com/the-hideout/tarkov-dev/assets/35779878/c3642b9e-8ebd-43b5-bca7-f0ee7a084ab1)

The average price line is solid (as previously), and the new minimum price line is dashed.

Previously, the price line would be red or green depending on if the price had gone down or up in the last two days. This changes it so that each line are either red or green depending on if the average or minimum price has gone up or down from the start of the graph to the end of the graph.

Also makes the minimum for the chart dynamic to show a better range for items with a higher price floor:
![image](https://github.com/the-hideout/tarkov-dev/assets/35779878/838ba63f-e0b7-4d12-9575-60e55db2f524)
