### PR TITLE
Grouped Dependabot Changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,11 @@ updates:
     schedule:
       interval: "monthly"
       
-  - package-ecosystem: "github-actions"
+  - package-ecosystem: github-actions
     directory: "/"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     schedule:
-      interval: "monthly"
+      interval: monthly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,20 @@
 # Please see the documentation for all configuration options:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
+---
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-      
   - package-ecosystem: github-actions
     directory: "/"
     groups:
       github-actions:
+        patterns:
+          - "*"
+    schedule:
+      interval: monthly
+  - package-ecosystem: npm
+    directory: "/"
+    groups:
+      npm-dependencies:
         patterns:
           - "*"
     schedule:


### PR DESCRIPTION
This pull request enables the `group` dependabot feature so that similar dependencies can be grouped together into a single pull request

https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/