### PR TITLE
Support alternate items in task objectives

### DIFF
--- a/src/components/quest-items-cell/index.js
+++ b/src/components/quest-items-cell/index.js
@@ -30,6 +30,7 @@ function QuestItemsCell({ questItems }) {
                     <div className="amount-wrapper">
                         {t('Amount')}
                         <span>:</span> {questItem.count.toLocaleString()}
+                        {questItem.alternates ? ` (${t('has alternates')})` : ''}
                     </div>
                     <div className="reward-type-wrapper">
                         {

--- a/src/components/quest-table/index.js
+++ b/src/components/quest-table/index.js
@@ -19,7 +19,7 @@ import './index.css';
 
 export function getRequiredQuestItems(quest, itemFilter = false) {
     const requiredItems = [];
-    const addItem = (item, count = 1, foundInRaid = false) => {
+    const addItem = (item, count = 1, foundInRaid = false, alternates = false) => {
         if (itemFilter && item.id !== itemFilter) {
             return;
         }
@@ -28,15 +28,19 @@ export function getRequiredQuestItems(quest, itemFilter = false) {
             req = {
                 item: item,
                 count: 0,
-                foundInRaid: foundInRaid
+                foundInRaid: foundInRaid,
+                alternates: alternates
             };
             requiredItems.push(req);
         }
         req.count += count;
     };
     quest.objectives.forEach((objectiveData) => {
-        if (objectiveData.item?.id && objectiveData.type !== 'findItem') {
-            addItem(objectiveData.item, objectiveData.count || 1, objectiveData.foundInRaid);
+        if (objectiveData.items && objectiveData.type !== 'findItem') {
+            const alternates = objectiveData.items.length > 1;
+            for (const objItem of objectiveData.items) {
+                addItem(objItem, objectiveData.count || 1, objectiveData.foundInRaid, alternates);
+            }
         }
         if (objectiveData.markerItem?.id) {
             addItem(objectiveData.markerItem);

--- a/src/features/quests/do-fetch-quests.mjs
+++ b/src/features/quests/do-fetch-quests.mjs
@@ -135,7 +135,7 @@ class QuestsQuery extends APIQuery {
                 count
             }
             ...on TaskObjectiveItem {
-                item {
+                items {
                     id
                 }
                 count

--- a/src/pages/quest/index.js
+++ b/src/pages/quest/index.js
@@ -526,7 +526,7 @@ function Quest() {
             );
         }
         if (objective.type === 'plantItem') {
-            let item = items.find((i) => i.id === objective.item.id);
+            let item = items.find((i) => i.id === objective.items[0].id);
             if (!item)
                 return null;
             if (item.properties?.defaultPreset) {

--- a/src/translations/en/translation.json
+++ b/src/translations/en/translation.json
@@ -577,5 +577,7 @@
     "achievements-page-description": "This page includes information on the achievements that can be earned.",
     "Description": "Description",
     "Hidden": "Hidden",
-    "Player %": "Player %"
+    "Player %": "Player %",
+    "has alternates": "has alternates",
+    "{{itemCount}}x any of": "{{itemCount}}x any of"
 }


### PR DESCRIPTION
Some tasks support turning in different items. This uses an API update to show the alternate items.

It also shows player level objectives, which were not previously handled.
Before:
![image](https://github.com/the-hideout/tarkov-dev/assets/35779878/a617e354-cb13-40e3-9bbb-495e3820c4dd)

After:
![image](https://github.com/the-hideout/tarkov-dev/assets/35779878/37e5342a-2a6a-465f-b336-2ee1f240c717)
