### PR TITLE
Exclude flea presets from trader spending table

### DIFF
--- a/src/components/small-item-table/index.js
+++ b/src/components/small-item-table/index.js
@@ -841,7 +841,9 @@ function SmallItemTable(props) {
         useBarterIngredients,
         useCraftIngredients,
         minPenetration,
-        maxPenetration
+        maxPenetration,
+        traderValue,
+        traderBuyback,
     ]);
     const lowHydrationCost = useMemo(() => {
         if (!totalEnergyCost && !provisionValue) {

--- a/src/components/small-item-table/index.js
+++ b/src/components/small-item-table/index.js
@@ -352,6 +352,8 @@ function SmallItemTable(props) {
                         return false;
                     if (!showAllSources && settings.useTarkovTracker && buyFor.vendor.taskUnlock && !settings.completedQuests.includes(buyFor.vendor.taskUnlock.id)) 
                         return false;
+                    if (buyFor.vendor.normalizedName === 'flea-market' && traderValue && traderBuyback && itemData.types.includes('preset'))
+                        return false;
                     return true;
                 }),
                 sellFor: itemData.sellFor,


### PR DESCRIPTION
Sometimes presets are randomly found on the flea. But because they cannot be reliably purchased on the flea, they are not useful to include in the trader spending tables. This removes them from that context.

Before:
![image](https://github.com/the-hideout/tarkov-dev/assets/35779878/cadf419f-f172-4df1-9625-2c60b155bf0e)

After:
![image](https://github.com/the-hideout/tarkov-dev/assets/35779878/df265d8c-fd2f-4c34-ac62-84f9dc7de0b9)
