### PR TITLE
fix coordinate incorrectly displaying x: then z::

### DIFF
--- a/src/pages/map/index.js
+++ b/src/pages/map/index.js
@@ -549,13 +549,13 @@ function Map() {
 
         L.control.coordinates({
             decimals: 2,
-            labelTemplateLat: 'z: {y}',
+            labelTemplateLat: 'y: {y}',
             labelTemplateLng: 'x: {x}',
             enableUserInput: false,
             wrapCoordinate: false,
             position: 'bottomright',
             customLabelFcn: (latLng, opts) => {
-                return `x: ${latLng.lng.toFixed(2)} z: ${latLng.lat.toFixed(2)}`;
+                return `x: ${latLng.lng.toFixed(2)} y: ${latLng.lat.toFixed(2)}`;
             }
         }).addTo(map);
 


### PR DESCRIPTION
<!-- 

⚠️ IMPORTANT ⚠️

- Please fill in all sections [in brackets]
- Please read the collapsible sections if you need help
- All comments in fenced brackets like this one are comments and will not be displayed

Please delete any sections below which you do not need to fill out. You may keep the collapsibe "help" section

-->

# [Fixed coordinate bug]

<!-- REQUIRED: Place a short description of your change here -->

## Description 🗒️

The coordinates on the map were incorrectly showing x: and z: changed it to x: and y:
 
<!-- OPTIONAL: Place a long form description of your change here if necessary - describe why your change is needed -->

## Examples 📸
![image](https://github.com/the-hideout/tarkov-dev/assets/66975848/b7bb52f7-551e-46fa-8c13-67e2959f655a)
![image](https://github.com/the-hideout/tarkov-dev/assets/66975848/15bc14e7-034b-48eb-9277-6803999751b4)

<!-- OPTIONAL: Screenshots with examples for your changes if they are UI related -->

## Related Issues 🔗

<!-- OPTIONAL: If this PR fixes, closes, or resolves an issue; please link that issue here -->

---

<details>
<summary> Expand for Help </summary>

- Have questions about the review or deployment process? View our [contributing docs](https://github.com/the-hideout/tarkov-dev/blob/main/CONTRIBUTING.md)
- Need additional help and want to chat in real time? Join our [community Discord](https://discord.gg/XPAsKGHSzH)

> By submitting this pull request, you agree to our [code of conduct](https://github.com/the-hideout/tarkov-dev/blob/main/CODE_OF_CONDUCT.md)

</details>
