### PR TITLE
add grids for new backpacks

### DIFF
--- a/src/data/item-grids.json
+++ b/src/data/item-grids.json
@@ -2920,5 +2920,83 @@
             "width": 1,
             "height": 1
         }
+    ],
+    "656ddcf0f02d7bcea90bf395": [
+        {
+            "row": 0,
+            "col": 0,
+            "width": 1,
+            "height": 3
+        },
+        {
+            "row": 0,
+            "col": 1,
+            "width": 3,
+            "height": 3
+        },
+        {
+            "row": 0,
+            "col": 4,
+            "width": 1,
+            "height": 3
+        },
+        {
+            "row": 3,
+            "col": 0,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 3,
+            "col": 1,
+            "width": 3,
+            "height": 2
+        },
+        {
+            "row": 3,
+            "col": 4,
+            "width": 1,
+            "height": 2
+        }
+    ],
+    "656f198fb27298d6fd005466": [
+        {
+            "row": 0,
+            "col": 0,
+            "width": 5,
+            "height": 3
+        },
+        {
+            "row": 3,
+            "col": 0,
+            "width": 2,
+            "height": 2
+        },
+        {
+            "row": 3,
+            "col": 2,
+            "width": 3,
+            "height": 2
+        }
+    ],
+    "656e0436d44a1bb4220303a0": [
+        {
+            "row": 0,
+            "col": 0,
+            "width": 3,
+            "height": 4
+        },
+        {
+            "row": 0,
+            "col": 3,
+            "width": 3,
+            "height": 4
+        },
+        {
+            "row": 4,
+            "col": 0,
+            "width": 6,
+            "height": 2
+        }
     ]
 }

--- a/src/features/items/do-fetch-items.mjs
+++ b/src/features/items/do-fetch-items.mjs
@@ -484,14 +484,22 @@ class ItemsQuery extends APIQuery {
 
             if (rawItem.properties?.grids) {
                 let gridPockets = [];
-                for (const grid of rawItem.properties.grids) {
+                if (rawItem.properties.grids.length === 1) {
+                    gridPockets.push({
+                        row: 0,
+                        col: 0,
+                        width: rawItem.properties.grids[0].width,
+                        height: rawItem.properties.grids[0].height,
+                    });
+                }
+                /*for (const grid of rawItem.properties.grids) {
                     gridPockets.push({
                         row: gridPockets.length,
                         col: 0,
                         width: grid.width,
                         height: grid.height,
                     });
-                }
+                }*/
                 /*let gridPockets = [
                     {
                         row: 0,
@@ -521,9 +529,9 @@ class ItemsQuery extends APIQuery {
                 }
 
                 // Rigs we haven't configured shouldn't break
-                if (!itemGrids[rawItem.id] && !rawItem.types.includes('backpack')) {
+                /*if (!itemGrids[rawItem.id] && !rawItem.types.includes('backpack')) {
                     grid = false;
-                }
+                }*/
             }
 
             const container = rawItem.properties?.slots || rawItem.properties?.grids;


### PR DESCRIPTION
Adds missing grids for 3 new backpacks.

Also changes things so that if a backpack/rig is missing a grid configuration (and it doesn't have only one pocket), the pockets are omitted rather than displaying a weird overlapping view of the pockets.