### PR TITLE
Added Basic Locations for Woods

### DIFF
--- a/src/data/maps.json
+++ b/src/data/maps.json
@@ -1827,7 +1827,83 @@
                 "author": "Shebuka",
                 "authorLink": "https://github.com/TarkovTracker/tarkovdata/",
                 "svgPath": "https://assets.tarkov.dev/maps/svg/Woods.svg",
-                "tilePath": "https://assets.tarkov.dev/maps/woods/main/{z}/{x}/{y}.png"
+                "tilePath": "https://assets.tarkov.dev/maps/woods/main/{z}/{x}/{y}.png",
+                "labels": [
+                    {
+                        "position": [10,-3],
+                        "text": "Sawmill"
+                    },
+                    {
+                        "position": [-485,-390],
+                        "text": "Scav Town"
+                    },
+                    {
+                        "position": [-517,-210],
+                        "text": "Old Sawmill"
+                    },
+                    {
+                        "position": [-80,-680],
+                        "text": "Cultist Village"
+                    },
+                    {
+                        "position": [290, -475],
+                        "text": "USEC Camp"
+                    },
+                    {
+                        "position": [-188,235],
+                        "text": "Military Camp"
+                    },
+                    {
+                        "position": [-5,-515],
+                        "text": "Ponds",
+                        "size": 80
+                    },
+                    {
+                        "position": [-252,-37],
+                        "text": "Crash Site",
+                        "size": 80
+                    },
+                    {
+                        "position": [239,-65],
+                        "text": "Checkpoint",
+                        "size": 70
+                    },
+                    {
+                        "position": [244,125],
+                        "text": "Shack",
+                        "size": 70
+                    },
+                    {
+                        "position": [-16,-122],
+                        "text": "Lumber",
+                        "size": 70
+                    },
+                    {
+                        "position": [-3,-74],
+                        "text": "Cabins",
+                        "size": 70
+                    },
+                    {
+                        "position": [-234,357],
+                        "text": "Bus Stop",
+                        "size": 70
+                    },
+                    {
+                        "position": [-327, 19],
+                        "text": "Jaeger's Camp",
+                        "size": 70
+                    },
+                    {
+                        "position": [85, -147],
+                        "text": "Sniper Rock",
+                        "size": 70
+                    },
+                    {
+                        "position": [200,-606],
+                        "text": "Convoy",
+                        "size": 70
+                    }
+                ]
             },
             {
                 "key": "woods-2d",


### PR DESCRIPTION
<!-- 

⚠️ IMPORTANT ⚠️

- Please fill in all sections [in brackets]
- Please read the collapsible sections if you need help
- All comments in fenced brackets like this one are comments and will not be displayed

Please delete any sections below which you do not need to fill out. You may keep the collapsibe "help" section

-->

# [Added Basic Locations for Woods]

<!-- REQUIRED: Place a short description of your change here -->

## Description 🗒️
Added following locations for Woods:

- Sawmill
- Scav Town
- Old Sawmill
- Cultist Village
- USEC Camp
- Military Camp
- Ponds
- Crash Site
- Checkpoint
- Shack
- Lumber
- Cabins
- Bus Stop
- Jaeger's Camp
- Sniper Rock
- Convoy

<!-- OPTIONAL: Place a long form description of your change here if necessary - describe why your change is needed -->

## Examples 📸
![image](https://github.com/the-hideout/tarkov-dev/assets/9431091/3756dc7c-268d-4212-a501-0c4a2430721f)

<!-- OPTIONAL: Screenshots with examples for your changes if they are UI related -->

## Related Issues 🔗
https://github.com/the-hideout/tarkov-dev/issues/840
<!-- OPTIONAL: If this PR fixes, closes, or resolves an issue; please link that issue here -->

---

<details>
<summary> Expand for Help </summary>

- Have questions about the review or deployment process? View our [contributing docs](https://github.com/the-hideout/tarkov-dev/blob/main/CONTRIBUTING.md)
- Need additional help and want to chat in real time? Join our [community Discord](https://discord.gg/XPAsKGHSzH)

> By submitting this pull request, you agree to our [code of conduct](https://github.com/the-hideout/tarkov-dev/blob/main/CODE_OF_CONDUCT.md)

</details>
