### PR TITLE
missing icon

### DIFF
--- a/src/pages/bitcoin-farm-calculator/index.js
+++ b/src/pages/bitcoin-farm-calculator/index.js
@@ -14,6 +14,7 @@ import StationSkillTraderSetting from '../../components/station-skill-trader-set
 
 import formatPrice from '../../modules/format-price.js';
 import { averageWipeLength, currentWipeLength } from '../../modules/wipe-length.js';
+import useHideoutData from '../../features/hideout/index.js';
 
 import {
     BitcoinItemId,
@@ -31,6 +32,9 @@ import './index.css';
 
 const BitcoinFarmCalculator = () => {
     const { t } = useTranslation();
+
+    const { data: hideout } = useHideoutData();
+    const solar = hideout.find(station => station.normalizedName === 'solar-power');
 
     const [graphicCardsCount, setGraphicCardsCount] = useStateWithLocalStorage(
         'num-graphic-cards',
@@ -110,8 +114,9 @@ const BitcoinFarmCalculator = () => {
                         type="skill"
                     />
                     <StationSkillTraderSetting
-                        stateKey={'solar-power'}
+                        stateKey={solar.normalizedName}
                         type="station"
+                        image={solar.imageLink}
                     />
                     <ToggleFilter
                         label={t('Use fuel cost: {{price}}/day', {


### PR DESCRIPTION
# missing icon
fix for the missing solar-power-icon in 'Bitcoin Farm Calculator' tab

## Description 🗒️

<!-- OPTIONAL: Place a long form description of your change here if necessary - describe why your change is needed -->

## Examples 📸
### before
![image](https://github.com/the-hideout/tarkov-dev/assets/52860350/f9a4faec-52b0-4de8-a167-fa7d0c6dcd27)

### after
![image](https://github.com/the-hideout/tarkov-dev/assets/52860350/7e695e1d-63c6-4a9b-9246-568c5898d9cc)

## Related Issues 🔗

<!-- OPTIONAL: If this PR fixes, closes, or resolves an issue; please link that issue here -->