### PR TITLE
Validate characters for player search

### DIFF
--- a/src/pages/player/index.js
+++ b/src/pages/player/index.js
@@ -114,7 +114,9 @@ function Player() {
         if (isNaN(accountId)) {
             try {
                 const searchResponse = await playerStats.searchPlayers(accountId, turnstileToken);
-                turnstileRef.current?.reset();
+                if (turnstileRef.current?.reset) {
+                    turnstileRef.current.reset();
+                }
                 for (const result of searchResponse) {
                     if (result.name.toLowerCase() === accountId.toLowerCase()) {
                         navigate('/player/'+result.aid);
@@ -129,7 +131,9 @@ function Player() {
         }
         try {
             setPlayerData(await playerStats.getProfile(accountId, turnstileToken));
-            turnstileRef.current?.reset();
+            if (turnstileRef.current?.reset) {
+                turnstileRef.current.reset();
+            }
         } catch (error) {
             setProfileError(error.message);
         }
@@ -862,7 +866,21 @@ function Player() {
                         
                     )}
                 </h1>
-                <Turnstile ref={turnstileRef} className="turnstile-widget" siteKey='0x4AAAAAAAVVIHGZCr2PPwrR' onSuccess={setTurnstileToken} options={{appearance: 'interaction-only'}} />
+                <Turnstile
+                    ref={turnstileRef}
+                    className="turnstile-widget"
+                    siteKey='0x4AAAAAAAVVIHGZCr2PPwrR'
+                    onSuccess={setTurnstileToken}
+                    onError={(errorCode) => {
+                        // https://developers.cloudflare.com/turnstile/reference/client-side-errors#error-codes
+                        if (errorCode === '110200') {
+                            setProfileError(`Turnstile error: ${window.location.hostname} is not a valid hostname`);
+                        } else {
+                            setProfileError(`Turnstile error code ${errorCode}`);
+                        }
+                    }}
+                    options={{appearance: 'interaction-only'}}
+                />
             </div>
             <div>
                 {!!playerData.saved && (

--- a/src/pages/players/index.js
+++ b/src/pages/players/index.js
@@ -58,7 +58,9 @@ function Players() {
             setNameResults([]);
             setNameResultsError(error.message);
         }
-        turnstileRef.current.reset();
+        if (turnstileRef.current?.reset) {
+            turnstileRef.current.reset();
+        }
     }, [nameFilter, searchTextValid, setNameResults, setNameResultsError, turnstileToken, turnstileRef]);
 
     const searchResults = useMemo(() => {
@@ -137,7 +139,21 @@ function Players() {
                 </div>
             )}
             {!nameResultsError && searchResults}
-            <Turnstile ref={turnstileRef} className="turnstile-widget" siteKey='0x4AAAAAAAVVIHGZCr2PPwrR' onSuccess={setTurnstileToken} options={{appearance: 'interaction-only'}} />
+            <Turnstile 
+                ref={turnstileRef}
+                className="turnstile-widget"
+                siteKey='0x4AAAAAAAVVIHGZCr2PPwrR'
+                onSuccess={setTurnstileToken}
+                onError={(errorCode) => {
+                    // https://developers.cloudflare.com/turnstile/reference/client-side-errors#error-codes
+                    if (errorCode === '110200') {
+                        setNameResultsError(`Turnstile error: ${window.location.hostname} is not a valid hostname`);
+                    } else {
+                        setNameResultsError(`Turnstile error code ${errorCode}`);
+                    }
+                }}
+                options={{appearance: 'interaction-only'}}
+            />
         </div>,
     ];
 }

--- a/src/pages/players/index.js
+++ b/src/pages/players/index.js
@@ -33,8 +33,19 @@ function Players() {
     const [searched, setSearched] = useState(false);
     const [turnstileToken, setTurnstileToken] = useState();
 
+    const searchTextValid = useMemo(() => {
+        const charactersValid = nameFilter.match(/^[a-zA-Z0-9-_]*$/);
+        const lengthValid = nameFilter.length >= 3 && nameFilter.length <= 15;
+        setButtonDisabled(!charactersValid || !lengthValid);
+        setNameResultsError(false);
+        if (!charactersValid) {
+            setNameResultsError(`Names can only contain letters, numbers, dashes (-), and underscores (_)`);
+        }
+        return charactersValid && lengthValid;
+    }, [nameFilter, setButtonDisabled, setNameResultsError]);
+
     const searchForName = useCallback(async () => {
-        if (nameFilter.length < 3 || nameFilter.length > 15) {
+        if (searchTextValid) {
             return;
         }
         try {
@@ -48,7 +59,7 @@ function Players() {
             setNameResultsError(error.message);
         }
         turnstileRef.current.reset();
-    }, [nameFilter, setNameResults, setNameResultsError, turnstileToken, turnstileRef]);
+    }, [nameFilter, searchTextValid, setNameResults, setNameResultsError, turnstileToken, turnstileRef]);
 
     const searchResults = useMemo(() => {
         if (!searched) {
@@ -116,7 +127,6 @@ function Players() {
                     onChange={(event) => {
                         let newNameFilter = event.target.value;
                         setNameFilter(newNameFilter);
-                        setButtonDisabled(newNameFilter.length < 3 || newNameFilter.length > 15);
                     }}
                 />
                 <button className="search-button" onClick={searchForName} disabled={isButtonDisabled || turnstileToken === undefined}>{t('Search')}</button>

--- a/src/pages/players/index.js
+++ b/src/pages/players/index.js
@@ -34,7 +34,7 @@ function Players() {
     const [turnstileToken, setTurnstileToken] = useState();
 
     const searchTextValid = useMemo(() => {
-        const charactersValid = nameFilter.match(/^[a-zA-Z0-9-_]*$/);
+        const charactersValid = !!nameFilter.match(/^[a-zA-Z0-9-_]*$/);
         const lengthValid = nameFilter.length >= 3 && nameFilter.length <= 15;
         setButtonDisabled(!charactersValid || !lengthValid);
         setNameResultsError(false);
@@ -45,7 +45,7 @@ function Players() {
     }, [nameFilter, setButtonDisabled, setNameResultsError]);
 
     const searchForName = useCallback(async () => {
-        if (searchTextValid) {
+        if (!searchTextValid) {
             return;
         }
         try {


### PR DESCRIPTION
Player search now validates allowed characters for name searching, and displays an error if invalid characters are used.
![image](https://github.com/the-hideout/tarkov-dev/assets/35779878/7a379ad7-a109-4715-8841-bb0ed8abd83f)

Also catches errors in the turnstile widget component and shows appropriate errors.
