### PR TITLE
Fix for #906 bug (Filter by caliber table height doesnt fit items inside properly)

### DIFF
--- a/src/components/Graph.jsx
+++ b/src/components/Graph.jsx
@@ -212,7 +212,7 @@ const Graph = (props) => {
         <VictoryChart
             domainPadding={10}
             padding={chartPadding}
-            height={180}
+            height={185}
             theme={VictoryTheme.material}
             minDomain={chartMinDomain}
             maxDomain={chartMaxDomain}


### PR DESCRIPTION
# Fix for [#906](https://github.com/the-hideout/tarkov-dev/issues/908)  bug (Filter by caliber table height doesnt fit items inside properly)

<!-- REQUIRED: Place a short description of your change here -->

## Description 🗒️

Height of "VictoryChart" component in Graph.jsx adjusted to fix it.

## Examples 📸

![imagen](https://github.com/the-hideout/tarkov-dev/assets/99326312/dec4d3a3-f5a2-4a85-846b-75aa04b5fc29)
