### PR TITLE
Make ammo chart height dynamic

### DIFF
--- a/src/components/Graph.jsx
+++ b/src/components/Graph.jsx
@@ -212,7 +212,7 @@ const Graph = (props) => {
         <VictoryChart
             domainPadding={10}
             padding={chartPadding}
-            height={185}
+            height={Math.max((props.legendData.length * 7) + 17, 180)}
             theme={VictoryTheme.material}
             minDomain={chartMinDomain}
             maxDomain={chartMaxDomain}


### PR DESCRIPTION
When additional calibers are added, the bottom of the ammo chart legend gets cut off. This should make the height dynamic depending on how many different calibers there are.

Resolves #908 