### PR TITLE
Use polyfill for ResizeObserver

### DIFF
--- a/src/components/item-image/index.js
+++ b/src/components/item-image/index.js
@@ -5,6 +5,7 @@ import ImageViewer from 'react-simple-image-viewer';
 import { useTranslation } from 'react-i18next';
 import Tippy from '@tippyjs/react';
 import 'tippy.js/dist/tippy.css';
+import ResizeObserver from 'resize-observer-polyfill';
 
 import './index.css';
 

--- a/src/pages/map/index.js
+++ b/src/pages/map/index.js
@@ -6,6 +6,7 @@ import {
     TransformWrapper,
     TransformComponent,
 } from 'react-zoom-pan-pinch';
+import ResizeObserver from 'resize-observer-polyfill';
 
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';

--- a/src/pages/player/index.js
+++ b/src/pages/player/index.js
@@ -714,7 +714,7 @@ function Player() {
             }
         }
         if (loadoutItem.upd?.Repairable) {
-            countLabel = `${loadoutItem.upd.Repairable.Durability}/${loadoutItem.upd.Repairable.MaxDurability}`
+            countLabel = `${loadoutItem.upd.Repairable.Durability.toFixed(2)}/${loadoutItem.upd.Repairable.MaxDurability}`
         }
         if (loadoutItem.upd?.MedKit) {
             const item = items.find(i => i.id === loadoutItem._tpl);


### PR DESCRIPTION
ResizeObserver isn't available in older browsers. We already have a polyfill package installed, but it wasn't being used everywhere ResizeObserver is being used. This PR corrects that.