### PR TITLE
Improve TarkovCitizen name searches

### DIFF
--- a/src/pages/players/index.js
+++ b/src/pages/players/index.js
@@ -33,7 +33,7 @@ function Players() {
 
     const searchTextValid = useMemo(() => {
         const charactersValid = !!nameFilter.match(/^[a-zA-Z0-9-_]*$/);
-        const lengthValid = nameFilter.length >= 3 && nameFilter.length <= 15;
+        const lengthValid = !!nameFilter.match(/^[a-zA-Z0-9-_]{3,15}$|^TarkovCitizen\d{1,10}$/i);
         setButtonDisabled(!charactersValid || !lengthValid);
         setNameResultsError(false);
         if (!charactersValid) {


### PR DESCRIPTION
There are accounts created/renamed by BSG that are TarkovCitizen###### where the number is the account number. These names are longer than the names typically allowed, and the current player search only allows searching for names up to 15 characters. This change enables longer name searches for TarkovCitizen accounts.

Resolves #919 