### PR TITLE
Better filtering of buyback items

### DIFF
--- a/src/components/small-item-table/index.js
+++ b/src/components/small-item-table/index.js
@@ -355,7 +355,7 @@ function SmallItemTable(props) {
                         return false;
                     if (!showAllSources && settings.useTarkovTracker && buyFor.vendor.taskUnlock && !settings.completedQuests.includes(buyFor.vendor.taskUnlock.id)) 
                         return false;
-                    if (buyFor.vendor.normalizedName === 'flea-market' && traderValue && traderBuyback && itemData.types.includes('preset'))
+                    if (buyFor.vendor.normalizedName === 'flea-market' && traderValue && traderBuyback && (itemData.types.includes('preset') || itemData.lastOfferCount < 2))
                         return false;
                     return true;
                 }),

--- a/src/features/items/do-fetch-items.mjs
+++ b/src/features/items/do-fetch-items.mjs
@@ -36,6 +36,7 @@ class ItemsQuery extends APIQuery {
                     low24hPrice
                     high24hPrice
                     lastLowPrice
+                    lastOfferCount
                     gridImageLink
                     iconLink
                     baseImageLink


### PR DESCRIPTION
When showing items to buy and sell back to a trader to increase that trader's spend, we had been filtering weapon presets from the flea because presets show up rarely and cannot be counted on to buy and sell to the traders. Now, in addition to filtering presets, it also filters any items where the last offer count was less than 2. This will further filter out items that aren't reliably on the flea market.