### PR TITLE
increase z-index of data-table thead elements

### DIFF
--- a/src/components/data-table/index.css
+++ b/src/components/data-table/index.css
@@ -20,6 +20,10 @@
     top: 0;
 }
 
+.data-table thead {
+    z-index: 1;
+}
+
 .data-table tbody tr {
     height: 69px;
 }


### PR DESCRIPTION
# Increase the z-index of data-table `thead` elements

I'm unsure if it is intentional, but on the `TASKS` table the trader images scroll overtop the table header. Thought I'd offer a simple PR in case the behavior is in fact a bug. Tested on Chrome, Edge and Firefox. I verified the fix on other pages, but I may have missed some tables.

## Examples 📸
Before:
![Screenshot 2024-06-17 192913](https://github.com/the-hideout/tarkov-dev/assets/13973880/587970c5-4744-4a6a-87a6-4ad8a56fa32d)

After:
![Screenshot 2024-06-17 192935](https://github.com/the-hideout/tarkov-dev/assets/13973880/bdccff36-1454-4525-8dc4-bcb10c484bdb)
