### PR TITLE
Fix crash when loading tasks page from scratch

### DIFF
--- a/src/components/quest-table/index.js
+++ b/src/components/quest-table/index.js
@@ -470,6 +470,9 @@ function QuestTable({
                     return <CenterCell>
                         {props.row.original.finishRewards.traderStanding.map(reward => {
                             const trader = traders.find(t => t.id === reward.trader.id);
+                            if (!trader) {
+                                return '';
+                            }
                             return <TraderImage
                                 trader={trader}
                                 reputationChange={reward.standing}


### PR DESCRIPTION
When the user is using the site in PVE mode, the tasks page would crash when it was the first page loaded on the site.