### PR TITLE
Issue #1000 Responsive design changes and element overhaul to Player Loadout in tarkov.dev/players/* pages

### DIFF
--- a/src/components/item-image/index.js
+++ b/src/components/item-image/index.js
@@ -1,32 +1,33 @@
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
-import {renderToStaticMarkup} from "react-dom/server";
-import { Link, useNavigate } from "react-router-dom";
+import { renderToStaticMarkup } from 'react-dom/server';
+import { Link, useNavigate } from 'react-router-dom';
 import ImageViewer from 'react-simple-image-viewer';
 import { useTranslation } from 'react-i18next';
 import Tippy from '@tippyjs/react';
 import 'tippy.js/dist/tippy.css';
 import ResizeObserver from 'resize-observer-polyfill';
+import useResponsiveScaling from '../../hooks/useResponsiveScaling.jsx';
 
 import './index.css';
 
 const colors = {
-    black: {r: 0, g: 0, b: 0, alpha: 77/255},
-    blue: {r: 28, g: 65, b: 86, alpha: 77/255},
-    default: {r: 127, g: 127, b: 127, alpha: 77/255},
-    green: {r: 21, g: 45, b: 0, alpha: 77/255},
-    grey: {r: 29, g: 29, b: 29, alpha: 77/255},
-    orange: {r: 60, g: 25, b: 0, alpha: 77/255},
-    red: {r: 109, g: 36, b: 24, alpha: 77/255},
-    violet: {r: 76, g: 42, b: 85, alpha: 77/255},
-    yellow: {r: 104, g: 102, b: 40, alpha: 77/255},
+    black: { r: 0, g: 0, b: 0, alpha: 77 / 255 },
+    blue: { r: 28, g: 65, b: 86, alpha: 77 / 255 },
+    default: { r: 127, g: 127, b: 127, alpha: 77 / 255 },
+    green: { r: 21, g: 45, b: 0, alpha: 77 / 255 },
+    grey: { r: 29, g: 29, b: 29, alpha: 77 / 255 },
+    orange: { r: 60, g: 25, b: 0, alpha: 77 / 255 },
+    red: { r: 109, g: 36, b: 24, alpha: 77 / 255 },
+    violet: { r: 76, g: 42, b: 85, alpha: 77 / 255 },
+    yellow: { r: 104, g: 102, b: 40, alpha: 77 / 255 },
 };
 
-function ItemImage({ 
-    item, 
-    backgroundScale = 1, 
-    imageField = 'baseImageLink', 
-    nonFunctionalOverlay = false, 
-    imageViewer = false, 
+function ItemImage({
+    item,
+    backgroundScale = 1,
+    imageField = 'baseImageLink',
+    nonFunctionalOverlay = false,
+    imageViewer = false,
     children = '',
     attributes = [],
     count,
@@ -57,7 +58,8 @@ function ItemImage({
     }, []);*/
 
     const refImage = useRef();
-    const [imageDimensions, setImageDimensions] = useState({ width: 0, height: 0});
+    const scaler = useResponsiveScaling();
+    const [imageDimensions, setImageDimensions] = useState({ width: 0, height: 0 });
     useEffect(() => {
         if (!refImage.current) {
             return;
@@ -66,7 +68,10 @@ function ItemImage({
             if (!refImage.current) {
                 return;
             }
-            if (refImage.current.width === imageDimensions.width && refImage.current.height === imageDimensions.height) {
+            if (
+                refImage.current.width === imageDimensions.width &&
+                refImage.current.height === imageDimensions.height
+            ) {
                 return;
             }
             setImageDimensions({
@@ -74,7 +79,7 @@ function ItemImage({
                 height: refImage.current.height,
             });
         });
-        const intersectionObserver = new IntersectionObserver(entries => {
+        const intersectionObserver = new IntersectionObserver((entries) => {
             if (!refImage.current) {
                 return;
             }
@@ -95,13 +100,11 @@ function ItemImage({
             return <></>;
         }
         const loadingStyle = {
-            WebkitMask:`url(${item[imageField]}) center/cover`,
-                  mask:`url(${item[imageField]}) center/cover`,
+            WebkitMask: `url(${item[imageField]}) center/cover`,
+            mask: `url(${item[imageField]}) center/cover`,
         };
-        
-        return (
-            <div className="item-image-mask" style={loadingStyle}></div>
-        );
+
+        return <div className="item-image-mask" style={loadingStyle}></div>;
     }, [item, imageField]);
 
     const [isViewerOpen, setIsViewerOpen] = useState(false);
@@ -110,7 +113,7 @@ function ItemImage({
             return;
         }
         setIsViewerOpen(true);
-      }, [imageViewer]);
+    }, [imageViewer]);
     const closeImageViewer = () => {
         setIsViewerOpen(false);
     };
@@ -130,20 +133,32 @@ function ItemImage({
             imageStyle.cursor = 'zoom-in';
         }
         //console.log(dimensions);
-        const img = <img ref={refImage} onClick={openImageViewer} src={item[imageField]} alt={item.name} loading="lazy" style={imageStyle}/>;
+        if (imageField === 'inspectImageLink') {
+            imageStyle.maxWidth = `100%`;
+            imageStyle.maxHeight = `100%`;
+        }
+
+        const img = (
+            <img
+                ref={refImage}
+                onClick={openImageViewer}
+                src={item[imageField]}
+                alt={item.name}
+                loading="lazy"
+                style={imageStyle}
+            />
+        );
         if (linkToItem && !item.types.includes('quest')) {
-            return <Link to={`/item/${item.normalizedName}`}>
-                {img}
-            </Link>;
+            return <Link to={`/item/${item.normalizedName}`}>{img}</Link>;
         }
         return img;
     }, [item, refImage, imageField, openImageViewer, imageViewer, linkToItem]);
 
     const imageScale = useMemo(() => {
-        const w = imageDimensions.width || (item.width * 63) + 1
-        return w / ((item.width * 63) + 1);
+        const w = imageDimensions.width || item.width * 63 + 1;
+        return w / (item.width * 63 + 1);
     }, [imageDimensions, item]);
-    
+
     const textSize = useMemo(() => {
         return Math.min(12 * imageScale, 16);
     }, [imageScale]);
@@ -158,32 +173,42 @@ function ItemImage({
     }, [item]);
 
     const nonFunctionalElement = useMemo(() => {
-        if (!nonFunctionalOverlay || !item.types.includes('gun') || !item.properties?.defaultPreset) {
+        if (
+            !nonFunctionalOverlay ||
+            !item.types.includes('gun') ||
+            !item.properties?.defaultPreset
+        ) {
             return <></>;
         }
         const nonFunctionalStyle = {
             position: 'absolute',
             boxSizing: 'border-box',
-            top: `${1*backgroundScale}px`, 
-            left: `${1*backgroundScale}px`,
-            height: `calc(100% - ${2*backgroundScale}px)`,
-            width:  `calc(100% - ${2*backgroundScale}px)`,
+            top: `${1 * backgroundScale}px`,
+            left: `${1 * backgroundScale}px`,
+            height: `calc(100% - ${2 * backgroundScale}px)`,
+            width: `calc(100% - ${2 * backgroundScale}px)`,
             fallbacks: [
-                {width: `-webkit-calc(100% - ${2*backgroundScale}px)`},
-                {width:    `-moz-calc(100% - ${2*backgroundScale}px)`},
-                {height: `-webkit-calc(100% - ${2*backgroundScale}px)`},
-                {height:    `-moz-calc(100% - ${2*backgroundScale}px)`},
+                { width: `-webkit-calc(100% - ${2 * backgroundScale}px)` },
+                { width: `-moz-calc(100% - ${2 * backgroundScale}px)` },
+                { height: `-webkit-calc(100% - ${2 * backgroundScale}px)` },
+                { height: `-moz-calc(100% - ${2 * backgroundScale}px)` },
             ],
             backgroundColor: '#4400004f',
         };
         if (imageViewer) {
             nonFunctionalStyle.cursor = 'zoom-in';
         }
-        return <div className='item-nonfunctional-mask' onClick={openImageViewer} style={nonFunctionalStyle}/>;
+        return (
+            <div
+                className="item-nonfunctional-mask"
+                onClick={openImageViewer}
+                style={nonFunctionalStyle}
+            />
+        );
     }, [item, nonFunctionalOverlay, backgroundScale, openImageViewer, imageViewer]);
 
     const toolOverride = useMemo(() => {
-        return isTool || attributes?.some(att => att.name === 'tool');
+        return isTool || attributes?.some((att) => att.name === 'tool');
     }, [attributes, isTool]);
 
     const borderColor = useMemo(() => {
@@ -198,14 +223,12 @@ function ItemImage({
         }
         return color;
     }, [item, toolOverride, nonFunctional]);
-    
-
     const backgroundStyle = useMemo(() => {
         if (imageField === 'iconLink') {
             const iconStyle = {
                 position: 'relative',
                 maxHeight: `${imageDimensions.height || 64}px`,
-                maxWidth:  `${imageDimensions.width || 64}px`,
+                maxWidth: `${imageDimensions.width || 64}px`,
             };
             if (toolOverride || nonFunctional) {
                 iconStyle.outline = `1px solid ${borderColor}`;
@@ -215,55 +238,125 @@ function ItemImage({
         }
         let sizeFactor = 1;
         if (imageField === 'image512pxLink') {
-            sizeFactor = 512 / ((item.width * 63) + 1);
+            sizeFactor = 512 / (item.width * 63 + 1);
             if (item.height > item.width) {
-                sizeFactor = 512 / ((item.height * 63) + 1);
+                sizeFactor = 512 / (item.height * 63 + 1);
             }
         }
         if (imageField === 'image8xLink') {
             sizeFactor = 8;
         }
-        let width = imageDimensions.width || (((item.width * 63) + 1) * sizeFactor);
-        let height = imageDimensions.height || (((item.height * 63) + 1) * sizeFactor);
-        const gridSvg = () => 
+        if (imageField === 'inspectImageLink') {
+            const loadOutImgStyle = {
+                maxHeight: `${175 / scaler}px`,
+                maxWidth: `${256 / scaler}px`,
+                position: 'relative',
+            };
+            return loadOutImgStyle;
+        }
+        let width = imageDimensions.width || (item.width * 63 + 1) * sizeFactor;
+        let height = imageDimensions.height || (item.height * 63 + 1) * sizeFactor;
+        const gridSvg = () => (
             <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%">
                 <defs>
-                    <pattern id="smallChecks" width={2*backgroundScale} height={2*backgroundScale} patternUnits="userSpaceOnUse">
-                        <rect x="0" y="0" width={1*backgroundScale} height={1*backgroundScale} style={{fill:'rgba(29, 29, 29, .62)'}} />
-                        <rect x="0" y={1*backgroundScale} width={1*backgroundScale} height={1*backgroundScale} style={{fill:'rgba(44, 44, 44, .62)'}} />
-                        <rect x={1*backgroundScale} y="0" width={1*backgroundScale} height={1*backgroundScale} style={{fill:'rgba(44, 44, 44, .62)'}} />
-                        <rect x={1*backgroundScale} y={1*backgroundScale} width={1*backgroundScale} height={1*backgroundScale} style={{fill:'rgba(29, 29, 29, .62)'}} />
+                    <pattern
+                        id="smallChecks"
+                        width={2 * backgroundScale}
+                        height={2 * backgroundScale}
+                        patternUnits="userSpaceOnUse"
+                    >
+                        <rect
+                            x="0"
+                            y="0"
+                            width={1 * backgroundScale}
+                            height={1 * backgroundScale}
+                            style={{ fill: 'rgba(29, 29, 29, .62)' }}
+                        />
+                        <rect
+                            x="0"
+                            y={1 * backgroundScale}
+                            width={1 * backgroundScale}
+                            height={1 * backgroundScale}
+                            style={{ fill: 'rgba(44, 44, 44, .62)' }}
+                        />
+                        <rect
+                            x={1 * backgroundScale}
+                            y="0"
+                            width={1 * backgroundScale}
+                            height={1 * backgroundScale}
+                            style={{ fill: 'rgba(44, 44, 44, .62)' }}
+                        />
+                        <rect
+                            x={1 * backgroundScale}
+                            y={1 * backgroundScale}
+                            width={1 * backgroundScale}
+                            height={1 * backgroundScale}
+                            style={{ fill: 'rgba(29, 29, 29, .62)' }}
+                        />
                     </pattern>
                     <pattern id="gridCell" width="100%" height="100%" patternUnits="userSpaceOnUse">
-                        <rect x="0" y="0" width="100%" height="100%" fill="url(#smallChecks)"/>
-                        <line x1="0" x2="0" y1="0" y2="100%" stroke="rgba(50, 50, 50, .75)" strokeWidth={`${2*backgroundScale}`}/>
-                        <line x1="0" x2="100%" y1="0" y2="0" stroke="rgba(50, 50, 50, .75)" strokeWidth={`${2*backgroundScale}`}/>
-                        <rect x="0" y="0" width="100%" height="100%" style={{fill:`rgba(${colorString})`}} />
+                        <rect x="0" y="0" width="100%" height="100%" fill="url(#smallChecks)" />
+                        <line
+                            x1="0"
+                            x2="0"
+                            y1="0"
+                            y2="100%"
+                            stroke="rgba(50, 50, 50, .75)"
+                            strokeWidth={`${2 * backgroundScale}`}
+                        />
+                        <line
+                            x1="0"
+                            x2="100%"
+                            y1="0"
+                            y2="0"
+                            stroke="rgba(50, 50, 50, .75)"
+                            strokeWidth={`${2 * backgroundScale}`}
+                        />
+                        <rect
+                            x="0"
+                            y="0"
+                            width="100%"
+                            height="100%"
+                            style={{ fill: `rgba(${colorString})` }}
+                        />
                     </pattern>
                 </defs>
-                <rect width="100%" height="100%" fill="#000"/>
-                <rect width="100%" height="100%" fill="url(#gridCell)"/>
-            </svg>;
+                <rect width="100%" height="100%" fill="#000" />
+                <rect width="100%" height="100%" fill="url(#gridCell)" />
+            </svg>
+        );
         const backgroundStyle = {
             backgroundImage: `url('data:image/svg+xml,${encodeURIComponent(renderToStaticMarkup(gridSvg()))}')`,
             backgroundSize: `${gridPercentX}% ${gridPercentY}%`,
             position: 'relative',
-            outline: `${1*backgroundScale}px solid ${borderColor}`,
-            outlineOffset: `-${1*backgroundScale}px`,
+            outline: `${1 * backgroundScale}px solid ${borderColor}`,
+            outlineOffset: `-${1 * backgroundScale}px`,
             maxHeight: `${height}px`,
-            maxWidth:  `${width}px`,
+            maxWidth: `${width}px`,
         };
         return backgroundStyle;
-    }, [backgroundScale, borderColor, colorString, imageField, gridPercentX, gridPercentY, item, imageDimensions, toolOverride, nonFunctional]);
+    }, [
+        backgroundScale,
+        borderColor,
+        colorString,
+        imageField,
+        gridPercentX,
+        gridPercentY,
+        item,
+        imageDimensions,
+        toolOverride,
+        nonFunctional,
+        scaler,
+    ]);
 
     const imageTextStyle = useMemo(() => {
         if (imageField === 'iconLink' || item.types.includes('loading')) {
-            return {display: 'none'};
+            return { display: 'none' };
         }
         const style = {
             position: 'absolute',
             top: `${Math.min(backgroundScale + imageScale, 4)}px`,
-            right: `${Math.min(backgroundScale + (1.5*imageScale), 7)}px`,
+            right: `${Math.min(backgroundScale + 1.5 * imageScale, 7)}px`,
             cursor: 'default',
             color: '#a4aeb4',
             fontWeight: 'bold',
@@ -274,8 +367,11 @@ function ItemImage({
         if (linkToItem) {
             style.cursor = 'pointer';
         }
+        if (imageField === 'inspectImageLink') {
+            style.fontSize = `${Math.min(26 / scaler, 20)}px`;
+        }
         return style;
-    }, [imageField, imageScale, textSize, backgroundScale, item, linkToItem]);
+    }, [imageField, imageScale, textSize, backgroundScale, item, linkToItem, scaler]);
 
     const imageTextClick = useMemo(() => {
         if (!linkToItem) {
@@ -287,11 +383,13 @@ function ItemImage({
     }, [item, linkToItem, navigate]);
 
     const imageText = useMemo(() => {
-        let element = <div style={imageTextStyle} onClick={imageTextClick}>{item.shortName}</div>;
-        if (fullNameTooltip && imageTextStyle.dispolay !== 'none') {
-            element = <Tippy content={item.name}>
-                {element}
-            </Tippy>;
+        let element = (
+            <div style={imageTextStyle} onClick={imageTextClick}>
+                {item.shortName}
+            </div>
+        );
+        if (fullNameTooltip && imageTextStyle.display !== 'none') {
+            element = <Tippy content={item.name}>{element}</Tippy>;
         }
         return element;
     }, [fullNameTooltip, imageTextClick, imageTextStyle, item]);
@@ -334,40 +432,52 @@ function ItemImage({
     }, [imageScale, item]);
 
     return (
-        <div ref={refContainer} style={{...backgroundStyle, ...style}} className={className}>
+        <div ref={refContainer} style={{ ...backgroundStyle, ...style }} className={className}>
             {loadingImage}
             {imageElement}
             {nonFunctionalElement}
             {imageText}
             <div style={itemExtraStyle}>
-                {isFIR && <Tippy
-                    placement="bottom"
-                    content={t('Found In Raid')}
-                >
-                    <img alt="" className="item-image-fir" loading="lazy" src={`${process.env.PUBLIC_URL}/images/icon-fir.png`} />
-                </Tippy>}
+                {isFIR && (
+                    <Tippy placement="bottom" content={t('Found In Raid')}>
+                        <img
+                            alt=""
+                            className="item-image-fir"
+                            loading="lazy"
+                            src={`${process.env.PUBLIC_URL}/images/icon-fir.png`}
+                        />
+                    </Tippy>
+                )}
                 {count && <span className="item-image-count">{count}</span>}
             </div>
-            {trader && <div style={traderElementStyle}>
-                <Tippy
-                    placement="top"
-                    content={trader.name}
-                >
-                    <Link to={`/trader/${trader.normalizedName}`}>
-                        <img alt={trader.name} src={`/images/traders/${trader.normalizedName}-icon.jpg`} style={traderImageStyle}/>
-                    </Link>
-                </Tippy>
-            </div>}
-            {station && <div style={traderElementStyle}>
-                <Tippy
-                    placement="top"
-                    content={station.name}
-                >
-                    <Link to={`/hideout-profit/?station=${station.normalizedName}&all=true&search=${item.name}`}>
-                        <img alt={station.name} src={station.imageLink} style={traderImageStyle}/>
-                    </Link>
-                </Tippy>
-            </div>}
+            {trader && (
+                <div style={traderElementStyle}>
+                    <Tippy placement="top" content={trader.name}>
+                        <Link to={`/trader/${trader.normalizedName}`}>
+                            <img
+                                alt={trader.name}
+                                src={`/images/traders/${trader.normalizedName}-icon.jpg`}
+                                style={traderImageStyle}
+                            />
+                        </Link>
+                    </Tippy>
+                </div>
+            )}
+            {station && (
+                <div style={traderElementStyle}>
+                    <Tippy placement="top" content={station.name}>
+                        <Link
+                            to={`/hideout-profit/?station=${station.normalizedName}&all=true&search=${item.name}`}
+                        >
+                            <img
+                                alt={station.name}
+                                src={station.imageLink}
+                                style={traderImageStyle}
+                            />
+                        </Link>
+                    </Tippy>
+                </div>
+            )}
             {children}
             {isViewerOpen && (
                 <ImageViewer
@@ -377,7 +487,7 @@ function ItemImage({
                     disableScroll={true}
                     closeOnClickOutside={true}
                     onClose={closeImageViewer}
-                    style={{                
+                    style={{
                         maxWidth: '100%',
                         maxHeight: '100%',
                     }}

--- a/src/hooks/useResponsiveScaling.jsx
+++ b/src/hooks/useResponsiveScaling.jsx
@@ -1,0 +1,25 @@
+import { useState, useEffect } from 'react';
+
+const useResponsiveScaling = () => {
+    const [scaler, setScaler] = useState(1);
+    useEffect(() => {
+        const adjustScaler = () => {
+            const width = window.innerWidth;
+            if (width >= 1000) {
+                setScaler(1);
+            } else if (width <= 500) {
+                setScaler(2);
+            } else setScaler(1.5);
+        };
+
+        adjustScaler();
+
+        window.addEventListener('resize', adjustScaler, false);
+        return () => {
+            window.removeEventListener('resize', adjustScaler);
+        };
+    }, []);
+    return scaler;
+};
+
+export default useResponsiveScaling;

--- a/src/pages/player/index.css
+++ b/src/pages/player/index.css
@@ -1,41 +1,82 @@
+.css-53rj3a-MuiTreeItem-content {
+    justify-content: center;
+}
+
 .MuiTreeItem-iconContainer {
     width: auto !important;
     justify-content: normal !important;
     margin-right: 0px !important;
+    align-self: center;
+}
+
+.MuiTreeItem-label {
+    width: auto !important;
+    font-size: 16px !important;
+    font-weight: bold !important;
+    word-wrap: break-word;
 }
 
 .inventory {
-    display: flow-root;
+    display: flex;
+    gap: 10px;
+    overflow-y: hidden;
+    overflow-x: scroll;
+    justify-content: center;
+    padding-bottom: 12px;
 }
 
 .grid-container {
     display: grid;
-    float: left;
     gap: 10px;
 }
 
 .grid-container.main {
-    grid-template-columns: auto auto auto;
+    grid-template-columns: repeat(3, minmax(280px, auto));
+    grid-template-rows: repeat(4, minmax(183px, auto));
 }
 
 .grid-container.side {
-    margin-left: 10px;
-    grid-template-columns: auto;
+    grid-template-columns: minmax(280px, auto);
+    grid-template-rows: minmax(183px, auto) 32px repeat(2, minmax(183px, auto));
+    align-self: flex-start;
 }
 
-.grid-container>div {
-    background-color: rgba(0, 0, 0, 0.4);
+.grid-container > div {
+    background-color: rgba(0, 0, 0);
     text-align: center;
     font-size: 20px;
+    clip-path: polygon(0 0, 0 100%, 100% 100%, 100% 24px, 96% 0);
+    font-size: 16px;
+    font-weight: bold;
+}
+
+.gear-slot-label {
+    background-image: linear-gradient(#474747, #000);
+    background-size: 101% 101%;
+    color: #fff;
+    padding: 0 0 5px 5px;
+    width: 100%;
+    text-align: left;
+    font-size: 16px;
+    font-weight: bold;
 }
 
 .weapon {
     grid-column: 1 / span 2;
+    justify-items: center;
+    align-items: center;
+    clip-path: polygon(0 0, 0 100%, 100% 100%, 100% 24px, 98% 0) !important;
+}
+
+.pockets_and_special_slots {
+    clip-path: none !important;
 }
 
 ul.favorite-item-list {
     list-style: none;
     padding: 0px;
+    display: flex;
+    flex-wrap: wrap;
 }
 
 ul.favorite-item-list li {
@@ -51,7 +92,8 @@ ul.favorite-item-list li {
     color: #ffe084;
 }
 
-.banned, .not-banned {
+.banned,
+.not-banned {
     margin-left: 1em;
 }
 
@@ -68,7 +110,7 @@ ul.favorite-item-list li {
 }
 
 .profile-button {
-    padding: .2rem;
+    padding: 0.2rem;
     border-radius: 4px;
     vertical-align: middle;
     margin-left: 20px;
@@ -76,4 +118,41 @@ ul.favorite-item-list li {
 
 .current-wipe-achievement {
     font-weight: bold;
+}
+
+@media screen and (max-width: 1000px) {
+    .grid-container.main {
+        grid-template-columns: repeat(3, minmax(187.7px, auto));
+        grid-template-rows: repeat(4, minmax(122px, auto));
+    }
+
+    .grid-container.side {
+        grid-template-columns: minmax(187.7px, auto);
+        grid-template-rows: minmax(122px, auto) 32px repeat(2, minmax(122px, auto));
+    }
+
+    .inventory {
+        justify-content: flex-start;
+    }
+
+    .gear-slot-label {
+        padding-bottom: 1px;
+        font-size: 14px;
+    }
+}
+
+@media screen and (max-width: 500px) {
+    .grid-container.main {
+        grid-template-columns: repeat(3, minmax(140px, auto));
+        grid-template-rows: repeat(4, minmax(91.5px, auto));
+    }
+
+    .grid-container.side {
+        grid-template-columns: minmax(140px, auto);
+        grid-template-rows: minmax(91.5px, auto) 32px repeat(2, minmax(91.5px, auto));
+    }
+
+    .gear-slot-label {
+        font-size: 12px;
+    }
 }

--- a/src/pages/player/index.js
+++ b/src/pages/player/index.js
@@ -1,7 +1,7 @@
 import { useState, useMemo, useEffect, useCallback, useRef } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { Turnstile } from '@marsidev/react-turnstile'
+//import { Turnstile } from '@marsidev/react-turnstile';   --------------------COMMENTED OUT CLOUDFLARE IS ANNOYING DURING DEV ISSUE #1000---------------------
 import { Icon } from '@mdi/react';
 import {
     mdiAccountDetails,
@@ -39,30 +39,30 @@ function getDHMS(seconds) {
     // calculate (and subtract) whole days
     const secondsPerDay = 24 * 60 * 60;
     const days = Math.floor(seconds / secondsPerDay);
-    seconds -= (days * secondsPerDay);
+    seconds -= days * secondsPerDay;
 
     // calculate (and subtract) whole hours
     const secondsPerHour = secondsPerDay / 24;
     const hours = Math.floor(seconds / secondsPerHour) % 24;
-    seconds -= (hours * secondsPerHour);
+    seconds -= hours * secondsPerHour;
 
     // calculate (and subtract) whole minutes
     const minutes = Math.floor(seconds / 60) % 60;
-    seconds -= (minutes * 60);
+    seconds -= minutes * 60;
 
     return {
         days,
         hours,
         minutes,
         seconds,
-    }
+    };
 }
 
 const raritySort = {
-    "common": 0,
-    "rare": 1,
-    "legendary": 2
-}
+    common: 0,
+    rare: 1,
+    legendary: 2,
+};
 
 const memberFlags = {
     Developer: 1,
@@ -71,11 +71,11 @@ const memberFlags = {
     Sherpa: 256,
     Emissary: 512,
     Unheard: 1024,
-}
+};
 
 function Player() {
     const turnstileRef = useRef();
-    const inputFile = useRef() 
+    const inputFile = useRef();
     const { t } = useTranslation();
     const params = useParams();
     const navigate = useNavigate();
@@ -112,7 +112,7 @@ function Player() {
     const { data: metaData } = useMetaData();
     const { data: achievements } = useAchievementsData();
     const [turnstileToken, setTurnstileToken] = useState();
-    const [ playerBanned, setPlayerBanned ] = useState();
+    const [playerBanned, setPlayerBanned] = useState();
     const bannedButtonRef = useRef();
 
     const fetchProfile = useCallback(async () => {
@@ -125,7 +125,11 @@ function Player() {
         }
         if (isNaN(accountId)) {
             try {
-                const searchResponse = await playerStats.searchPlayers(accountId, gameMode, turnstileToken);
+                const searchResponse = await playerStats.searchPlayers(
+                    accountId,
+                    gameMode,
+                    turnstileToken,
+                );
                 if (turnstileRef.current?.reset) {
                     turnstileRef.current.reset();
                 }
@@ -149,7 +153,15 @@ function Player() {
         } catch (error) {
             setProfileError(error.message);
         }
-    }, [accountId, setPlayerData, setProfileError, navigate, turnstileToken, turnstileRef, gameMode]);
+    }, [
+        accountId,
+        setPlayerData,
+        setProfileError,
+        navigate,
+        turnstileToken,
+        turnstileRef,
+        gameMode,
+    ]);
 
     const checkBanned = useCallback(async () => {
         const token = turnstileRef?.current?.getResponse();
@@ -160,7 +172,11 @@ function Player() {
             return;
         }
         try {
-            const searchResponse = await playerStats.searchPlayers(playerData.info.nickname, gameMode, turnstileToken);
+            const searchResponse = await playerStats.searchPlayers(
+                playerData.info.nickname,
+                gameMode,
+                turnstileToken,
+            );
             if (turnstileRef.current?.reset) {
                 turnstileRef.current.reset();
             }
@@ -172,7 +188,9 @@ function Player() {
             }
             setPlayerBanned(true);
         } catch (error) {
-            console.log(`Error checking banned status for ${playerData.info.nickname}: ${error.message}`);
+            console.log(
+                `Error checking banned status for ${playerData.info.nickname}: ${error.message}`,
+            );
         }
         return false;
     }, [playerData, setPlayerBanned, turnstileToken, turnstileRef, gameMode]);
@@ -182,29 +200,32 @@ function Player() {
             return;
         }
         const element = document.createElement('a');
-        const file = new Blob([JSON.stringify(playerData, null, 4)], {type: 'application/json'});
+        const file = new Blob([JSON.stringify(playerData, null, 4)], { type: 'application/json' });
         element.href = URL.createObjectURL(file);
         element.download = `${playerData.aid}.json`;
         document.body.appendChild(element); // Required for this to work in FireFox
         element.click();
     }, [playerData]);
 
-    const loadProfile = useCallback((e) => {
-        e.preventDefault()
-        const reader = new FileReader();
-        reader.onload = async (e) => { 
-            const text = (e.target.result);
-            try {
-                const data = JSON.parse(text);
-                data.saved = true;
-                setPlayerData(data);
-                window.history.replaceState(null, null, `/players/${gameMode}/${data.aid}`);
-            } catch(error) {
-                setProfileError('Error reading profile');
-            }
-        };
-        reader.readAsText(e.target.files[0]);
-    }, [setPlayerData, setProfileError, gameMode]);
+    const loadProfile = useCallback(
+        (e) => {
+            e.preventDefault();
+            const reader = new FileReader();
+            reader.onload = async (e) => {
+                const text = e.target.result;
+                try {
+                    const data = JSON.parse(text);
+                    data.saved = true;
+                    setPlayerData(data);
+                    window.history.replaceState(null, null, `/players/${gameMode}/${data.aid}`);
+                } catch (error) {
+                    setProfileError('Error reading profile');
+                }
+            };
+            reader.readAsText(e.target.files[0]);
+        },
+        [setPlayerData, setProfileError, gameMode],
+    );
 
     const currentWipe = wipeDetails()[0];
 
@@ -222,7 +243,6 @@ function Player() {
             if (expTotal > playerData.info.experience) {
                 return metaData.playerLevels[i - 1].level;
             }
-
         }
         return metaData.playerLevels[metaData.playerLevels.length - 1].level;
     }, [playerData, metaData]);
@@ -270,24 +290,26 @@ function Player() {
         if (latest === 0) {
             return '';
         }
-        return <div>{t('Last active: {{date}}', {date: new Date(latest * 1000).toLocaleString()})}</div>;
+        return (
+            <div>
+                {t('Last active: {{date}}', { date: new Date(latest * 1000).toLocaleString() })}
+            </div>
+        );
     }, [playerData, t]);
 
     const achievementColumns = useMemo(
         () => [
             {
                 Header: () => (
-                    <div style={{ textAlign: 'left', paddingLeft: '10px' }}>
-                        {t('Name')}
-                    </div>),
+                    <div style={{ textAlign: 'left', paddingLeft: '10px' }}>{t('Name')}</div>
+                ),
                 id: 'name',
                 accessor: 'name',
             },
             {
                 Header: () => (
-                    <div style={{ textAlign: 'left', paddingLeft: '10px' }}>
-                        {t('Description')}
-                    </div>),
+                    <div style={{ textAlign: 'left', paddingLeft: '10px' }}>{t('Description')}</div>
+                ),
                 id: 'description',
                 accessor: 'description',
             },
@@ -296,11 +318,7 @@ function Player() {
                 id: 'playersCompletedPercent',
                 accessor: 'adjustedPlayersCompletedPercent',
                 Cell: (props) => {
-                    return (
-                        <div className="center-content">
-                            {props.value}%
-                        </div>
-                    );
+                    return <div className="center-content">{props.value}%</div>;
                 },
             },
             {
@@ -309,7 +327,9 @@ function Player() {
                 accessor: 'completionDate',
                 Cell: (props) => {
                     return (
-                        <div className={`center-content${new Date(props.value * 1000) > currentWipe.start ? ' current-wipe-achievement' : ''}`}>
+                        <div
+                            className={`center-content${new Date(props.value * 1000) > currentWipe.start ? ' current-wipe-achievement' : ''}`}
+                        >
                             {new Date(props.value * 1000).toLocaleString()}
                         </div>
                     );
@@ -330,7 +350,10 @@ function Player() {
                     let rowAr = raritySort[rowA.original.normalizedRarity];
                     let rowBr = raritySort[rowB.original.normalizedRarity];
                     if (rowAr === rowBr) {
-                        return rowB.original.playersCompletedPercent - rowA.original.playersCompletedPercent
+                        return (
+                            rowB.original.playersCompletedPercent -
+                            rowA.original.playersCompletedPercent
+                        );
                     }
                     return rowAr - rowBr;
                 },
@@ -340,25 +363,25 @@ function Player() {
     );
 
     const achievementsData = useMemo(() => {
-        return achievements?.map(a => {
-            if (!playerData.achievements[a.id]) {
-                return false;
-            }
-            return {
-                ...a,
-                completionDate: playerData.achievements[a.id],
-            }
-        }).filter(Boolean) || [];
+        return (
+            achievements
+                ?.map((a) => {
+                    if (!playerData.achievements[a.id]) {
+                        return false;
+                    }
+                    return {
+                        ...a,
+                        completionDate: playerData.achievements[a.id],
+                    };
+                })
+                .filter(Boolean) || []
+        );
     }, [achievements, playerData]);
 
     const raidsColumns = useMemo(
         () => [
             {
-                Header: (
-                    <div style={{ textAlign: 'left', paddingLeft: '10px' }}>
-                        {t('Side')}
-                    </div>
-                ),
+                Header: <div style={{ textAlign: 'left', paddingLeft: '10px' }}>{t('Side')}</div>,
                 id: 'side',
                 accessor: 'side',
                 Cell: (props) => {
@@ -366,28 +389,20 @@ function Player() {
                 },
             },
             {
-                Header: (
-                    <div style={{ textAlign: 'left', paddingLeft: '10px' }}>
-                        {t('Raids')}
-                    </div>
-                ),
+                Header: <div style={{ textAlign: 'left', paddingLeft: '10px' }}>{t('Raids')}</div>,
                 id: 'raids',
                 accessor: 'raids',
             },
             {
                 Header: (
-                    <div style={{ textAlign: 'left', paddingLeft: '10px' }}>
-                        {t('Survived')}
-                    </div>
+                    <div style={{ textAlign: 'left', paddingLeft: '10px' }}>{t('Survived')}</div>
                 ),
                 id: 'survived',
                 accessor: 'survived',
             },
             {
                 Header: (
-                    <div style={{ textAlign: 'left', paddingLeft: '10px' }}>
-                        {t('Runthrough')}
-                    </div>
+                    <div style={{ textAlign: 'left', paddingLeft: '10px' }}>{t('Runthrough')}</div>
                 ),
                 id: 'runthrough',
                 accessor: 'runthrough',
@@ -396,11 +411,7 @@ function Player() {
                 },
             },
             {
-                Header: (
-                    <div style={{ textAlign: 'left', paddingLeft: '10px' }}>
-                        {t('MIA')}
-                    </div>
-                ),
+                Header: <div style={{ textAlign: 'left', paddingLeft: '10px' }}>{t('MIA')}</div>,
                 id: 'mia',
                 accessor: 'mia',
                 Cell: (props) => {
@@ -408,11 +419,7 @@ function Player() {
                 },
             },
             {
-                Header: (
-                    <div style={{ textAlign: 'left', paddingLeft: '10px' }}>
-                        {t('KIA')}
-                    </div>
-                ),
+                Header: <div style={{ textAlign: 'left', paddingLeft: '10px' }}>{t('KIA')}</div>,
                 id: 'kia',
                 accessor: 'kia',
                 Cell: (props) => {
@@ -420,11 +427,7 @@ function Player() {
                 },
             },
             {
-                Header: (
-                    <div style={{ textAlign: 'left', paddingLeft: '10px' }}>
-                        {t('Kills')}
-                    </div>
-                ),
+                Header: <div style={{ textAlign: 'left', paddingLeft: '10px' }}>{t('Kills')}</div>,
                 id: 'kills',
                 accessor: 'kills',
                 Cell: (props) => {
@@ -445,9 +448,7 @@ function Player() {
             },
             {
                 Header: (
-                    <div style={{ textAlign: 'left', paddingLeft: '10px' }}>
-                        {t('Win Streak')}
-                    </div>
+                    <div style={{ textAlign: 'left', paddingLeft: '10px' }}>{t('Win Streak')}</div>
                 ),
                 id: 'streak',
                 accessor: 'streak',
@@ -463,7 +464,7 @@ function Player() {
         if (!playerData.pmcStats?.eft) {
             return [];
         }
-        const statSides = { 'scavStats': 'Scav', 'pmcStats': 'PMC' };
+        const statSides = { scavStats: 'Scav', pmcStats: 'PMC' };
         const statTypes = [
             {
                 name: 'raids',
@@ -491,8 +492,8 @@ function Player() {
             },
             {
                 name: 'streak',
-                key: ['LongestWinStreak']
-            }
+                key: ['LongestWinStreak'],
+            },
         ];
         const getStats = (side) => {
             return {
@@ -500,7 +501,7 @@ function Player() {
                 ...statTypes.reduce((all, s) => {
                     all[s.name] = 0;
                     return all;
-                }, {})
+                }, {}),
             };
         };
         const totalStats = getStats('Total');
@@ -510,7 +511,9 @@ function Player() {
             const stats = playerData[sideKey].eft.overAllCounters.Items;
             const currentData = getStats(sideLabel);
             for (const st of statTypes) {
-                const foundStat = stats.find(s => !st.key.some(keyPart => !s.Key.includes(keyPart)));
+                const foundStat = stats.find(
+                    (s) => !st.key.some((keyPart) => !s.Key.includes(keyPart)),
+                );
                 currentData[st.name] = foundStat?.Value || 0;
                 totalStats[st.name] += currentData[st.name];
             }
@@ -522,11 +525,7 @@ function Player() {
     const skillsColumns = useMemo(
         () => [
             {
-                Header: (
-                    <div style={{ textAlign: 'left', paddingLeft: '10px' }}>
-                        {t('Skill')}
-                    </div>
-                ),
+                Header: <div style={{ textAlign: 'left', paddingLeft: '10px' }}>{t('Skill')}</div>,
                 id: 'skill',
                 accessor: 'skill',
                 Cell: (props) => {
@@ -534,11 +533,7 @@ function Player() {
                 },
             },
             {
-                Header: (
-                    <div style={{ textAlign: 'left', paddingLeft: '10px' }}>
-                        {t('Level')}
-                    </div>
-                ),
+                Header: <div style={{ textAlign: 'left', paddingLeft: '10px' }}>{t('Level')}</div>,
                 id: 'progress',
                 accessor: 'progress',
                 Cell: (props) => {
@@ -547,9 +542,7 @@ function Player() {
             },
             {
                 Header: (
-                    <div style={{ textAlign: 'left', paddingLeft: '10px' }}>
-                        {t('Last Access')}
-                    </div>
+                    <div style={{ textAlign: 'left', paddingLeft: '10px' }}>{t('Last Access')}</div>
                 ),
                 id: 'lastAccess',
                 accessor: 'lastAccess',
@@ -562,27 +555,26 @@ function Player() {
     );
 
     const skillsData = useMemo(() => {
-        return playerData.skills?.Common?.map(s => {
-            if (!s.Progress || s.LastAccess <= 0) {
-                return false;
-            }
-            const skill = metaData.skills.find(skill => skill.id === s.Id);
-            return {
-                skill: skill?.name || s.Id,
-                progress: s.Progress,
-                lastAccess: s.LastAccess,
-            }
-        }).filter(Boolean) || [];
+        return (
+            playerData.skills?.Common?.map((s) => {
+                if (!s.Progress || s.LastAccess <= 0) {
+                    return false;
+                }
+                const skill = metaData.skills.find((skill) => skill.id === s.Id);
+                return {
+                    skill: skill?.name || s.Id,
+                    progress: s.Progress,
+                    lastAccess: s.LastAccess,
+                };
+            }).filter(Boolean) || []
+        );
     }, [playerData, metaData]);
 
     const masteringColumns = useMemo(
         () => [
             {
                 id: 'expander',
-                Header: ({
-                    getToggleAllRowsExpandedProps,
-                    isAllRowsExpanded,
-                }) =>
+                Header: ({ getToggleAllRowsExpandedProps, isAllRowsExpanded }) =>
                     // <span {...getToggleAllRowsExpandedProps()}>
                     //     {isAllRowsExpanded ? 'v' : '>'}
                     // </span>
@@ -610,30 +602,19 @@ function Player() {
                     ) : null,
             },
             {
-                Header: (
-                    <div style={{ textAlign: 'left', paddingLeft: '10px' }}>
-                        {t('Weapon')}
-                    </div>
-                ),
+                Header: <div style={{ textAlign: 'left', paddingLeft: '10px' }}>{t('Weapon')}</div>,
                 id: 'name',
                 accessor: 'name',
                 Cell: (props) => {
                     if (props.row.original.shortName) {
-                        return (
-                            <ItemNameCell
-                                item={props.row.original}
-                                items={items}
-                            />
-                        );
+                        return <ItemNameCell item={props.row.original} items={items} />;
                     }
                     return props.value;
                 },
             },
             {
                 Header: (
-                    <div style={{ textAlign: 'left', paddingLeft: '10px' }}>
-                        {t('Progress')}
-                    </div>
+                    <div style={{ textAlign: 'left', paddingLeft: '10px' }}>{t('Progress')}</div>
                 ),
                 id: 'Progress',
                 accessor: 'Progress',
@@ -658,37 +639,45 @@ function Player() {
     );
 
     const masteringData = useMemo(() => {
-        return playerData.skills?.Mastering?.map(masteringProgress => {
-            const mastering = metaData.mastering.find(m => m.id === String(masteringProgress.Id));
-            if (!mastering) {
-                return false;
-            }
-            let level = 1;
-            if (masteringProgress.Progress > mastering.level3) {
-                level = 3;
-            } else if (masteringProgress.Progress > mastering.level2) {
-                level = 2;
-            }
-            return {
-                ...masteringProgress,
-                name: masteringProgress.Id,
-                level,
-                subRows: mastering.weapons.map(w => {
-                    const baseItem = items.find(i => i.id === w.id);
-                    if (!baseItem) {
-                        return false;
-                    }
-                    const preset = items.find (i => i.id === baseItem.properties.defaultPreset?.id);
-                    return {
-                        ...baseItem,
-                        itemLink: `/item/${baseItem.normalizedName}`,
-                        iconLink: preset ? preset.iconLink : baseItem.iconLink,
-                        Progress: masteringProgress.Progress,
-                        level,
-                    };
-                }).filter(Boolean),
-            };
-        }).filter(Boolean) || [];
+        return (
+            playerData.skills?.Mastering?.map((masteringProgress) => {
+                const mastering = metaData.mastering.find(
+                    (m) => m.id === String(masteringProgress.Id),
+                );
+                if (!mastering) {
+                    return false;
+                }
+                let level = 1;
+                if (masteringProgress.Progress > mastering.level3) {
+                    level = 3;
+                } else if (masteringProgress.Progress > mastering.level2) {
+                    level = 2;
+                }
+                return {
+                    ...masteringProgress,
+                    name: masteringProgress.Id,
+                    level,
+                    subRows: mastering.weapons
+                        .map((w) => {
+                            const baseItem = items.find((i) => i.id === w.id);
+                            if (!baseItem) {
+                                return false;
+                            }
+                            const preset = items.find(
+                                (i) => i.id === baseItem.properties.defaultPreset?.id,
+                            );
+                            return {
+                                ...baseItem,
+                                itemLink: `/item/${baseItem.normalizedName}`,
+                                iconLink: preset ? preset.iconLink : baseItem.iconLink,
+                                Progress: masteringProgress.Progress,
+                                level,
+                            };
+                        })
+                        .filter(Boolean),
+                };
+            }).filter(Boolean) || []
+        );
     }, [playerData, metaData, items]);
 
     const totalTimeInGame = useMemo(() => {
@@ -701,175 +690,224 @@ function Player() {
             days,
             hours,
             minutes,
-            seconds
+            seconds,
         });
-        return (<p>{`${t('Total account time in game')}: ${formattedTime}`}</p>);
+        return <p>{`${t('Total account time in game')}: ${formattedTime}`}</p>;
     }, [playerData, t]);
 
-    const getItemDisplay = useCallback((loadoutItem, imageOptions = {}) => {
-        let item = items.find(i => i.id === loadoutItem._tpl);
-        if (!item) {
-            return undefined;
-        }
-        if (item.properties?.defaultPreset) {
-            const preset = items.find(i => i.id === item.properties.defaultPreset.id);
-            item = {
-                ...item,
-                width: preset.width,
-                height: preset.height,
-                baseImageLink: preset.baseImageLink,
-            };
-        }
-        let countLabel;
-
-        let label = '';
-        if (loadoutItem.upd?.StackObjectsCount > 1) {
-            countLabel = loadoutItem.upd?.StackObjectsCount;
-        }
-        if (loadoutItem.upd?.Dogtag) {
-            const tag = loadoutItem.upd.Dogtag;
-            const weapon = items.find(i => i.id === tag.WeaponName?.split(' ')[0]);
-            countLabel = tag.Level;
-            let killerInfo = <span>{tag.KillerName}</span>;
-            if (tag.KillerAccountId) {
-                killerInfo = <Link to={`/players/${gameMode}/${tag.KillerAccountId}`}>{tag.KillerName}</Link>;
+    const getItemDisplay = useCallback(
+        (loadoutItem, imageOptions = {}) => {
+            let item = items.find((i) => i.id === loadoutItem._tpl);
+            if (!item) {
+                return undefined;
             }
-            let victimInfo = (
-                <span>{tag.Nickname}</span>
-            );
-            if (tag.AccountId !== '0') {
-                victimInfo = (
-                    <Link to={`/players/${gameMode}/${tag.AccountId}`}>{tag.Nickname}</Link>
+            if (item.properties?.defaultPreset) {
+                const preset = items.find((i) => i.id === item.properties.defaultPreset.id);
+                item = {
+                    ...item,
+                    width: preset.width,
+                    height: preset.height,
+                    inspectImageLink: preset.inspectImageLink,
+                };
+            }
+            let countLabel;
+
+            let label = '';
+            if (loadoutItem.upd?.StackObjectsCount > 1) {
+                countLabel = loadoutItem.upd?.StackObjectsCount;
+            }
+            if (loadoutItem.upd?.Dogtag) {
+                const tag = loadoutItem.upd.Dogtag;
+                const weapon = items.find((i) => i.id === tag.WeaponName?.split(' ')[0]);
+                countLabel = tag.Level;
+                let killerInfo = <span>{tag.KillerName}</span>;
+                if (tag.KillerAccountId) {
+                    killerInfo = (
+                        <Link to={`/players/${gameMode}/${tag.KillerAccountId}`}>
+                            {tag.KillerName}
+                        </Link>
+                    );
+                }
+                let victimInfo = <span>{tag.Nickname}</span>;
+                if (tag.AccountId !== '0') {
+                    victimInfo = (
+                        <Link to={`/players/${gameMode}/${tag.AccountId}`}>{tag.Nickname}</Link>
+                    );
+                }
+                label = (
+                    <span>
+                        {victimInfo}
+                        <span>{` ${t(tag.Status)} `}</span>
+                        {killerInfo}
+                        {weapon !== undefined && [
+                            <span key={'weapon-using-label'}>{` ${t('using')} `}</span>,
+                            <Link
+                                key={`weapon-using ${weapon.id}`}
+                                to={`/item/${weapon.normalizedName}`}
+                            >
+                                {weapon.shortName}
+                            </Link>,
+                        ]}
+                        <div>{` ${new Date(tag.Time).toLocaleString()}`}</div>
+                    </span>
                 );
             }
-            label = (
-                <span>
-                    {victimInfo}
-                    <span>{` ${t(tag.Status)} `}</span>
-                    {killerInfo}
-                    {weapon !== undefined && [
-                        <span key={'weapon-using-label'}>{` ${t('using')} `}</span>,
-                        <Link key={`weapon-using ${weapon.id}`} to={`/item/${weapon.normalizedName}`}>{weapon.shortName}</Link>
-                    ]}
-                    <div>{` ${new Date(tag.Time).toLocaleString()}`}</div>
-                </span>
-            );
-        }
-        if (loadoutItem.upd?.Key) {
-            const key = items.find(i => i.id === loadoutItem._tpl);
-            if (key) {
-                if (key.properties.uses) {
-                    countLabel = `${key.properties.uses - loadoutItem.upd.Key.NumberOfUsages}/${key.properties.uses}`;
-                } else {
-                    countLabel = loadoutItem.upd.Key.NumberOfUsages;
+            if (loadoutItem.upd?.Key) {
+                const key = items.find((i) => i.id === loadoutItem._tpl);
+                if (key) {
+                    if (key.properties.uses) {
+                        countLabel = `${key.properties.uses - loadoutItem.upd.Key.NumberOfUsages}/${key.properties.uses}`;
+                    } else {
+                        countLabel = loadoutItem.upd.Key.NumberOfUsages;
+                    }
                 }
-
             }
-        }
-        if (loadoutItem.upd?.Repairable) {
-            countLabel = `${loadoutItem.upd.Repairable.Durability.toFixed(2)}/${loadoutItem.upd.Repairable.MaxDurability}`
-        }
-        if (loadoutItem.upd?.MedKit) {
-            const item = items.find(i => i.id === loadoutItem._tpl);
-            if (item?.properties?.uses || item?.properties?.hitpoints) {
-                countLabel = `${loadoutItem.upd.MedKit.HpResource}/${item.properties?.uses || item.properties?.hitpoints}`;
+            if (loadoutItem.upd?.Repairable) {
+                countLabel = `${loadoutItem.upd.Repairable.Durability.toFixed(2)}/${loadoutItem.upd.Repairable.MaxDurability}`;
             }
-        }
+            if (loadoutItem.upd?.MedKit) {
+                const item = items.find((i) => i.id === loadoutItem._tpl);
+                if (item?.properties?.uses || item?.properties?.hitpoints) {
+                    countLabel = `${loadoutItem.upd.MedKit.HpResource}/${item.properties?.uses || item.properties?.hitpoints}`;
+                }
+            }
 
-        const itemImage = (
-            <ItemImage
-                item={item}
-                imageField={imageOptions?.imageField || 'baseImageLink'}
-                linkToItem={imageOptions?.linkToItem}
-                count={countLabel}
-            />
-        );
-        return { image: itemImage, label };
-    }, [items, t, gameMode]);
+            const itemImage = (
+                <ItemImage
+                    item={item}
+                    imageField={imageOptions?.imageField || 'inspectImageLink'} // issue #1000 original imageOptions?.imageField || baseImageLink
+                    linkToItem={imageOptions?.linkToItem}
+                    count={countLabel}
+                />
+            );
+            return { image: itemImage, label };
+        },
+        [items, t, gameMode],
+    );
 
-    const getLoadoutContents = useCallback((parentItem, itemType = 'loadout') => {
-        const itemSource = itemType === 'loadout' ? playerData?.equipment?.Items : playerData?.favoriteItems;
-        return itemSource?.reduce((contents, loadoutItem) => {
-            if (loadoutItem.parentId !== parentItem._id) {
+    const getLoadoutContents = useCallback(
+        (parentItem, itemType = 'loadout') => {
+            const itemSource =
+                itemType === 'loadout' ? playerData?.equipment?.Items : playerData?.favoriteItems;
+            return itemSource?.reduce((contents, loadoutItem) => {
+                if (loadoutItem.parentId !== parentItem._id) {
+                    return contents;
+                }
+                const itemDisplay = getItemDisplay(loadoutItem);
+                if (!itemDisplay) {
+                    return contents;
+                }
+                contents.push(
+                    <TreeItem
+                        key={`${itemType}-item-${loadoutItem._id}`}
+                        itemId={loadoutItem._id}
+                        slots={{
+                            icon: () => {
+                                return itemDisplay.image;
+                            },
+                        }}
+                        label={itemDisplay.label}
+                    >
+                        {getLoadoutContents(loadoutItem, itemType)}
+                    </TreeItem>,
+                );
                 return contents;
+            }, []);
+        },
+        [playerData, getItemDisplay],
+    );
+
+    const getLoadoutInSlot = useCallback(
+        (slot) => {
+            if (playerData?.equipment?.Id === undefined) {
+                return 'None';
             }
-            const itemDisplay = getItemDisplay(loadoutItem);
-            if (!itemDisplay) {
-                return contents;
+
+            let loadoutRoot = playerData.equipment.Items.find(
+                (i) => i._id === playerData.equipment.Id,
+            );
+            let loadoutItem = playerData.equipment.Items.find(
+                (i) => i.slotId === slot && i.parentId === loadoutRoot._id,
+            );
+
+            if (loadoutItem === undefined) {
+                return 'None';
             }
-            contents.push((
-                <TreeItem key={`${itemType}-item-${loadoutItem._id}`} itemId={loadoutItem._id} slots={{icon: () => { return itemDisplay.image}}} label={itemDisplay.label}>
-                    {getLoadoutContents(loadoutItem, itemType)}
-                </TreeItem>
-            ));
-            return contents;
-        }, []);
-    }, [playerData, getItemDisplay]);
 
-    const getLoadoutInSlot = useCallback((slot) => {
-        if (playerData?.equipment?.Id === undefined) {
-            return "None";
-        }
+            let itemImage = undefined;
+            let itemLabel = '';
+            let contents = [];
+            let itemDisplay = getItemDisplay(loadoutItem);
+            if (itemDisplay) {
+                itemImage = itemDisplay.image;
+            } else {
+                itemLabel = slot;
+            }
+            contents.push(
+                <TreeItem
+                    key={`loadout-item-${loadoutItem._id}`}
+                    itemId={loadoutItem._id}
+                    slots={{
+                        icon: () => {
+                            return itemImage;
+                        },
+                    }}
+                    label={itemLabel}
+                >
+                    {getLoadoutContents(loadoutItem)}
+                </TreeItem>,
+            );
 
-        let loadoutRoot = playerData.equipment.Items.find(i => i._id === playerData.equipment.Id);
-        let loadoutItem = playerData.equipment.Items.find(i => i.slotId === slot && i.parentId === loadoutRoot._id);
-
-        if (loadoutItem === undefined) {
-            return "None";
-        }
-
-        let itemImage = undefined;
-        let itemLabel = '';
-        let contents = [];
-        let itemDisplay = getItemDisplay(loadoutItem);
-        if (itemDisplay) {
-            itemImage = itemDisplay.image;
-        }
-        else {
-            itemLabel = slot;
-        }
-        contents.push((
-            <TreeItem key={`loadout-item-${loadoutItem._id}`} itemId={loadoutItem._id} slots={{icon: () => { return itemImage}}} label={itemLabel}>
-                {getLoadoutContents(loadoutItem)}
-            </TreeItem>
-        ));
-
-        return <SimpleTreeView>
-            {contents}
-        </SimpleTreeView>
-    }, [playerData, getItemDisplay, getLoadoutContents]);
+            return <SimpleTreeView>{contents}</SimpleTreeView>;
+        },
+        [playerData, getItemDisplay, getLoadoutContents],
+    );
 
     const favoriteItemsContent = useMemo(() => {
         if (!playerData?.favoriteItems?.length) {
             return '';
         }
-        return ([
-            <h2 key="favorite-items-title"><Icon path={mdiTrophyAward} size={1.5} className="icon-with-text" />{t('Favorite Items')}</h2>,
+        return [
+            <h2 key="favorite-items-title">
+                <Icon path={mdiTrophyAward} size={1.5} className="icon-with-text" />
+                {t('Favorite Items')}
+            </h2>,
             <ul key="favorite-items-content" className="favorite-item-list">
-                {playerData.favoriteItems.map(itemData => {
-                    if (itemData.parentId) {
-                        return false;
-                    }
+                {playerData.favoriteItems
+                    .map((itemData) => {
+                        if (itemData.parentId) {
+                            return false;
+                        }
 
-                    let itemImage = undefined;
-                    let itemLabel = '';
-                    let itemDisplay = getItemDisplay(itemData);
-                    if (itemDisplay) {
-                        itemImage = itemDisplay.image;
-                        itemLabel = itemDisplay.label;
-                    }
-                    return (
-                        <li key={itemData._id}>
-                            <SimpleTreeView>
-                                <TreeItem key={`loadout-item-${itemData._id}`} itemId={itemData._id} slots={{icon: () => { return itemImage}}} label={itemLabel}>
-                                    {getLoadoutContents(itemData, 'favorite')}
-                                </TreeItem>
-                            </SimpleTreeView>
-                        </li>
-                    );
-                }).filter(Boolean)}
-            </ul>
-        ])
+                        let itemImage = undefined;
+                        let itemLabel = '';
+                        let itemDisplay = getItemDisplay(itemData);
+                        if (itemDisplay) {
+                            itemImage = itemDisplay.image;
+                            itemLabel = itemDisplay.label;
+                        }
+                        return (
+                            <li key={itemData._id}>
+                                <SimpleTreeView>
+                                    <TreeItem
+                                        key={`loadout-item-${itemData._id}`}
+                                        itemId={itemData._id}
+                                        slots={{
+                                            icon: () => {
+                                                return itemImage;
+                                            },
+                                        }}
+                                        label={itemLabel}
+                                    >
+                                        {getLoadoutContents(itemData, 'favorite')}
+                                    </TreeItem>
+                                </SimpleTreeView>
+                            </li>
+                        );
+                    })
+                    .filter(Boolean)}
+            </ul>,
+        ];
     }, [playerData, getItemDisplay, getLoadoutContents, t]);
 
     useEffect(() => {
@@ -882,19 +920,36 @@ function Player() {
         if (playerData.saved) {
             return;
         }
-        fetchProfile();
-    }, [playerData, accountId, turnstileToken, fetchProfile])
+        /*
+         *-----Commented out to prevent any unneccesary fetches to CloudFlare workers and/or Tarkov scanners, using the load profile feature to populate page ISSUE #1000 ------
+         *fetchProfile();
+         */
+    }, [playerData, accountId, turnstileToken, fetchProfile]);
 
     const playerSearchDiv = (
         <div>
             <p>
-                <Link to={`/players?gameMode=${gameMode}`}><Icon path={mdiAccountSearch} size={1} className="icon-with-text" />{t('Search different player')}</Link>
-                <input type='file' id='file' ref={inputFile} style={{display: 'none'}} onChange={loadProfile} accept="application/json,.json"/>
-                <Tippy
-                    content={t('Load profile from file')}
-                    placement="bottom"
-                >
-                    <button className="profile-button open" onClick={() => {inputFile.current?.click();}}><Icon path={mdiFolderOpen} size={1} className="icon-with-text" /></button>    
+                <Link to={`/players?gameMode=${gameMode}`}>
+                    <Icon path={mdiAccountSearch} size={1} className="icon-with-text" />
+                    {t('Search different player')}
+                </Link>
+                <input
+                    type="file"
+                    id="file"
+                    ref={inputFile}
+                    style={{ display: 'none' }}
+                    onChange={loadProfile}
+                    accept="application/json,.json"
+                />
+                <Tippy content={t('Load profile from file')} placement="bottom">
+                    <button
+                        className="profile-button open"
+                        onClick={() => {
+                            inputFile.current?.click();
+                        }}
+                    >
+                        <Icon path={mdiFolderOpen} size={1} className="icon-with-text" />
+                    </button>
                 </Tippy>
             </p>
         </div>
@@ -923,10 +978,17 @@ function Player() {
                     {pageTitle}
                     {playerData.aid !== 0 && (
                         <span>
-                            <Tippy
-                                content={t('Save profile')}
-                            >
-                            <button className="profile-button download" onClick={downloadProfile}><Icon path={mdiDownloadBox} size={1} className="icon-with-text" /></button>
+                            <Tippy content={t('Save profile')}>
+                                <button
+                                    className="profile-button download"
+                                    onClick={downloadProfile}
+                                >
+                                    <Icon
+                                        path={mdiDownloadBox}
+                                        size={1}
+                                        className="icon-with-text"
+                                    />
+                                </button>
                             </Tippy>
                         </span>
                     )}
@@ -934,10 +996,16 @@ function Player() {
                         <span>
                             {typeof playerBanned === 'undefined' && (
                                 <Tippy content={t('Check if player appears to be banned')}>
-                                    <button ref={bannedButtonRef} className="profile-button banned-btn" onClick={() => {
-                                        bannedButtonRef.current.disabled = true;
-                                        checkBanned();
-                                    }}><Icon path={mdiGavel} size={1} className="icon-with-text" /></button>
+                                    <button
+                                        ref={bannedButtonRef}
+                                        className="profile-button banned-btn"
+                                        onClick={() => {
+                                            bannedButtonRef.current.disabled = true;
+                                            checkBanned();
+                                        }}
+                                    >
+                                        <Icon path={mdiGavel} size={1} className="icon-with-text" />
+                                    </button>
                                 </Tippy>
                             )}
                             {playerBanned === false && (
@@ -949,42 +1017,49 @@ function Player() {
                         </span>
                     )}
                 </h1>
-                <Turnstile
+                {/* ------------------------------------------COMMENTED OUT CLOUDFLARE IS ANNOYING DURING DEV ISSUE #1000---------------------------*/}
+                {/* <Turnstile
                     ref={turnstileRef}
                     className="turnstile-widget"
-                    siteKey='0x4AAAAAAAVVIHGZCr2PPwrR'
+                    siteKey="0x4AAAAAAAVVIHGZCr2PPwrR"
                     onSuccess={setTurnstileToken}
                     onError={(errorCode) => {
                         // https://developers.cloudflare.com/turnstile/reference/client-side-errors#error-codes
                         if (errorCode === '110200') {
-                            setProfileError(`Turnstile error: ${window.location.hostname} is not a valid hostname`);
+                            setProfileError(
+                                `Turnstile error: ${window.location.hostname} is not a valid hostname`,
+                            );
                         } else {
                             setProfileError(`Turnstile error code ${errorCode}`);
                         }
                     }}
-                    options={{appearance: 'interaction-only'}}
-                />
+                    options={{ appearance: 'interaction-only' }}
+                /> */}
             </div>
             <div>
                 {accountCategories}
                 {!!playerData.saved && (
-                    <p className="banned">{t('Warning: Profiles loaded from files may contain edited information')}</p>
+                    <p className="banned">
+                        {t('Warning: Profiles loaded from files may contain edited information')}
+                    </p>
                 )}
                 {totalTimeInGame}
                 {lastActiveDate}
-                {raidsData?.length > 0  && (
+                {raidsData?.length > 0 && (
                     <>
-                        <h2 key="raids-title"><Icon path={mdiChartLine} size={1.5} className="icon-with-text" />{t('Raid Stats')}</h2>
-                        <DataTable
-                            key="raids-table"
-                            columns={raidsColumns}
-                            data={raidsData}
-                        />
+                        <h2 key="raids-title">
+                            <Icon path={mdiChartLine} size={1.5} className="icon-with-text" />
+                            {t('Raid Stats')}
+                        </h2>
+                        <DataTable key="raids-table" columns={raidsColumns} data={raidsData} />
                     </>
                 )}
-                {achievementsData?.length > 0  && (
+                {achievementsData?.length > 0 && (
                     <>
-                        <h2 key="achievements-title"><Icon path={mdiTrophy} size={1.5} className="icon-with-text" />{t('Achievements')}</h2>
+                        <h2 key="achievements-title">
+                            <Icon path={mdiTrophy} size={1.5} className="icon-with-text" />
+                            {t('Achievements')}
+                        </h2>
                         <DataTable
                             key="achievements-table"
                             columns={achievementColumns}
@@ -995,25 +1070,69 @@ function Player() {
                 )}
                 {playerData.equipment?.Items?.length > 0 && (
                     <>
-                        <h2><Icon path={mdiBagPersonal} size={1.5} className="icon-with-text" />{t('Loadout')}</h2>
+                        <h2>
+                            <Icon path={mdiBagPersonal} size={1.5} className="icon-with-text" />
+                            {t('Loadout')}
+                        </h2>
                         <div className="inventory">
                             <div className="grid-container main">
-                                <div className="earpiece">{getLoadoutInSlot('Earpiece')}</div>
-                                <div className="headwear">{getLoadoutInSlot('Headwear')}</div>
-                                <div className="face_cover">{getLoadoutInSlot('FaceCover')}</div>
-                                <div className="armband">{getLoadoutInSlot('ArmBand')}</div>
-                                <div className="body_armor">{getLoadoutInSlot('ArmorVest')}</div>
-                                <div className="eyewear">{getLoadoutInSlot('Eyewear')}</div>
-                                <div className="weapon on_sling">{getLoadoutInSlot('FirstPrimaryWeapon')}</div>
-                                <div className="holster">{getLoadoutInSlot('Holster')}</div>
-                                <div className="weapon on_back">{getLoadoutInSlot('SecondPrimaryWeapon')}</div>
-                                <div className="sheath">{getLoadoutInSlot('Scabbard')}</div>
+                                <div className="earpiece">
+                                    <div className="gear-slot-label">{'EARPIECE'}</div>
+                                    {getLoadoutInSlot('Earpiece')}
+                                </div>
+                                <div className="headwear">
+                                    <div className="gear-slot-label">{'HEADWEAR'}</div>
+                                    {getLoadoutInSlot('Headwear')}
+                                </div>
+                                <div className="face_cover">
+                                    <div className="gear-slot-label">{'FACE COVER'}</div>
+                                    {getLoadoutInSlot('FaceCover')}
+                                </div>
+                                <div className="armband">
+                                    <div className="gear-slot-label">{'ARMBAND'}</div>
+                                    {getLoadoutInSlot('ArmBand')}
+                                </div>
+                                <div className="body_armor">
+                                    <div className="gear-slot-label">{'BODY ARMOR'}</div>
+                                    {getLoadoutInSlot('ArmorVest')}
+                                </div>
+                                <div className="eyewear">
+                                    <div className="gear-slot-label">{'EYEWEAR'}</div>
+                                    {getLoadoutInSlot('Eyewear')}
+                                </div>
+                                <div className="weapon on_sling">
+                                    <div className="gear-slot-label">{'ON SLING'}</div>
+                                    {getLoadoutInSlot('FirstPrimaryWeapon')}
+                                </div>
+                                <div className="holster">
+                                    <div className="gear-slot-label">{'HOLSTER'}</div>
+                                    {getLoadoutInSlot('Holster')}
+                                </div>
+                                <div className="weapon on_back">
+                                    <div className="gear-slot-label">{'ON BACK'}</div>
+                                    {getLoadoutInSlot('SecondPrimaryWeapon')}
+                                </div>
+                                <div className="sheath">
+                                    <div className="gear-slot-label">{'SHEATH'}</div>
+                                    {getLoadoutInSlot('Scabbard')}
+                                </div>
                             </div>
                             <div className="grid-container side">
-                                <div className="tactical_rig">{getLoadoutInSlot('TacticalVest')}</div>
-                                <div className="pockets_and_special_slots">{getLoadoutInSlot('Pockets')}</div>
-                                <div className="backpack">{getLoadoutInSlot('Backpack')}</div>
-                                <div className="pouch">{getLoadoutInSlot('SecuredContainer')}</div>
+                                <div className="tactical_rig">
+                                    <div className="gear-slot-label">{'TATICAL RIG'}</div>
+                                    {getLoadoutInSlot('TacticalVest')}
+                                </div>
+                                <div className="pockets_and_special_slots">
+                                    {getLoadoutInSlot('Pockets')}
+                                </div>
+                                <div className="backpack">
+                                    <div className="gear-slot-label">{'BACKPACK'}</div>
+                                    {getLoadoutInSlot('Backpack')}
+                                </div>
+                                <div className="pouch">
+                                    <div className="gear-slot-label">{'POUCH'}</div>
+                                    {getLoadoutInSlot('SecuredContainer')}
+                                </div>
                             </div>
                         </div>
                     </>
@@ -1021,7 +1140,10 @@ function Player() {
                 {favoriteItemsContent}
                 {skillsData?.length > 0 && (
                     <>
-                        <h2 key="skills-title"><Icon path={mdiArmFlex} size={1.5} className="icon-with-text" />{t('Skills')}</h2>
+                        <h2 key="skills-title">
+                            <Icon path={mdiArmFlex} size={1.5} className="icon-with-text" />
+                            {t('Skills')}
+                        </h2>
                         <DataTable
                             key="skills-table"
                             columns={skillsColumns}
@@ -1032,7 +1154,10 @@ function Player() {
                 )}
                 {masteringData?.length > 0 && (
                     <>
-                        <h2 key="mastering-title"><Icon path={mdiStarBox} size={1.5} className="icon-with-text" />{t('Mastering')}</h2>
+                        <h2 key="mastering-title">
+                            <Icon path={mdiStarBox} size={1.5} className="icon-with-text" />
+                            {t('Mastering')}
+                        </h2>
                         <DataTable
                             key="skills-table"
                             columns={masteringColumns}

--- a/src/pages/player/saved-profiles-issue#1000/empty.json
+++ b/src/pages/player/saved-profiles-issue#1000/empty.json
@@ -1,0 +1,681 @@
+{
+    "aid": 5598985,
+    "info": {
+        "nickname": "applefrittr",
+        "side": "Bear",
+        "experience": 1367682,
+        "memberCategory": 2,
+        "selectedMemberCategory": 2
+    },
+    "customization": {
+        "head": "5cc084dd14c02e000b0550a3",
+        "body": "6295e698e9de5e7b3751c47a",
+        "feet": "65707a89f5a6f1412f0c5f7b",
+        "hands": "62961424869a02221651df53"
+    },
+    "skills": {
+        "Common": [
+            {
+                "Id": "BotReload",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": -2147483648
+            },
+            {
+                "Id": "BotSound",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": -2147483648
+            },
+            {
+                "Id": "Endurance",
+                "Progress": 1148.40637,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753553
+            },
+            {
+                "Id": "Strength",
+                "Progress": 1225.64673,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753793
+            },
+            {
+                "Id": "Vitality",
+                "Progress": 574.796143,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753793
+            },
+            {
+                "Id": "Health",
+                "Progress": 1055.7666,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753793
+            },
+            {
+                "Id": "StressResistance",
+                "Progress": 524.947937,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753793
+            },
+            {
+                "Id": "Metabolism",
+                "Progress": 2076.95483,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753106
+            },
+            {
+                "Id": "Immunity",
+                "Progress": 111.965736,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729558969
+            },
+            {
+                "Id": "Perception",
+                "Progress": 1014.106,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753618
+            },
+            {
+                "Id": "Intellect",
+                "Progress": 13.02,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729568635
+            },
+            {
+                "Id": "Attention",
+                "Progress": 1156.84351,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753617
+            },
+            {
+                "Id": "Charisma",
+                "Progress": 873.2466,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753618
+            },
+            {
+                "Id": "Pistol",
+                "Progress": 82.2000046,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729750541
+            },
+            {
+                "Id": "Revolver",
+                "Progress": 13.55,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1728790987
+            },
+            {
+                "Id": "SMG",
+                "Progress": 425.909241,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729653336
+            },
+            {
+                "Id": "Assault",
+                "Progress": 571.2419,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753724
+            },
+            {
+                "Id": "Shotgun",
+                "Progress": 240.813034,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729651901
+            },
+            {
+                "Id": "Sniper",
+                "Progress": 258.222,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729750868
+            },
+            {
+                "Id": "LMG",
+                "Progress": 34.6999931,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1728024507
+            },
+            {
+                "Id": "HMG",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "Launcher",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "AttachedLauncher",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "Throwing",
+                "Progress": 63.6999741,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729749646
+            },
+            {
+                "Id": "Melee",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "DMR",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "AimDrills",
+                "Progress": 539.609558,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753723
+            },
+            {
+                "Id": "TroubleShooting",
+                "Progress": 31.6,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729482181
+            },
+            {
+                "Id": "Surgery",
+                "Progress": 384.7879,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729750002
+            },
+            {
+                "Id": "CovertMovement",
+                "Progress": 313.145081,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753656
+            },
+            {
+                "Id": "Search",
+                "Progress": 626.9003,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753567
+            },
+            {
+                "Id": "MagDrills",
+                "Progress": 301.436981,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753726
+            },
+            {
+                "Id": "FieldMedicine",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "FirstAid",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "LightVests",
+                "Progress": 227.948578,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729749604
+            },
+            {
+                "Id": "HeavyVests",
+                "Progress": 275.265625,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729750539
+            },
+            {
+                "Id": "NightOps",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "SilentOps",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "WeaponTreatment",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "Auctions",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "Cleanoperations",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "Shadowconnections",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "Taskperformance",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "Crafting",
+                "Progress": 126,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1728362172
+            },
+            {
+                "Id": "HideoutManagement",
+                "Progress": 840.86,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729144095
+            }
+        ],
+        "Mastering": [
+            {
+                "Id": "AKM",
+                "Progress": 183
+            },
+            {
+                "Id": "AK74",
+                "Progress": 438
+            },
+            {
+                "Id": "mosin",
+                "Progress": 161
+            },
+            {
+                "Id": "DEAGLE",
+                "Progress": 7
+            },
+            {
+                "Id": "M590",
+                "Progress": 0
+            },
+            {
+                "Id": "Mk17",
+                "Progress": 21
+            },
+            {
+                "Id": "PP19",
+                "Progress": 44
+            },
+            {
+                "Id": "MP133",
+                "Progress": 0
+            },
+            {
+                "Id": "GLOCK17",
+                "Progress": 15
+            },
+            {
+                "Id": "AKSU",
+                "Progress": 255
+            },
+            {
+                "Id": "SKS",
+                "Progress": 224
+            },
+            {
+                "Id": "M4",
+                "Progress": 23
+            },
+            {
+                "Id": "MP443",
+                "Progress": 24
+            },
+            {
+                "Id": "VPO101",
+                "Progress": 21
+            },
+            {
+                "Id": "r700",
+                "Progress": 0
+            },
+            {
+                "Id": "PM",
+                "Progress": 1
+            },
+            {
+                "Id": "M870",
+                "Progress": 0
+            },
+            {
+                "Id": "MP153",
+                "Progress": 562
+            },
+            {
+                "Id": "STM-9",
+                "Progress": 10
+            },
+            {
+                "Id": "M60",
+                "Progress": 11
+            },
+            {
+                "Id": "UMP45",
+                "Progress": 64
+            },
+            {
+                "Id": "m9",
+                "Progress": 3
+            },
+            {
+                "Id": "SV98",
+                "Progress": 20
+            },
+            {
+                "Id": "G36",
+                "Progress": 20
+            },
+            {
+                "Id": "UZI",
+                "Progress": 71
+            },
+            {
+                "Id": "MP5",
+                "Progress": 102
+            },
+            {
+                "Id": "PL15",
+                "Progress": 6
+            },
+            {
+                "Id": "UZI-PRO",
+                "Progress": 354
+            },
+            {
+                "Id": "SAIGA",
+                "Progress": 26
+            },
+            {
+                "Id": "MDR",
+                "Progress": 129
+            },
+            {
+                "Id": "MP9",
+                "Progress": 403
+            },
+            {
+                "Id": "MCX",
+                "Progress": 2
+            },
+            {
+                "Id": "SVD",
+                "Progress": 0
+            },
+            {
+                "Id": "P226",
+                "Progress": 0
+            },
+            {
+                "Id": "DVL",
+                "Progress": 1
+            },
+            {
+                "Id": "PP-91",
+                "Progress": 12
+            },
+            {
+                "Id": "PB",
+                "Progress": 0
+            },
+            {
+                "Id": "MK47",
+                "Progress": 3
+            },
+            {
+                "Id": "VSS",
+                "Progress": 54
+            },
+            {
+                "Id": "SPEAR",
+                "Progress": 0
+            },
+            {
+                "Id": "SR2",
+                "Progress": 71
+            },
+            {
+                "Id": "RSH12",
+                "Progress": 9
+            },
+            {
+                "Id": "SVT-40",
+                "Progress": 12
+            },
+            {
+                "Id": "USP",
+                "Progress": 0
+            },
+            {
+                "Id": "VSK94",
+                "Progress": 103
+            },
+            {
+                "Id": 57,
+                "Progress": 5
+            },
+            {
+                "Id": "AUG",
+                "Progress": 409
+            },
+            {
+                "Id": "MR43",
+                "Progress": 0
+            },
+            {
+                "Id": "TOZ106",
+                "Progress": 0
+            },
+            {
+                "Id": "VPO_215",
+                "Progress": 1
+            },
+            {
+                "Id": "mp7",
+                "Progress": 0
+            },
+            {
+                "Id": "MPX",
+                "Progress": 0
+            }
+        ],
+        "Points": 0
+    },
+    "equipment": {
+        "Id": "66c4b690fbf6319b1e11c422",
+        "Items": [
+            {
+                "_id": "66c4b690fbf6319b1e11c422",
+                "_tpl": "55d7217a4bdc2d86028b456d"
+            },
+            {
+                "_id": "670a14b67e0ea2f5db119329",
+                "_tpl": "601948682627df266209af05",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "Scabbard",
+                "upd": {
+                    "Repairable": {
+                        "MaxDurability": 90,
+                        "Durability": 90
+                    }
+                }
+            },
+            {
+                "_id": "66c4b690fbf6319b1e11c412",
+                "_tpl": "5857a8bc2459772bad15db29",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "SecuredContainer"
+            },
+            {
+                "_id": "66c4b690fbf6319b1e11c420",
+                "_tpl": "627a4e6b255f7527fb05a0f6",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "Pockets"
+            },
+            {
+                "_id": "66c5489ecc10fe584117bc59",
+                "_tpl": "60b0f988c4449e4cb624c1da",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "ArmBand"
+            }
+        ]
+    },
+    "achievements": {
+        "65141c30ec10ff011f17cc3b": 1704093498,
+        "65141c80ec10ff011f17cc3e": 1704098100,
+        "65141eb5c31fcb0e163577dd": 1704139506,
+        "65141e37cf2f1c285e606361": 1704169569,
+        "6512ea46f7a078264a4376e4": 1704340463,
+        "6527ee4a647c29201011defe": 1704660209,
+        "65141b9859647d2cb3213ca2": 1704695763,
+        "6513eb6e0dc723592b0f9095": 1705130359,
+        "6512eb3ddfb0ae1ee75a0376": 1705305836,
+        "65141bdfcf2f1c285e606446": 1705811984,
+        "6513ee11a3dd9b6aa7159b4a": 1706348261,
+        "6512f1e3be73cc7f07358ed5": 1707112841,
+        "65141dd6303df252af1c72c9": 1712469793,
+        "6513f0a10dc723592b0f90cf": 1715126717,
+        "655b49bc91aa9e07687ae47c": 1717218630,
+        "6513eec00dc723592b0f90cc": 1717356486,
+        "6513efa1b49e3253755f47eb": 1717477240,
+        "66c328aca91e7d66fa1b0b7b": 1724538538,
+        "66b493bc2d8cd3b5e90a3648": 1728368856
+    },
+    "favoriteItems": [],
+    "pmcStats": {
+        "eft": {
+            "totalInGameTime": 17431542,
+            "overAllCounters": {
+                "Items": [
+                    {
+                        "Key": [
+                            "Sessions",
+                            "Pmc"
+                        ],
+                        "Value": 253
+                    },
+                    {
+                        "Key": [
+                            "ExitStatus",
+                            "Killed",
+                            "Pmc"
+                        ],
+                        "Value": 120
+                    },
+                    {
+                        "Key": [
+                            "Kills"
+                        ],
+                        "Value": 808
+                    },
+                    {
+                        "Key": [
+                            "Deaths"
+                        ],
+                        "Value": 120
+                    },
+                    {
+                        "Key": [
+                            "ExitStatus",
+                            "Survived",
+                            "Pmc"
+                        ],
+                        "Value": 118
+                    },
+                    {
+                        "Key": [
+                            "LongestWinStreak",
+                            "Pmc"
+                        ],
+                        "Value": 11
+                    },
+                    {
+                        "Key": [
+                            "ExitStatus",
+                            "Transit",
+                            "Pmc"
+                        ],
+                        "Value": 15
+                    }
+                ]
+            }
+        }
+    },
+    "scavStats": {
+        "eft": {
+            "totalInGameTime": 17431542,
+            "overAllCounters": {
+                "Items": [
+                    {
+                        "Key": [
+                            "Sessions",
+                            "Scav"
+                        ],
+                        "Value": 33
+                    },
+                    {
+                        "Key": [
+                            "ExitStatus",
+                            "Survived",
+                            "Scav"
+                        ],
+                        "Value": 20
+                    },
+                    {
+                        "Key": [
+                            "Kills"
+                        ],
+                        "Value": 11
+                    },
+                    {
+                        "Key": [
+                            "Deaths"
+                        ],
+                        "Value": 13
+                    },
+                    {
+                        "Key": [
+                            "LongestWinStreak",
+                            "Scav"
+                        ],
+                        "Value": 10
+                    },
+                    {
+                        "Key": [
+                            "ExitStatus",
+                            "Killed",
+                            "Scav"
+                        ],
+                        "Value": 11
+                    },
+                    {
+                        "Key": [
+                            "ExitStatus",
+                            "Left",
+                            "Scav"
+                        ],
+                        "Value": 2
+                    }
+                ]
+            }
+        }
+    },
+    "updated": 1729875178618
+}

--- a/src/pages/player/saved-profiles-issue#1000/full.json
+++ b/src/pages/player/saved-profiles-issue#1000/full.json
@@ -1,0 +1,1295 @@
+{
+    "aid": 5598985,
+    "info": {
+        "nickname": "applefrittr",
+        "side": "Bear",
+        "experience": 1367682,
+        "memberCategory": 2,
+        "selectedMemberCategory": 2
+    },
+    "customization": {
+        "head": "5cc084dd14c02e000b0550a3",
+        "body": "6295e698e9de5e7b3751c47a",
+        "feet": "65707a89f5a6f1412f0c5f7b",
+        "hands": "62961424869a02221651df53"
+    },
+    "skills": {
+        "Common": [
+            {
+                "Id": "BotReload",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": -2147483648
+            },
+            {
+                "Id": "BotSound",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": -2147483648
+            },
+            {
+                "Id": "Endurance",
+                "Progress": 1148.40637,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753553
+            },
+            {
+                "Id": "Strength",
+                "Progress": 1225.64673,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753793
+            },
+            {
+                "Id": "Vitality",
+                "Progress": 574.796143,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753793
+            },
+            {
+                "Id": "Health",
+                "Progress": 1055.7666,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753793
+            },
+            {
+                "Id": "StressResistance",
+                "Progress": 524.947937,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753793
+            },
+            {
+                "Id": "Metabolism",
+                "Progress": 2076.95483,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753106
+            },
+            {
+                "Id": "Immunity",
+                "Progress": 111.965736,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729558969
+            },
+            {
+                "Id": "Perception",
+                "Progress": 1014.106,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753618
+            },
+            {
+                "Id": "Intellect",
+                "Progress": 13.02,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729568635
+            },
+            {
+                "Id": "Attention",
+                "Progress": 1156.84351,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753617
+            },
+            {
+                "Id": "Charisma",
+                "Progress": 873.2466,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753618
+            },
+            {
+                "Id": "Pistol",
+                "Progress": 82.2000046,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729750541
+            },
+            {
+                "Id": "Revolver",
+                "Progress": 13.55,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1728790987
+            },
+            {
+                "Id": "SMG",
+                "Progress": 425.909241,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729653336
+            },
+            {
+                "Id": "Assault",
+                "Progress": 571.2419,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753724
+            },
+            {
+                "Id": "Shotgun",
+                "Progress": 240.813034,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729651901
+            },
+            {
+                "Id": "Sniper",
+                "Progress": 258.222,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729750868
+            },
+            {
+                "Id": "LMG",
+                "Progress": 34.6999931,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1728024507
+            },
+            {
+                "Id": "HMG",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "Launcher",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "AttachedLauncher",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "Throwing",
+                "Progress": 63.6999741,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729749646
+            },
+            {
+                "Id": "Melee",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "DMR",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "AimDrills",
+                "Progress": 539.609558,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753723
+            },
+            {
+                "Id": "TroubleShooting",
+                "Progress": 31.6,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729482181
+            },
+            {
+                "Id": "Surgery",
+                "Progress": 384.7879,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729750002
+            },
+            {
+                "Id": "CovertMovement",
+                "Progress": 313.145081,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753656
+            },
+            {
+                "Id": "Search",
+                "Progress": 626.9003,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753567
+            },
+            {
+                "Id": "MagDrills",
+                "Progress": 301.436981,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753726
+            },
+            {
+                "Id": "FieldMedicine",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "FirstAid",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "LightVests",
+                "Progress": 227.948578,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729749604
+            },
+            {
+                "Id": "HeavyVests",
+                "Progress": 275.265625,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729750539
+            },
+            {
+                "Id": "NightOps",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "SilentOps",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "WeaponTreatment",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "Auctions",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "Cleanoperations",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "Shadowconnections",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "Taskperformance",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "Crafting",
+                "Progress": 126,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1728362172
+            },
+            {
+                "Id": "HideoutManagement",
+                "Progress": 840.86,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729144095
+            }
+        ],
+        "Mastering": [
+            {
+                "Id": "AKM",
+                "Progress": 183
+            },
+            {
+                "Id": "AK74",
+                "Progress": 438
+            },
+            {
+                "Id": "mosin",
+                "Progress": 161
+            },
+            {
+                "Id": "DEAGLE",
+                "Progress": 7
+            },
+            {
+                "Id": "M590",
+                "Progress": 0
+            },
+            {
+                "Id": "Mk17",
+                "Progress": 21
+            },
+            {
+                "Id": "PP19",
+                "Progress": 44
+            },
+            {
+                "Id": "MP133",
+                "Progress": 0
+            },
+            {
+                "Id": "GLOCK17",
+                "Progress": 15
+            },
+            {
+                "Id": "AKSU",
+                "Progress": 255
+            },
+            {
+                "Id": "SKS",
+                "Progress": 224
+            },
+            {
+                "Id": "M4",
+                "Progress": 23
+            },
+            {
+                "Id": "MP443",
+                "Progress": 24
+            },
+            {
+                "Id": "VPO101",
+                "Progress": 21
+            },
+            {
+                "Id": "r700",
+                "Progress": 0
+            },
+            {
+                "Id": "PM",
+                "Progress": 1
+            },
+            {
+                "Id": "M870",
+                "Progress": 0
+            },
+            {
+                "Id": "MP153",
+                "Progress": 562
+            },
+            {
+                "Id": "STM-9",
+                "Progress": 10
+            },
+            {
+                "Id": "M60",
+                "Progress": 11
+            },
+            {
+                "Id": "UMP45",
+                "Progress": 64
+            },
+            {
+                "Id": "m9",
+                "Progress": 3
+            },
+            {
+                "Id": "SV98",
+                "Progress": 20
+            },
+            {
+                "Id": "G36",
+                "Progress": 20
+            },
+            {
+                "Id": "UZI",
+                "Progress": 71
+            },
+            {
+                "Id": "MP5",
+                "Progress": 102
+            },
+            {
+                "Id": "PL15",
+                "Progress": 6
+            },
+            {
+                "Id": "UZI-PRO",
+                "Progress": 354
+            },
+            {
+                "Id": "SAIGA",
+                "Progress": 26
+            },
+            {
+                "Id": "MDR",
+                "Progress": 129
+            },
+            {
+                "Id": "MP9",
+                "Progress": 403
+            },
+            {
+                "Id": "MCX",
+                "Progress": 2
+            },
+            {
+                "Id": "SVD",
+                "Progress": 0
+            },
+            {
+                "Id": "P226",
+                "Progress": 0
+            },
+            {
+                "Id": "DVL",
+                "Progress": 1
+            },
+            {
+                "Id": "PP-91",
+                "Progress": 12
+            },
+            {
+                "Id": "PB",
+                "Progress": 0
+            },
+            {
+                "Id": "MK47",
+                "Progress": 3
+            },
+            {
+                "Id": "VSS",
+                "Progress": 54
+            },
+            {
+                "Id": "SPEAR",
+                "Progress": 0
+            },
+            {
+                "Id": "SR2",
+                "Progress": 71
+            },
+            {
+                "Id": "RSH12",
+                "Progress": 9
+            },
+            {
+                "Id": "SVT-40",
+                "Progress": 12
+            },
+            {
+                "Id": "USP",
+                "Progress": 0
+            },
+            {
+                "Id": "VSK94",
+                "Progress": 103
+            },
+            {
+                "Id": 57,
+                "Progress": 5
+            },
+            {
+                "Id": "AUG",
+                "Progress": 409
+            },
+            {
+                "Id": "MR43",
+                "Progress": 0
+            },
+            {
+                "Id": "TOZ106",
+                "Progress": 0
+            },
+            {
+                "Id": "VPO_215",
+                "Progress": 1
+            },
+            {
+                "Id": "mp7",
+                "Progress": 0
+            },
+            {
+                "Id": "MPX",
+                "Progress": 0
+            }
+        ],
+        "Points": 0
+    },
+    "equipment": {
+        "Id": "66c4b690fbf6319b1e11c422",
+        "Items": [
+            {
+                "_id": "66c4b690fbf6319b1e11c422",
+                "_tpl": "55d7217a4bdc2d86028b456d"
+            },
+            {
+                "_id": "670a14b67e0ea2f5db119329",
+                "_tpl": "601948682627df266209af05",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "Scabbard",
+                "upd": {
+                    "Repairable": {
+                        "MaxDurability": 90,
+                        "Durability": 90
+                    }
+                }
+            },
+            {
+                "_id": "66c4b690fbf6319b1e11c412",
+                "_tpl": "5857a8bc2459772bad15db29",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "SecuredContainer"
+            },
+            {
+                "_id": "66c4b690fbf6319b1e11c420",
+                "_tpl": "627a4e6b255f7527fb05a0f6",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "Pockets"
+            },
+            {
+                "_id": "66c5489ecc10fe584117bc59",
+                "_tpl": "60b0f988c4449e4cb624c1da",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "ArmBand"
+            },
+            {
+                "_id": "6716f6a63716047cfa051aa3",
+                "_tpl": "5ab8e79e86f7742d8b372e78",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "ArmorVest",
+                "upd": {
+                    "SpawnedInSession": true
+                }
+            },
+            {
+                "_id": "6716f6a63716047cfa051aa4",
+                "_tpl": "656f611f94b480b8a500c0db",
+                "parentId": "6716f6a63716047cfa051aa3",
+                "slotId": "Front_plate",
+                "upd": {
+                    "SpawnedInSession": true,
+                    "Repairable": {
+                        "MaxDurability": 50,
+                        "Durability": 28
+                    }
+                }
+            },
+            {
+                "_id": "6716f6a63716047cfa051aa5",
+                "_tpl": "65573fa5655447403702a816",
+                "parentId": "6716f6a63716047cfa051aa3",
+                "slotId": "Back_plate",
+                "upd": {
+                    "SpawnedInSession": true,
+                    "Repairable": {
+                        "MaxDurability": 55,
+                        "Durability": 29
+                    }
+                }
+            },
+            {
+                "_id": "6716f6a63716047cfa051aa6",
+                "_tpl": "65732688d9d89ff7ac0d9c4c",
+                "parentId": "6716f6a63716047cfa051aa3",
+                "slotId": "Soft_armor_front",
+                "upd": {
+                    "SpawnedInSession": true,
+                    "Repairable": {
+                        "MaxDurability": 54.33,
+                        "Durability": 49.13
+                    }
+                }
+            },
+            {
+                "_id": "6716f6a63716047cfa051aa7",
+                "_tpl": "657326978c1cc6dcd9098b56",
+                "parentId": "6716f6a63716047cfa051aa3",
+                "slotId": "Soft_armor_back",
+                "upd": {
+                    "SpawnedInSession": true,
+                    "Repairable": {
+                        "MaxDurability": 52.67,
+                        "Durability": 45.83
+                    }
+                }
+            },
+            {
+                "_id": "6716f6a63716047cfa051aa8",
+                "_tpl": "657326a28c1cc6dcd9098b5a",
+                "parentId": "6716f6a63716047cfa051aa3",
+                "slotId": "Soft_armor_left",
+                "upd": {
+                    "SpawnedInSession": true,
+                    "Repairable": {
+                        "MaxDurability": 13.39,
+                        "Durability": 11.46
+                    }
+                }
+            },
+            {
+                "_id": "6716f6a63716047cfa051aa9",
+                "_tpl": "657326b08c1cc6dcd9098b5e",
+                "parentId": "6716f6a63716047cfa051aa3",
+                "slotId": "soft_armor_right",
+                "upd": {
+                    "SpawnedInSession": true,
+                    "Repairable": {
+                        "MaxDurability": 13.44,
+                        "Durability": 11.46
+                    }
+                }
+            },
+            {
+                "_id": "6716f6a63716047cfa051aaa",
+                "_tpl": "657326bc5d3a3129fb05f36b",
+                "parentId": "6716f6a63716047cfa051aa3",
+                "slotId": "Collar",
+                "upd": {
+                    "SpawnedInSession": true,
+                    "Repairable": {
+                        "MaxDurability": 13.39,
+                        "Durability": 11.79
+                    }
+                }
+            },
+            {
+                "_id": "6715f358d2932583c413bce6",
+                "_tpl": "5e9db13186f7742f845ee9d3",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "TacticalVest",
+                "upd": {
+                    "SpawnedInSession": true
+                }
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a89",
+                "_tpl": "5447a9cd4bdc2dbd208b4567",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "FirstPrimaryWeapon",
+                "upd": {
+                    "Repairable": {
+                        "MaxDurability": 97.63,
+                        "Durability": 96.59441
+                    },
+                    "FireMode": {
+                        "FireMode": "fullauto"
+                    }
+                }
+            },
+            {
+                "_id": "6715dacea0e10764af01aa95",
+                "_tpl": "6113cce3d92c473c770200c7",
+                "parentId": "6704a3ac80fd1dac0f111a89",
+                "slotId": "mod_pistol_grip"
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a8a",
+                "_tpl": "55802d5f4bdc2dac148b458e",
+                "parentId": "6704a3ac80fd1dac0f111a89",
+                "slotId": "mod_magazine"
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a8b",
+                "_tpl": "55d355e64bdc2d962f8b4569",
+                "parentId": "6704a3ac80fd1dac0f111a89",
+                "slotId": "mod_reciever"
+            },
+            {
+                "_id": "6715dacea0e10764af01aa94",
+                "_tpl": "5b3b99265acfc4704b4a1afb",
+                "parentId": "6704a3ac80fd1dac0f111a8b",
+                "slotId": "mod_scope"
+            },
+            {
+                "_id": "6715daeeb74743dec608f495",
+                "_tpl": "5b3b99475acfc432ff4dcbee",
+                "parentId": "6715dacea0e10764af01aa94",
+                "slotId": "mod_scope",
+                "upd": {
+                    "Sight": {
+                        "ScopesCurrentCalibPointIndexes": [
+                            0
+                        ],
+                        "ScopesSelectedModes": [
+                            0
+                        ],
+                        "SelectedScope": 0,
+                        "ScopeZoomValue": 0
+                    }
+                }
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a8c",
+                "_tpl": "63d3d44a2a49307baf09386d",
+                "parentId": "6704a3ac80fd1dac0f111a8b",
+                "slotId": "mod_barrel"
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a8e",
+                "_tpl": "6386120cd6baa055ad1e201c",
+                "parentId": "6704a3ac80fd1dac0f111a8c",
+                "slotId": "mod_muzzle"
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a8f",
+                "_tpl": "638612b607dfed1ccb7206ba",
+                "parentId": "6704a3ac80fd1dac0f111a8e",
+                "slotId": "mod_muzzle"
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a8d",
+                "_tpl": "63d3ce281fe77d0f2801859e",
+                "parentId": "6704a3ac80fd1dac0f111a8c",
+                "slotId": "mod_gas_block"
+            },
+            {
+                "_id": "6715dacea0e10764af01aa97",
+                "_tpl": "595cfa8b86f77427437e845b",
+                "parentId": "6704a3ac80fd1dac0f111a8b",
+                "slotId": "mod_handguard"
+            },
+            {
+                "_id": "6715dacea0e10764af01aa93",
+                "_tpl": "59e0bed186f774156f04ce84",
+                "parentId": "6715dacea0e10764af01aa97",
+                "slotId": "mod_mount_000"
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a94",
+                "_tpl": "5b057b4f5acfc4771e1bd3e9",
+                "parentId": "6715dacea0e10764af01aa93",
+                "slotId": "mod_foregrip"
+            },
+            {
+                "_id": "6715dacea0e10764af01aa92",
+                "_tpl": "59e0bdb186f774156f04ce82",
+                "parentId": "6715dacea0e10764af01aa97",
+                "slotId": "mod_mount_004"
+            },
+            {
+                "_id": "6715dacea0e10764af01aa96",
+                "_tpl": "5a5f1ce64f39f90b401987bc",
+                "parentId": "6715dacea0e10764af01aa92",
+                "slotId": "mod_tactical",
+                "upd": {
+                    "Light": {
+                        "IsActive": false,
+                        "SelectedMode": 0
+                    }
+                }
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a90",
+                "_tpl": "5c1780312e221602b66cc189",
+                "parentId": "6704a3ac80fd1dac0f111a8b",
+                "slotId": "mod_sight_rear",
+                "upd": {
+                    "Sight": {
+                        "ScopesCurrentCalibPointIndexes": [
+                            0
+                        ],
+                        "ScopesSelectedModes": [
+                            0
+                        ],
+                        "SelectedScope": 0,
+                        "ScopeZoomValue": 0
+                    }
+                }
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a96",
+                "_tpl": "5c793fb92e221644f31bfb64",
+                "parentId": "6704a3ac80fd1dac0f111a89",
+                "slotId": "mod_stock"
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a97",
+                "_tpl": "58d2946386f774496974c37e",
+                "parentId": "6704a3ac80fd1dac0f111a96",
+                "slotId": "mod_stock_000"
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a98",
+                "_tpl": "58d2912286f7744e27117493",
+                "parentId": "6704a3ac80fd1dac0f111a97",
+                "slotId": "mod_stock"
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a9a",
+                "_tpl": "5f633ff5c444ce7e3c30a006",
+                "parentId": "6704a3ac80fd1dac0f111a89",
+                "slotId": "mod_charge"
+            },
+            {
+                "_id": "6715e1c1375fbc5538000011",
+                "_tpl": "54527ac44bdc2d36668b4567",
+                "parentId": "6704a3ac80fd1dac0f111a89",
+                "slotId": "patron_in_weapon"
+            },
+            {
+                "_id": "6711c390e2b768e414139748",
+                "_tpl": "5ea17ca01412a1425304d1c0",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "Headwear"
+            },
+            {
+                "_id": "6715d9bec5fd49128e088e12",
+                "_tpl": "5c0558060db834001b735271",
+                "parentId": "6711c390e2b768e414139748",
+                "slotId": "mod_nvg",
+                "upd": {
+                    "Sight": {
+                        "ScopesCurrentCalibPointIndexes": [
+                            0
+                        ],
+                        "ScopesSelectedModes": [
+                            0
+                        ],
+                        "SelectedScope": 0,
+                        "ScopeZoomValue": 0
+                    },
+                    "Togglable": {
+                        "On": true
+                    }
+                }
+            },
+            {
+                "_id": "6711c390e2b768e414139749",
+                "_tpl": "657f9a55c6679fefb3051e19",
+                "parentId": "6711c390e2b768e414139748",
+                "slotId": "Helmet_top",
+                "upd": {
+                    "Repairable": {
+                        "MaxDurability": 21.52,
+                        "Durability": 15.3870106
+                    }
+                }
+            },
+            {
+                "_id": "6711c390e2b768e41413974a",
+                "_tpl": "657f9a94ada5fadd1f07a589",
+                "parentId": "6711c390e2b768e414139748",
+                "slotId": "Helmet_back",
+                "upd": {
+                    "Repairable": {
+                        "MaxDurability": 18.96,
+                        "Durability": 18.29
+                    }
+                }
+            },
+            {
+                "_id": "670b6ddf2b270b4d490ad8a8",
+                "_tpl": "5447a9cd4bdc2dbd208b4567",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "SecondPrimaryWeapon",
+                "upd": {
+                    "Repairable": {
+                        "MaxDurability": 100,
+                        "Durability": 98.7257156
+                    },
+                    "FireMode": {
+                        "FireMode": "fullauto"
+                    }
+                }
+            },
+            {
+                "_id": "66ede19643566dc1ee1456b8",
+                "_tpl": "59db3a1d86f77429e05b4e92",
+                "parentId": "670b6ddf2b270b4d490ad8a8",
+                "slotId": "mod_pistol_grip"
+            },
+            {
+                "_id": "67033657f7360631c705d5b9",
+                "_tpl": "5c6d46132e221601da357d56",
+                "parentId": "670b6ddf2b270b4d490ad8a8",
+                "slotId": "mod_magazine"
+            },
+            {
+                "_id": "66edbe3ed669f19445165441",
+                "_tpl": "59bfe68886f7746004266202",
+                "parentId": "670b6ddf2b270b4d490ad8a8",
+                "slotId": "mod_reciever"
+            },
+            {
+                "_id": "670b53064d7d4aad89089e91",
+                "_tpl": "58d2664f86f7747fec5834f6",
+                "parentId": "66edbe3ed669f19445165441",
+                "slotId": "mod_scope"
+            },
+            {
+                "_id": "670a020337be8baa9e1e3446",
+                "_tpl": "58d268fc86f774111273f8c2",
+                "parentId": "670b53064d7d4aad89089e91",
+                "slotId": "mod_scope",
+                "upd": {
+                    "Sight": {
+                        "ScopesCurrentCalibPointIndexes": [
+                            0
+                        ],
+                        "ScopesSelectedModes": [
+                            0
+                        ],
+                        "SelectedScope": 0,
+                        "ScopeZoomValue": 0
+                    }
+                }
+            },
+            {
+                "_id": "66edbe3ed669f19445165442",
+                "_tpl": "63d3ce0446bd475bcb50f55f",
+                "parentId": "66edbe3ed669f19445165441",
+                "slotId": "mod_barrel"
+            },
+            {
+                "_id": "66edbe3ed669f19445165444",
+                "_tpl": "609269c3b0e443224b421cc1",
+                "parentId": "66edbe3ed669f19445165442",
+                "slotId": "mod_muzzle"
+            },
+            {
+                "_id": "66edbe3ed669f19445165445",
+                "_tpl": "60926df0132d4d12c81fd9df",
+                "parentId": "66edbe3ed669f19445165444",
+                "slotId": "mod_muzzle"
+            },
+            {
+                "_id": "66edbe3ed669f19445165443",
+                "_tpl": "63d3ce281fe77d0f2801859e",
+                "parentId": "66edbe3ed669f19445165442",
+                "slotId": "mod_gas_block"
+            },
+            {
+                "_id": "66edbe3ed669f19445165448",
+                "_tpl": "5c78f2492e221600114c9f04",
+                "parentId": "66edbe3ed669f19445165441",
+                "slotId": "mod_handguard"
+            },
+            {
+                "_id": "66edbe3ed669f1944516544b",
+                "_tpl": "6269220d70b6c02e665f2635",
+                "parentId": "66edbe3ed669f19445165448",
+                "slotId": "mod_mount_000"
+            },
+            {
+                "_id": "66edbe3ed669f1944516544a",
+                "_tpl": "6269220d70b6c02e665f2635",
+                "parentId": "66edbe3ed669f19445165448",
+                "slotId": "mod_mount_001"
+            },
+            {
+                "_id": "66edbe3ed669f1944516544d",
+                "_tpl": "5b7be4895acfc400170e2dd5",
+                "parentId": "66edbe3ed669f19445165448",
+                "slotId": "mod_foregrip"
+            },
+            {
+                "_id": "670b043c9a1174317c10d9f2",
+                "_tpl": "5c1cd46f2e22164bef5cfedb",
+                "parentId": "66edbe3ed669f1944516544d",
+                "slotId": "mod_foregrip"
+            },
+            {
+                "_id": "66edbe3ed669f19445165449",
+                "_tpl": "5bc09a30d4351e00367fb7c8",
+                "parentId": "66edbe3ed669f19445165448",
+                "slotId": "mod_sight_front",
+                "upd": {
+                    "Sight": {
+                        "ScopesCurrentCalibPointIndexes": [
+                            0
+                        ],
+                        "ScopesSelectedModes": [
+                            0
+                        ],
+                        "SelectedScope": 0,
+                        "ScopeZoomValue": 0
+                    }
+                }
+            },
+            {
+                "_id": "66edbe3ed669f1944516544c",
+                "_tpl": "560d657b4bdc2da74d8b4572",
+                "parentId": "66edbe3ed669f19445165448",
+                "slotId": "mod_tactical_003",
+                "upd": {
+                    "Light": {
+                        "IsActive": false,
+                        "SelectedMode": 2
+                    }
+                }
+            },
+            {
+                "_id": "66edbe3ed669f19445165446",
+                "_tpl": "5bc09a18d4351e003562b68e",
+                "parentId": "66edbe3ed669f19445165441",
+                "slotId": "mod_sight_rear",
+                "upd": {
+                    "Sight": {
+                        "ScopesCurrentCalibPointIndexes": [
+                            0
+                        ],
+                        "ScopesSelectedModes": [
+                            0
+                        ],
+                        "SelectedScope": 0,
+                        "ScopeZoomValue": 0
+                    }
+                }
+            },
+            {
+                "_id": "66edbe3ed669f19445165452",
+                "_tpl": "5c793fb92e221644f31bfb64",
+                "parentId": "670b6ddf2b270b4d490ad8a8",
+                "slotId": "mod_stock"
+            },
+            {
+                "_id": "66edbe3ed669f19445165453",
+                "_tpl": "6516e91f609aaf354b34b3e2",
+                "parentId": "66edbe3ed669f19445165452",
+                "slotId": "mod_stock_000"
+            },
+            {
+                "_id": "66edbe3ed669f19445165454",
+                "_tpl": "6516e9d7e239bd0c487e3766",
+                "parentId": "66edbe3ed669f19445165453",
+                "slotId": "mod_stock_000"
+            },
+            {
+                "_id": "66edbe3ed669f1944516544f",
+                "_tpl": "55d44fd14bdc2d962f8b456e",
+                "parentId": "670b6ddf2b270b4d490ad8a8",
+                "slotId": "mod_charge"
+            },
+            {
+                "_id": "670b744f41b6b2a4e4000020",
+                "_tpl": "54527ac44bdc2d36668b4567",
+                "parentId": "670b6ddf2b270b4d490ad8a8",
+                "slotId": "patron_in_weapon"
+            },
+            {
+                "_id": "66c668a731b6103cd205fe49",
+                "_tpl": "545cdae64bdc2d39198b4568",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "Backpack"
+            },
+            {
+                "_id": "670b44a1f9f68ea41812646b",
+                "_tpl": "633ec7c2a6918cb895019c6c",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "Holster",
+                "upd": {
+                    "Repairable": {
+                        "MaxDurability": 100,
+                        "Durability": 99.2221146
+                    },
+                    "FireMode": {
+                        "FireMode": "single"
+                    }
+                }
+            },
+            {
+                "_id": "670b44a1f9f68ea41812646c",
+                "_tpl": "633ec6ee025b096d320a3b15",
+                "parentId": "670b44a1f9f68ea41812646b",
+                "slotId": "mod_magazine"
+            },
+            {
+                "_id": "670b44a1f9f68ea41812646d",
+                "_tpl": "633ec8e4025b096d320a3b1e",
+                "parentId": "670b44a1f9f68ea41812646b",
+                "slotId": "mod_pistol_grip"
+            },
+            {
+                "_id": "670b44a1f9f68ea41812646e",
+                "_tpl": "6272370ee4013c5d7e31f418",
+                "parentId": "670b44a1f9f68ea41812646b",
+                "slotId": "mod_tactical",
+                "upd": {
+                    "Light": {
+                        "IsActive": false,
+                        "SelectedMode": 1
+                    }
+                }
+            },
+            {
+                "_id": "670b44a1f9f68ea41812646f",
+                "_tpl": "57c69dd424597774c03b7bbc",
+                "parentId": "670b44a1f9f68ea41812646b",
+                "slotId": "mod_scope"
+            },
+            {
+                "_id": "670b44a1f9f68ea418126470",
+                "_tpl": "5b2388675acfc4771e1be0be",
+                "parentId": "670b44a1f9f68ea41812646f",
+                "slotId": "mod_scope",
+                "upd": {
+                    "Sight": {
+                        "ScopesCurrentCalibPointIndexes": [
+                            0
+                        ],
+                        "ScopesSelectedModes": [
+                            0
+                        ],
+                        "SelectedScope": 0,
+                        "ScopeZoomValue": 0
+                    }
+                }
+            },
+            {
+                "_id": "671be1f961942d96af055987",
+                "_tpl": "5aa2ba71e5b5b000137b758f",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "Earpiece",
+                "upd": {
+                    "StackObjectsCount": 1
+                }
+            },
+            {
+                "_id": "671be1fcdccdaae30b067b2a",
+                "_tpl": "5b432f3d5acfc4704b4a1dfb",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "FaceCover",
+                "upd": {
+                    "StackObjectsCount": 1,
+                    "Repairable": {
+                        "MaxDurability": 100,
+                        "Durability": 100
+                    }
+                }
+            },
+            {
+                "_id": "671be7ff1f6105ccc3057081",
+                "_tpl": "5c0d32fcd174af02a1659c75",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "Eyewear",
+                "upd": {
+                    "StackObjectsCount": 1
+                }
+            }
+        ]
+    },
+    "achievements": {
+        "65141c30ec10ff011f17cc3b": 1704093498,
+        "65141c80ec10ff011f17cc3e": 1704098100,
+        "65141eb5c31fcb0e163577dd": 1704139506,
+        "65141e37cf2f1c285e606361": 1704169569,
+        "6512ea46f7a078264a4376e4": 1704340463,
+        "6527ee4a647c29201011defe": 1704660209,
+        "65141b9859647d2cb3213ca2": 1704695763,
+        "6513eb6e0dc723592b0f9095": 1705130359,
+        "6512eb3ddfb0ae1ee75a0376": 1705305836,
+        "65141bdfcf2f1c285e606446": 1705811984,
+        "6513ee11a3dd9b6aa7159b4a": 1706348261,
+        "6512f1e3be73cc7f07358ed5": 1707112841,
+        "65141dd6303df252af1c72c9": 1712469793,
+        "6513f0a10dc723592b0f90cf": 1715126717,
+        "655b49bc91aa9e07687ae47c": 1717218630,
+        "6513eec00dc723592b0f90cc": 1717356486,
+        "6513efa1b49e3253755f47eb": 1717477240,
+        "66c328aca91e7d66fa1b0b7b": 1724538538,
+        "66b493bc2d8cd3b5e90a3648": 1728368856
+    },
+    "favoriteItems": [],
+    "pmcStats": {
+        "eft": {
+            "totalInGameTime": 17432315,
+            "overAllCounters": {
+                "Items": [
+                    {
+                        "Key": [
+                            "Sessions",
+                            "Pmc"
+                        ],
+                        "Value": 253
+                    },
+                    {
+                        "Key": [
+                            "ExitStatus",
+                            "Killed",
+                            "Pmc"
+                        ],
+                        "Value": 120
+                    },
+                    {
+                        "Key": [
+                            "Kills"
+                        ],
+                        "Value": 808
+                    },
+                    {
+                        "Key": [
+                            "Deaths"
+                        ],
+                        "Value": 120
+                    },
+                    {
+                        "Key": [
+                            "ExitStatus",
+                            "Survived",
+                            "Pmc"
+                        ],
+                        "Value": 118
+                    },
+                    {
+                        "Key": [
+                            "LongestWinStreak",
+                            "Pmc"
+                        ],
+                        "Value": 11
+                    },
+                    {
+                        "Key": [
+                            "ExitStatus",
+                            "Transit",
+                            "Pmc"
+                        ],
+                        "Value": 15
+                    }
+                ]
+            }
+        }
+    },
+    "scavStats": {
+        "eft": {
+            "totalInGameTime": 17432315,
+            "overAllCounters": {
+                "Items": [
+                    {
+                        "Key": [
+                            "Sessions",
+                            "Scav"
+                        ],
+                        "Value": 33
+                    },
+                    {
+                        "Key": [
+                            "ExitStatus",
+                            "Survived",
+                            "Scav"
+                        ],
+                        "Value": 20
+                    },
+                    {
+                        "Key": [
+                            "Kills"
+                        ],
+                        "Value": 11
+                    },
+                    {
+                        "Key": [
+                            "Deaths"
+                        ],
+                        "Value": 13
+                    },
+                    {
+                        "Key": [
+                            "LongestWinStreak",
+                            "Scav"
+                        ],
+                        "Value": 10
+                    },
+                    {
+                        "Key": [
+                            "ExitStatus",
+                            "Killed",
+                            "Scav"
+                        ],
+                        "Value": 11
+                    },
+                    {
+                        "Key": [
+                            "ExitStatus",
+                            "Left",
+                            "Scav"
+                        ],
+                        "Value": 2
+                    }
+                ]
+            }
+        }
+    },
+    "updated": 1729882311735
+}

--- a/src/pages/player/saved-profiles-issue#1000/standard-armor-with-rig.json
+++ b/src/pages/player/saved-profiles-issue#1000/standard-armor-with-rig.json
@@ -1,0 +1,1034 @@
+{
+    "aid": 5598985,
+    "info": {
+        "nickname": "applefrittr",
+        "side": "Bear",
+        "experience": 1367682,
+        "memberCategory": 2,
+        "selectedMemberCategory": 2
+    },
+    "customization": {
+        "head": "5cc084dd14c02e000b0550a3",
+        "body": "6295e698e9de5e7b3751c47a",
+        "feet": "65707a89f5a6f1412f0c5f7b",
+        "hands": "62961424869a02221651df53"
+    },
+    "skills": {
+        "Common": [
+            {
+                "Id": "BotReload",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": -2147483648
+            },
+            {
+                "Id": "BotSound",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": -2147483648
+            },
+            {
+                "Id": "Endurance",
+                "Progress": 1148.40637,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753553
+            },
+            {
+                "Id": "Strength",
+                "Progress": 1225.64673,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753793
+            },
+            {
+                "Id": "Vitality",
+                "Progress": 574.796143,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753793
+            },
+            {
+                "Id": "Health",
+                "Progress": 1055.7666,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753793
+            },
+            {
+                "Id": "StressResistance",
+                "Progress": 524.947937,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753793
+            },
+            {
+                "Id": "Metabolism",
+                "Progress": 2076.95483,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753106
+            },
+            {
+                "Id": "Immunity",
+                "Progress": 111.965736,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729558969
+            },
+            {
+                "Id": "Perception",
+                "Progress": 1014.106,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753618
+            },
+            {
+                "Id": "Intellect",
+                "Progress": 13.02,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729568635
+            },
+            {
+                "Id": "Attention",
+                "Progress": 1156.84351,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753617
+            },
+            {
+                "Id": "Charisma",
+                "Progress": 873.2466,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753618
+            },
+            {
+                "Id": "Pistol",
+                "Progress": 82.2000046,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729750541
+            },
+            {
+                "Id": "Revolver",
+                "Progress": 13.55,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1728790987
+            },
+            {
+                "Id": "SMG",
+                "Progress": 425.909241,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729653336
+            },
+            {
+                "Id": "Assault",
+                "Progress": 571.2419,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753724
+            },
+            {
+                "Id": "Shotgun",
+                "Progress": 240.813034,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729651901
+            },
+            {
+                "Id": "Sniper",
+                "Progress": 258.222,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729750868
+            },
+            {
+                "Id": "LMG",
+                "Progress": 34.6999931,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1728024507
+            },
+            {
+                "Id": "HMG",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "Launcher",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "AttachedLauncher",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "Throwing",
+                "Progress": 63.6999741,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729749646
+            },
+            {
+                "Id": "Melee",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "DMR",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "AimDrills",
+                "Progress": 539.609558,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753723
+            },
+            {
+                "Id": "TroubleShooting",
+                "Progress": 31.6,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729482181
+            },
+            {
+                "Id": "Surgery",
+                "Progress": 384.7879,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729750002
+            },
+            {
+                "Id": "CovertMovement",
+                "Progress": 313.145081,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753656
+            },
+            {
+                "Id": "Search",
+                "Progress": 626.9003,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753567
+            },
+            {
+                "Id": "MagDrills",
+                "Progress": 301.436981,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753726
+            },
+            {
+                "Id": "FieldMedicine",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "FirstAid",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "LightVests",
+                "Progress": 227.948578,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729749604
+            },
+            {
+                "Id": "HeavyVests",
+                "Progress": 275.265625,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729750539
+            },
+            {
+                "Id": "NightOps",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "SilentOps",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "WeaponTreatment",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "Auctions",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "Cleanoperations",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "Shadowconnections",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "Taskperformance",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "Crafting",
+                "Progress": 126,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1728362172
+            },
+            {
+                "Id": "HideoutManagement",
+                "Progress": 840.86,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729144095
+            }
+        ],
+        "Mastering": [
+            {
+                "Id": "AKM",
+                "Progress": 183
+            },
+            {
+                "Id": "AK74",
+                "Progress": 438
+            },
+            {
+                "Id": "mosin",
+                "Progress": 161
+            },
+            {
+                "Id": "DEAGLE",
+                "Progress": 7
+            },
+            {
+                "Id": "M590",
+                "Progress": 0
+            },
+            {
+                "Id": "Mk17",
+                "Progress": 21
+            },
+            {
+                "Id": "PP19",
+                "Progress": 44
+            },
+            {
+                "Id": "MP133",
+                "Progress": 0
+            },
+            {
+                "Id": "GLOCK17",
+                "Progress": 15
+            },
+            {
+                "Id": "AKSU",
+                "Progress": 255
+            },
+            {
+                "Id": "SKS",
+                "Progress": 224
+            },
+            {
+                "Id": "M4",
+                "Progress": 23
+            },
+            {
+                "Id": "MP443",
+                "Progress": 24
+            },
+            {
+                "Id": "VPO101",
+                "Progress": 21
+            },
+            {
+                "Id": "r700",
+                "Progress": 0
+            },
+            {
+                "Id": "PM",
+                "Progress": 1
+            },
+            {
+                "Id": "M870",
+                "Progress": 0
+            },
+            {
+                "Id": "MP153",
+                "Progress": 562
+            },
+            {
+                "Id": "STM-9",
+                "Progress": 10
+            },
+            {
+                "Id": "M60",
+                "Progress": 11
+            },
+            {
+                "Id": "UMP45",
+                "Progress": 64
+            },
+            {
+                "Id": "m9",
+                "Progress": 3
+            },
+            {
+                "Id": "SV98",
+                "Progress": 20
+            },
+            {
+                "Id": "G36",
+                "Progress": 20
+            },
+            {
+                "Id": "UZI",
+                "Progress": 71
+            },
+            {
+                "Id": "MP5",
+                "Progress": 102
+            },
+            {
+                "Id": "PL15",
+                "Progress": 6
+            },
+            {
+                "Id": "UZI-PRO",
+                "Progress": 354
+            },
+            {
+                "Id": "SAIGA",
+                "Progress": 26
+            },
+            {
+                "Id": "MDR",
+                "Progress": 129
+            },
+            {
+                "Id": "MP9",
+                "Progress": 403
+            },
+            {
+                "Id": "MCX",
+                "Progress": 2
+            },
+            {
+                "Id": "SVD",
+                "Progress": 0
+            },
+            {
+                "Id": "P226",
+                "Progress": 0
+            },
+            {
+                "Id": "DVL",
+                "Progress": 1
+            },
+            {
+                "Id": "PP-91",
+                "Progress": 12
+            },
+            {
+                "Id": "PB",
+                "Progress": 0
+            },
+            {
+                "Id": "MK47",
+                "Progress": 3
+            },
+            {
+                "Id": "VSS",
+                "Progress": 54
+            },
+            {
+                "Id": "SPEAR",
+                "Progress": 0
+            },
+            {
+                "Id": "SR2",
+                "Progress": 71
+            },
+            {
+                "Id": "RSH12",
+                "Progress": 9
+            },
+            {
+                "Id": "SVT-40",
+                "Progress": 12
+            },
+            {
+                "Id": "USP",
+                "Progress": 0
+            },
+            {
+                "Id": "VSK94",
+                "Progress": 103
+            },
+            {
+                "Id": 57,
+                "Progress": 5
+            },
+            {
+                "Id": "AUG",
+                "Progress": 409
+            },
+            {
+                "Id": "MR43",
+                "Progress": 0
+            },
+            {
+                "Id": "TOZ106",
+                "Progress": 0
+            },
+            {
+                "Id": "VPO_215",
+                "Progress": 1
+            },
+            {
+                "Id": "mp7",
+                "Progress": 0
+            },
+            {
+                "Id": "MPX",
+                "Progress": 0
+            }
+        ],
+        "Points": 0
+    },
+    "equipment": {
+        "Id": "66c4b690fbf6319b1e11c422",
+        "Items": [
+            {
+                "_id": "66c4b690fbf6319b1e11c422",
+                "_tpl": "55d7217a4bdc2d86028b456d"
+            },
+            {
+                "_id": "670a14b67e0ea2f5db119329",
+                "_tpl": "601948682627df266209af05",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "Scabbard",
+                "upd": {
+                    "Repairable": {
+                        "MaxDurability": 90,
+                        "Durability": 90
+                    }
+                }
+            },
+            {
+                "_id": "66c4b690fbf6319b1e11c412",
+                "_tpl": "5857a8bc2459772bad15db29",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "SecuredContainer"
+            },
+            {
+                "_id": "66c4b690fbf6319b1e11c420",
+                "_tpl": "627a4e6b255f7527fb05a0f6",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "Pockets"
+            },
+            {
+                "_id": "66c5489ecc10fe584117bc59",
+                "_tpl": "60b0f988c4449e4cb624c1da",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "ArmBand"
+            },
+            {
+                "_id": "6716f6a63716047cfa051aa3",
+                "_tpl": "5ab8e79e86f7742d8b372e78",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "ArmorVest",
+                "upd": {
+                    "SpawnedInSession": true
+                }
+            },
+            {
+                "_id": "6716f6a63716047cfa051aa4",
+                "_tpl": "656f611f94b480b8a500c0db",
+                "parentId": "6716f6a63716047cfa051aa3",
+                "slotId": "Front_plate",
+                "upd": {
+                    "SpawnedInSession": true,
+                    "Repairable": {
+                        "MaxDurability": 50,
+                        "Durability": 28
+                    }
+                }
+            },
+            {
+                "_id": "6716f6a63716047cfa051aa5",
+                "_tpl": "65573fa5655447403702a816",
+                "parentId": "6716f6a63716047cfa051aa3",
+                "slotId": "Back_plate",
+                "upd": {
+                    "SpawnedInSession": true,
+                    "Repairable": {
+                        "MaxDurability": 55,
+                        "Durability": 29
+                    }
+                }
+            },
+            {
+                "_id": "6716f6a63716047cfa051aa6",
+                "_tpl": "65732688d9d89ff7ac0d9c4c",
+                "parentId": "6716f6a63716047cfa051aa3",
+                "slotId": "Soft_armor_front",
+                "upd": {
+                    "SpawnedInSession": true,
+                    "Repairable": {
+                        "MaxDurability": 54.33,
+                        "Durability": 49.13
+                    }
+                }
+            },
+            {
+                "_id": "6716f6a63716047cfa051aa7",
+                "_tpl": "657326978c1cc6dcd9098b56",
+                "parentId": "6716f6a63716047cfa051aa3",
+                "slotId": "Soft_armor_back",
+                "upd": {
+                    "SpawnedInSession": true,
+                    "Repairable": {
+                        "MaxDurability": 52.67,
+                        "Durability": 45.83
+                    }
+                }
+            },
+            {
+                "_id": "6716f6a63716047cfa051aa8",
+                "_tpl": "657326a28c1cc6dcd9098b5a",
+                "parentId": "6716f6a63716047cfa051aa3",
+                "slotId": "Soft_armor_left",
+                "upd": {
+                    "SpawnedInSession": true,
+                    "Repairable": {
+                        "MaxDurability": 13.39,
+                        "Durability": 11.46
+                    }
+                }
+            },
+            {
+                "_id": "6716f6a63716047cfa051aa9",
+                "_tpl": "657326b08c1cc6dcd9098b5e",
+                "parentId": "6716f6a63716047cfa051aa3",
+                "slotId": "soft_armor_right",
+                "upd": {
+                    "SpawnedInSession": true,
+                    "Repairable": {
+                        "MaxDurability": 13.44,
+                        "Durability": 11.46
+                    }
+                }
+            },
+            {
+                "_id": "6716f6a63716047cfa051aaa",
+                "_tpl": "657326bc5d3a3129fb05f36b",
+                "parentId": "6716f6a63716047cfa051aa3",
+                "slotId": "Collar",
+                "upd": {
+                    "SpawnedInSession": true,
+                    "Repairable": {
+                        "MaxDurability": 13.39,
+                        "Durability": 11.79
+                    }
+                }
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a89",
+                "_tpl": "5447a9cd4bdc2dbd208b4567",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "FirstPrimaryWeapon",
+                "upd": {
+                    "Repairable": {
+                        "MaxDurability": 97.63,
+                        "Durability": 96.59441
+                    },
+                    "FireMode": {
+                        "FireMode": "fullauto"
+                    }
+                }
+            },
+            {
+                "_id": "6715dacea0e10764af01aa95",
+                "_tpl": "6113cce3d92c473c770200c7",
+                "parentId": "6704a3ac80fd1dac0f111a89",
+                "slotId": "mod_pistol_grip"
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a8a",
+                "_tpl": "55802d5f4bdc2dac148b458e",
+                "parentId": "6704a3ac80fd1dac0f111a89",
+                "slotId": "mod_magazine"
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a8b",
+                "_tpl": "55d355e64bdc2d962f8b4569",
+                "parentId": "6704a3ac80fd1dac0f111a89",
+                "slotId": "mod_reciever"
+            },
+            {
+                "_id": "6715dacea0e10764af01aa94",
+                "_tpl": "5b3b99265acfc4704b4a1afb",
+                "parentId": "6704a3ac80fd1dac0f111a8b",
+                "slotId": "mod_scope"
+            },
+            {
+                "_id": "6715daeeb74743dec608f495",
+                "_tpl": "5b3b99475acfc432ff4dcbee",
+                "parentId": "6715dacea0e10764af01aa94",
+                "slotId": "mod_scope",
+                "upd": {
+                    "Sight": {
+                        "ScopesCurrentCalibPointIndexes": [
+                            0
+                        ],
+                        "ScopesSelectedModes": [
+                            0
+                        ],
+                        "SelectedScope": 0,
+                        "ScopeZoomValue": 0
+                    }
+                }
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a8c",
+                "_tpl": "63d3d44a2a49307baf09386d",
+                "parentId": "6704a3ac80fd1dac0f111a8b",
+                "slotId": "mod_barrel"
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a8e",
+                "_tpl": "6386120cd6baa055ad1e201c",
+                "parentId": "6704a3ac80fd1dac0f111a8c",
+                "slotId": "mod_muzzle"
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a8f",
+                "_tpl": "638612b607dfed1ccb7206ba",
+                "parentId": "6704a3ac80fd1dac0f111a8e",
+                "slotId": "mod_muzzle"
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a8d",
+                "_tpl": "63d3ce281fe77d0f2801859e",
+                "parentId": "6704a3ac80fd1dac0f111a8c",
+                "slotId": "mod_gas_block"
+            },
+            {
+                "_id": "6715dacea0e10764af01aa97",
+                "_tpl": "595cfa8b86f77427437e845b",
+                "parentId": "6704a3ac80fd1dac0f111a8b",
+                "slotId": "mod_handguard"
+            },
+            {
+                "_id": "6715dacea0e10764af01aa93",
+                "_tpl": "59e0bed186f774156f04ce84",
+                "parentId": "6715dacea0e10764af01aa97",
+                "slotId": "mod_mount_000"
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a94",
+                "_tpl": "5b057b4f5acfc4771e1bd3e9",
+                "parentId": "6715dacea0e10764af01aa93",
+                "slotId": "mod_foregrip"
+            },
+            {
+                "_id": "6715dacea0e10764af01aa92",
+                "_tpl": "59e0bdb186f774156f04ce82",
+                "parentId": "6715dacea0e10764af01aa97",
+                "slotId": "mod_mount_004"
+            },
+            {
+                "_id": "6715dacea0e10764af01aa96",
+                "_tpl": "5a5f1ce64f39f90b401987bc",
+                "parentId": "6715dacea0e10764af01aa92",
+                "slotId": "mod_tactical",
+                "upd": {
+                    "Light": {
+                        "IsActive": false,
+                        "SelectedMode": 0
+                    }
+                }
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a90",
+                "_tpl": "5c1780312e221602b66cc189",
+                "parentId": "6704a3ac80fd1dac0f111a8b",
+                "slotId": "mod_sight_rear",
+                "upd": {
+                    "Sight": {
+                        "ScopesCurrentCalibPointIndexes": [
+                            0
+                        ],
+                        "ScopesSelectedModes": [
+                            0
+                        ],
+                        "SelectedScope": 0,
+                        "ScopeZoomValue": 0
+                    }
+                }
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a96",
+                "_tpl": "5c793fb92e221644f31bfb64",
+                "parentId": "6704a3ac80fd1dac0f111a89",
+                "slotId": "mod_stock"
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a97",
+                "_tpl": "58d2946386f774496974c37e",
+                "parentId": "6704a3ac80fd1dac0f111a96",
+                "slotId": "mod_stock_000"
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a98",
+                "_tpl": "58d2912286f7744e27117493",
+                "parentId": "6704a3ac80fd1dac0f111a97",
+                "slotId": "mod_stock"
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a9a",
+                "_tpl": "5f633ff5c444ce7e3c30a006",
+                "parentId": "6704a3ac80fd1dac0f111a89",
+                "slotId": "mod_charge"
+            },
+            {
+                "_id": "6715e1c1375fbc5538000011",
+                "_tpl": "54527ac44bdc2d36668b4567",
+                "parentId": "6704a3ac80fd1dac0f111a89",
+                "slotId": "patron_in_weapon"
+            },
+            {
+                "_id": "6715d957ccf545164f0b62db",
+                "_tpl": "5e9db13186f7742f845ee9d3",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "TacticalVest",
+                "upd": {
+                    "SpawnedInSession": true
+                }
+            },
+            {
+                "_id": "6711c390e2b768e414139748",
+                "_tpl": "5ea17ca01412a1425304d1c0",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "Headwear"
+            },
+            {
+                "_id": "6715d9bec5fd49128e088e12",
+                "_tpl": "5c0558060db834001b735271",
+                "parentId": "6711c390e2b768e414139748",
+                "slotId": "mod_nvg",
+                "upd": {
+                    "Sight": {
+                        "ScopesCurrentCalibPointIndexes": [
+                            0
+                        ],
+                        "ScopesSelectedModes": [
+                            0
+                        ],
+                        "SelectedScope": 0,
+                        "ScopeZoomValue": 0
+                    },
+                    "Togglable": {
+                        "On": true
+                    }
+                }
+            },
+            {
+                "_id": "6711c390e2b768e414139749",
+                "_tpl": "657f9a55c6679fefb3051e19",
+                "parentId": "6711c390e2b768e414139748",
+                "slotId": "Helmet_top",
+                "upd": {
+                    "Repairable": {
+                        "MaxDurability": 21.52,
+                        "Durability": 15.3870106
+                    }
+                }
+            },
+            {
+                "_id": "6711c390e2b768e41413974a",
+                "_tpl": "657f9a94ada5fadd1f07a589",
+                "parentId": "6711c390e2b768e414139748",
+                "slotId": "Helmet_back",
+                "upd": {
+                    "Repairable": {
+                        "MaxDurability": 18.96,
+                        "Durability": 18.29
+                    }
+                }
+            },
+            {
+                "_id": "66c668a731b6103cd205fe49",
+                "_tpl": "545cdae64bdc2d39198b4568",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "Backpack"
+            },
+            {
+                "_id": "671be1f961942d96af055987",
+                "_tpl": "5aa2ba71e5b5b000137b758f",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "Earpiece",
+                "upd": {
+                    "StackObjectsCount": 1
+                }
+            },
+            {
+                "_id": "671be1fcdccdaae30b067b2a",
+                "_tpl": "5b432f3d5acfc4704b4a1dfb",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "FaceCover",
+                "upd": {
+                    "StackObjectsCount": 1,
+                    "Repairable": {
+                        "MaxDurability": 100,
+                        "Durability": 100
+                    }
+                }
+            }
+        ]
+    },
+    "achievements": {
+        "65141c30ec10ff011f17cc3b": 1704093498,
+        "65141c80ec10ff011f17cc3e": 1704098100,
+        "65141eb5c31fcb0e163577dd": 1704139506,
+        "65141e37cf2f1c285e606361": 1704169569,
+        "6512ea46f7a078264a4376e4": 1704340463,
+        "6527ee4a647c29201011defe": 1704660209,
+        "65141b9859647d2cb3213ca2": 1704695763,
+        "6513eb6e0dc723592b0f9095": 1705130359,
+        "6512eb3ddfb0ae1ee75a0376": 1705305836,
+        "65141bdfcf2f1c285e606446": 1705811984,
+        "6513ee11a3dd9b6aa7159b4a": 1706348261,
+        "6512f1e3be73cc7f07358ed5": 1707112841,
+        "65141dd6303df252af1c72c9": 1712469793,
+        "6513f0a10dc723592b0f90cf": 1715126717,
+        "655b49bc91aa9e07687ae47c": 1717218630,
+        "6513eec00dc723592b0f90cc": 1717356486,
+        "6513efa1b49e3253755f47eb": 1717477240,
+        "66c328aca91e7d66fa1b0b7b": 1724538538,
+        "66b493bc2d8cd3b5e90a3648": 1728368856
+    },
+    "favoriteItems": [],
+    "pmcStats": {
+        "eft": {
+            "totalInGameTime": 17432315,
+            "overAllCounters": {
+                "Items": [
+                    {
+                        "Key": [
+                            "Sessions",
+                            "Pmc"
+                        ],
+                        "Value": 253
+                    },
+                    {
+                        "Key": [
+                            "ExitStatus",
+                            "Killed",
+                            "Pmc"
+                        ],
+                        "Value": 120
+                    },
+                    {
+                        "Key": [
+                            "Kills"
+                        ],
+                        "Value": 808
+                    },
+                    {
+                        "Key": [
+                            "Deaths"
+                        ],
+                        "Value": 120
+                    },
+                    {
+                        "Key": [
+                            "ExitStatus",
+                            "Survived",
+                            "Pmc"
+                        ],
+                        "Value": 118
+                    },
+                    {
+                        "Key": [
+                            "LongestWinStreak",
+                            "Pmc"
+                        ],
+                        "Value": 11
+                    },
+                    {
+                        "Key": [
+                            "ExitStatus",
+                            "Transit",
+                            "Pmc"
+                        ],
+                        "Value": 15
+                    }
+                ]
+            }
+        }
+    },
+    "scavStats": {
+        "eft": {
+            "totalInGameTime": 17432315,
+            "overAllCounters": {
+                "Items": [
+                    {
+                        "Key": [
+                            "Sessions",
+                            "Scav"
+                        ],
+                        "Value": 33
+                    },
+                    {
+                        "Key": [
+                            "ExitStatus",
+                            "Survived",
+                            "Scav"
+                        ],
+                        "Value": 20
+                    },
+                    {
+                        "Key": [
+                            "Kills"
+                        ],
+                        "Value": 11
+                    },
+                    {
+                        "Key": [
+                            "Deaths"
+                        ],
+                        "Value": 13
+                    },
+                    {
+                        "Key": [
+                            "LongestWinStreak",
+                            "Scav"
+                        ],
+                        "Value": 10
+                    },
+                    {
+                        "Key": [
+                            "ExitStatus",
+                            "Killed",
+                            "Scav"
+                        ],
+                        "Value": 11
+                    },
+                    {
+                        "Key": [
+                            "ExitStatus",
+                            "Left",
+                            "Scav"
+                        ],
+                        "Value": 2
+                    }
+                ]
+            }
+        }
+    },
+    "updated": 1729881359927
+}

--- a/src/pages/player/saved-profiles-issue#1000/standard-armoredRig.json
+++ b/src/pages/player/saved-profiles-issue#1000/standard-armoredRig.json
@@ -1,0 +1,931 @@
+{
+    "aid": 5598985,
+    "info": {
+        "nickname": "applefrittr",
+        "side": "Bear",
+        "experience": 1367682,
+        "memberCategory": 2,
+        "selectedMemberCategory": 2
+    },
+    "customization": {
+        "head": "5cc084dd14c02e000b0550a3",
+        "body": "6295e698e9de5e7b3751c47a",
+        "feet": "65707a89f5a6f1412f0c5f7b",
+        "hands": "62961424869a02221651df53"
+    },
+    "skills": {
+        "Common": [
+            {
+                "Id": "BotReload",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": -2147483648
+            },
+            {
+                "Id": "BotSound",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": -2147483648
+            },
+            {
+                "Id": "Endurance",
+                "Progress": 1148.40637,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753553
+            },
+            {
+                "Id": "Strength",
+                "Progress": 1225.64673,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753793
+            },
+            {
+                "Id": "Vitality",
+                "Progress": 574.796143,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753793
+            },
+            {
+                "Id": "Health",
+                "Progress": 1055.7666,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753793
+            },
+            {
+                "Id": "StressResistance",
+                "Progress": 524.947937,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753793
+            },
+            {
+                "Id": "Metabolism",
+                "Progress": 2076.95483,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753106
+            },
+            {
+                "Id": "Immunity",
+                "Progress": 111.965736,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729558969
+            },
+            {
+                "Id": "Perception",
+                "Progress": 1014.106,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753618
+            },
+            {
+                "Id": "Intellect",
+                "Progress": 13.02,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729568635
+            },
+            {
+                "Id": "Attention",
+                "Progress": 1156.84351,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753617
+            },
+            {
+                "Id": "Charisma",
+                "Progress": 873.2466,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753618
+            },
+            {
+                "Id": "Pistol",
+                "Progress": 82.2000046,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729750541
+            },
+            {
+                "Id": "Revolver",
+                "Progress": 13.55,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1728790987
+            },
+            {
+                "Id": "SMG",
+                "Progress": 425.909241,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729653336
+            },
+            {
+                "Id": "Assault",
+                "Progress": 571.2419,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753724
+            },
+            {
+                "Id": "Shotgun",
+                "Progress": 240.813034,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729651901
+            },
+            {
+                "Id": "Sniper",
+                "Progress": 258.222,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729750868
+            },
+            {
+                "Id": "LMG",
+                "Progress": 34.6999931,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1728024507
+            },
+            {
+                "Id": "HMG",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "Launcher",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "AttachedLauncher",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "Throwing",
+                "Progress": 63.6999741,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729749646
+            },
+            {
+                "Id": "Melee",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "DMR",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "AimDrills",
+                "Progress": 539.609558,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753723
+            },
+            {
+                "Id": "TroubleShooting",
+                "Progress": 31.6,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729482181
+            },
+            {
+                "Id": "Surgery",
+                "Progress": 384.7879,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729750002
+            },
+            {
+                "Id": "CovertMovement",
+                "Progress": 313.145081,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753656
+            },
+            {
+                "Id": "Search",
+                "Progress": 626.9003,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753567
+            },
+            {
+                "Id": "MagDrills",
+                "Progress": 301.436981,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729753726
+            },
+            {
+                "Id": "FieldMedicine",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "FirstAid",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "LightVests",
+                "Progress": 227.948578,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729749604
+            },
+            {
+                "Id": "HeavyVests",
+                "Progress": 275.265625,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729750539
+            },
+            {
+                "Id": "NightOps",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "SilentOps",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "WeaponTreatment",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "Auctions",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "Cleanoperations",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "Shadowconnections",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "Taskperformance",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "Crafting",
+                "Progress": 126,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1728362172
+            },
+            {
+                "Id": "HideoutManagement",
+                "Progress": 840.86,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729144095
+            }
+        ],
+        "Mastering": [
+            {
+                "Id": "AKM",
+                "Progress": 183
+            },
+            {
+                "Id": "AK74",
+                "Progress": 438
+            },
+            {
+                "Id": "mosin",
+                "Progress": 161
+            },
+            {
+                "Id": "DEAGLE",
+                "Progress": 7
+            },
+            {
+                "Id": "M590",
+                "Progress": 0
+            },
+            {
+                "Id": "Mk17",
+                "Progress": 21
+            },
+            {
+                "Id": "PP19",
+                "Progress": 44
+            },
+            {
+                "Id": "MP133",
+                "Progress": 0
+            },
+            {
+                "Id": "GLOCK17",
+                "Progress": 15
+            },
+            {
+                "Id": "AKSU",
+                "Progress": 255
+            },
+            {
+                "Id": "SKS",
+                "Progress": 224
+            },
+            {
+                "Id": "M4",
+                "Progress": 23
+            },
+            {
+                "Id": "MP443",
+                "Progress": 24
+            },
+            {
+                "Id": "VPO101",
+                "Progress": 21
+            },
+            {
+                "Id": "r700",
+                "Progress": 0
+            },
+            {
+                "Id": "PM",
+                "Progress": 1
+            },
+            {
+                "Id": "M870",
+                "Progress": 0
+            },
+            {
+                "Id": "MP153",
+                "Progress": 562
+            },
+            {
+                "Id": "STM-9",
+                "Progress": 10
+            },
+            {
+                "Id": "M60",
+                "Progress": 11
+            },
+            {
+                "Id": "UMP45",
+                "Progress": 64
+            },
+            {
+                "Id": "m9",
+                "Progress": 3
+            },
+            {
+                "Id": "SV98",
+                "Progress": 20
+            },
+            {
+                "Id": "G36",
+                "Progress": 20
+            },
+            {
+                "Id": "UZI",
+                "Progress": 71
+            },
+            {
+                "Id": "MP5",
+                "Progress": 102
+            },
+            {
+                "Id": "PL15",
+                "Progress": 6
+            },
+            {
+                "Id": "UZI-PRO",
+                "Progress": 354
+            },
+            {
+                "Id": "SAIGA",
+                "Progress": 26
+            },
+            {
+                "Id": "MDR",
+                "Progress": 129
+            },
+            {
+                "Id": "MP9",
+                "Progress": 403
+            },
+            {
+                "Id": "MCX",
+                "Progress": 2
+            },
+            {
+                "Id": "SVD",
+                "Progress": 0
+            },
+            {
+                "Id": "P226",
+                "Progress": 0
+            },
+            {
+                "Id": "DVL",
+                "Progress": 1
+            },
+            {
+                "Id": "PP-91",
+                "Progress": 12
+            },
+            {
+                "Id": "PB",
+                "Progress": 0
+            },
+            {
+                "Id": "MK47",
+                "Progress": 3
+            },
+            {
+                "Id": "VSS",
+                "Progress": 54
+            },
+            {
+                "Id": "SPEAR",
+                "Progress": 0
+            },
+            {
+                "Id": "SR2",
+                "Progress": 71
+            },
+            {
+                "Id": "RSH12",
+                "Progress": 9
+            },
+            {
+                "Id": "SVT-40",
+                "Progress": 12
+            },
+            {
+                "Id": "USP",
+                "Progress": 0
+            },
+            {
+                "Id": "VSK94",
+                "Progress": 103
+            },
+            {
+                "Id": 57,
+                "Progress": 5
+            },
+            {
+                "Id": "AUG",
+                "Progress": 409
+            },
+            {
+                "Id": "MR43",
+                "Progress": 0
+            },
+            {
+                "Id": "TOZ106",
+                "Progress": 0
+            },
+            {
+                "Id": "VPO_215",
+                "Progress": 1
+            },
+            {
+                "Id": "mp7",
+                "Progress": 0
+            },
+            {
+                "Id": "MPX",
+                "Progress": 0
+            }
+        ],
+        "Points": 0
+    },
+    "equipment": {
+        "Id": "66c4b690fbf6319b1e11c422",
+        "Items": [
+            {
+                "_id": "66c4b690fbf6319b1e11c422",
+                "_tpl": "55d7217a4bdc2d86028b456d"
+            },
+            {
+                "_id": "670a14b67e0ea2f5db119329",
+                "_tpl": "601948682627df266209af05",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "Scabbard",
+                "upd": {
+                    "Repairable": {
+                        "MaxDurability": 90,
+                        "Durability": 90
+                    }
+                }
+            },
+            {
+                "_id": "66c4b690fbf6319b1e11c412",
+                "_tpl": "5857a8bc2459772bad15db29",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "SecuredContainer"
+            },
+            {
+                "_id": "66c4b690fbf6319b1e11c420",
+                "_tpl": "627a4e6b255f7527fb05a0f6",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "Pockets"
+            },
+            {
+                "_id": "66c5489ecc10fe584117bc59",
+                "_tpl": "60b0f988c4449e4cb624c1da",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "ArmBand"
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a89",
+                "_tpl": "5447a9cd4bdc2dbd208b4567",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "FirstPrimaryWeapon",
+                "upd": {
+                    "Repairable": {
+                        "MaxDurability": 97.63,
+                        "Durability": 96.59441
+                    },
+                    "FireMode": {
+                        "FireMode": "fullauto"
+                    }
+                }
+            },
+            {
+                "_id": "6715dacea0e10764af01aa95",
+                "_tpl": "6113cce3d92c473c770200c7",
+                "parentId": "6704a3ac80fd1dac0f111a89",
+                "slotId": "mod_pistol_grip"
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a8a",
+                "_tpl": "55802d5f4bdc2dac148b458e",
+                "parentId": "6704a3ac80fd1dac0f111a89",
+                "slotId": "mod_magazine"
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a8b",
+                "_tpl": "55d355e64bdc2d962f8b4569",
+                "parentId": "6704a3ac80fd1dac0f111a89",
+                "slotId": "mod_reciever"
+            },
+            {
+                "_id": "6715dacea0e10764af01aa94",
+                "_tpl": "5b3b99265acfc4704b4a1afb",
+                "parentId": "6704a3ac80fd1dac0f111a8b",
+                "slotId": "mod_scope"
+            },
+            {
+                "_id": "6715daeeb74743dec608f495",
+                "_tpl": "5b3b99475acfc432ff4dcbee",
+                "parentId": "6715dacea0e10764af01aa94",
+                "slotId": "mod_scope",
+                "upd": {
+                    "Sight": {
+                        "ScopesCurrentCalibPointIndexes": [
+                            0
+                        ],
+                        "ScopesSelectedModes": [
+                            0
+                        ],
+                        "SelectedScope": 0,
+                        "ScopeZoomValue": 0
+                    }
+                }
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a8c",
+                "_tpl": "63d3d44a2a49307baf09386d",
+                "parentId": "6704a3ac80fd1dac0f111a8b",
+                "slotId": "mod_barrel"
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a8e",
+                "_tpl": "6386120cd6baa055ad1e201c",
+                "parentId": "6704a3ac80fd1dac0f111a8c",
+                "slotId": "mod_muzzle"
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a8f",
+                "_tpl": "638612b607dfed1ccb7206ba",
+                "parentId": "6704a3ac80fd1dac0f111a8e",
+                "slotId": "mod_muzzle"
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a8d",
+                "_tpl": "63d3ce281fe77d0f2801859e",
+                "parentId": "6704a3ac80fd1dac0f111a8c",
+                "slotId": "mod_gas_block"
+            },
+            {
+                "_id": "6715dacea0e10764af01aa97",
+                "_tpl": "595cfa8b86f77427437e845b",
+                "parentId": "6704a3ac80fd1dac0f111a8b",
+                "slotId": "mod_handguard"
+            },
+            {
+                "_id": "6715dacea0e10764af01aa93",
+                "_tpl": "59e0bed186f774156f04ce84",
+                "parentId": "6715dacea0e10764af01aa97",
+                "slotId": "mod_mount_000"
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a94",
+                "_tpl": "5b057b4f5acfc4771e1bd3e9",
+                "parentId": "6715dacea0e10764af01aa93",
+                "slotId": "mod_foregrip"
+            },
+            {
+                "_id": "6715dacea0e10764af01aa92",
+                "_tpl": "59e0bdb186f774156f04ce82",
+                "parentId": "6715dacea0e10764af01aa97",
+                "slotId": "mod_mount_004"
+            },
+            {
+                "_id": "6715dacea0e10764af01aa96",
+                "_tpl": "5a5f1ce64f39f90b401987bc",
+                "parentId": "6715dacea0e10764af01aa92",
+                "slotId": "mod_tactical",
+                "upd": {
+                    "Light": {
+                        "IsActive": false,
+                        "SelectedMode": 0
+                    }
+                }
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a90",
+                "_tpl": "5c1780312e221602b66cc189",
+                "parentId": "6704a3ac80fd1dac0f111a8b",
+                "slotId": "mod_sight_rear",
+                "upd": {
+                    "Sight": {
+                        "ScopesCurrentCalibPointIndexes": [
+                            0
+                        ],
+                        "ScopesSelectedModes": [
+                            0
+                        ],
+                        "SelectedScope": 0,
+                        "ScopeZoomValue": 0
+                    }
+                }
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a96",
+                "_tpl": "5c793fb92e221644f31bfb64",
+                "parentId": "6704a3ac80fd1dac0f111a89",
+                "slotId": "mod_stock"
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a97",
+                "_tpl": "58d2946386f774496974c37e",
+                "parentId": "6704a3ac80fd1dac0f111a96",
+                "slotId": "mod_stock_000"
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a98",
+                "_tpl": "58d2912286f7744e27117493",
+                "parentId": "6704a3ac80fd1dac0f111a97",
+                "slotId": "mod_stock"
+            },
+            {
+                "_id": "6704a3ac80fd1dac0f111a9a",
+                "_tpl": "5f633ff5c444ce7e3c30a006",
+                "parentId": "6704a3ac80fd1dac0f111a89",
+                "slotId": "mod_charge"
+            },
+            {
+                "_id": "6715e1c1375fbc5538000011",
+                "_tpl": "54527ac44bdc2d36668b4567",
+                "parentId": "6704a3ac80fd1dac0f111a89",
+                "slotId": "patron_in_weapon"
+            },
+            {
+                "_id": "6711c390e2b768e414139748",
+                "_tpl": "5ea17ca01412a1425304d1c0",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "Headwear"
+            },
+            {
+                "_id": "6715d9bec5fd49128e088e12",
+                "_tpl": "5c0558060db834001b735271",
+                "parentId": "6711c390e2b768e414139748",
+                "slotId": "mod_nvg",
+                "upd": {
+                    "Sight": {
+                        "ScopesCurrentCalibPointIndexes": [
+                            0
+                        ],
+                        "ScopesSelectedModes": [
+                            0
+                        ],
+                        "SelectedScope": 0,
+                        "ScopeZoomValue": 0
+                    },
+                    "Togglable": {
+                        "On": true
+                    }
+                }
+            },
+            {
+                "_id": "6711c390e2b768e414139749",
+                "_tpl": "657f9a55c6679fefb3051e19",
+                "parentId": "6711c390e2b768e414139748",
+                "slotId": "Helmet_top",
+                "upd": {
+                    "Repairable": {
+                        "MaxDurability": 21.52,
+                        "Durability": 15.3870106
+                    }
+                }
+            },
+            {
+                "_id": "6711c390e2b768e41413974a",
+                "_tpl": "657f9a94ada5fadd1f07a589",
+                "parentId": "6711c390e2b768e414139748",
+                "slotId": "Helmet_back",
+                "upd": {
+                    "Repairable": {
+                        "MaxDurability": 18.96,
+                        "Durability": 18.29
+                    }
+                }
+            },
+            {
+                "_id": "67088895173fe0b93b02ab8b",
+                "_tpl": "5d5d87f786f77427997cfaef",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "TacticalVest"
+            },
+            {
+                "_id": "66c668a731b6103cd205fe49",
+                "_tpl": "545cdae64bdc2d39198b4568",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "Backpack"
+            },
+            {
+                "_id": "671be1f961942d96af055987",
+                "_tpl": "5aa2ba71e5b5b000137b758f",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "Earpiece",
+                "upd": {
+                    "StackObjectsCount": 1
+                }
+            },
+            {
+                "_id": "671be1fcdccdaae30b067b2a",
+                "_tpl": "5b432f3d5acfc4704b4a1dfb",
+                "parentId": "66c4b690fbf6319b1e11c422",
+                "slotId": "FaceCover",
+                "upd": {
+                    "StackObjectsCount": 1,
+                    "Repairable": {
+                        "MaxDurability": 100,
+                        "Durability": 100
+                    }
+                }
+            }
+        ]
+    },
+    "achievements": {
+        "65141c30ec10ff011f17cc3b": 1704093498,
+        "65141c80ec10ff011f17cc3e": 1704098100,
+        "65141eb5c31fcb0e163577dd": 1704139506,
+        "65141e37cf2f1c285e606361": 1704169569,
+        "6512ea46f7a078264a4376e4": 1704340463,
+        "6527ee4a647c29201011defe": 1704660209,
+        "65141b9859647d2cb3213ca2": 1704695763,
+        "6513eb6e0dc723592b0f9095": 1705130359,
+        "6512eb3ddfb0ae1ee75a0376": 1705305836,
+        "65141bdfcf2f1c285e606446": 1705811984,
+        "6513ee11a3dd9b6aa7159b4a": 1706348261,
+        "6512f1e3be73cc7f07358ed5": 1707112841,
+        "65141dd6303df252af1c72c9": 1712469793,
+        "6513f0a10dc723592b0f90cf": 1715126717,
+        "655b49bc91aa9e07687ae47c": 1717218630,
+        "6513eec00dc723592b0f90cc": 1717356486,
+        "6513efa1b49e3253755f47eb": 1717477240,
+        "66c328aca91e7d66fa1b0b7b": 1724538538,
+        "66b493bc2d8cd3b5e90a3648": 1728368856
+    },
+    "favoriteItems": [],
+    "pmcStats": {
+        "eft": {
+            "totalInGameTime": 17432315,
+            "overAllCounters": {
+                "Items": [
+                    {
+                        "Key": [
+                            "Sessions",
+                            "Pmc"
+                        ],
+                        "Value": 253
+                    },
+                    {
+                        "Key": [
+                            "ExitStatus",
+                            "Killed",
+                            "Pmc"
+                        ],
+                        "Value": 120
+                    },
+                    {
+                        "Key": [
+                            "Kills"
+                        ],
+                        "Value": 808
+                    },
+                    {
+                        "Key": [
+                            "Deaths"
+                        ],
+                        "Value": 120
+                    },
+                    {
+                        "Key": [
+                            "ExitStatus",
+                            "Survived",
+                            "Pmc"
+                        ],
+                        "Value": 118
+                    },
+                    {
+                        "Key": [
+                            "LongestWinStreak",
+                            "Pmc"
+                        ],
+                        "Value": 11
+                    },
+                    {
+                        "Key": [
+                            "ExitStatus",
+                            "Transit",
+                            "Pmc"
+                        ],
+                        "Value": 15
+                    }
+                ]
+            }
+        }
+    },
+    "scavStats": {
+        "eft": {
+            "totalInGameTime": 17432315,
+            "overAllCounters": {
+                "Items": [
+                    {
+                        "Key": [
+                            "Sessions",
+                            "Scav"
+                        ],
+                        "Value": 33
+                    },
+                    {
+                        "Key": [
+                            "ExitStatus",
+                            "Survived",
+                            "Scav"
+                        ],
+                        "Value": 20
+                    },
+                    {
+                        "Key": [
+                            "Kills"
+                        ],
+                        "Value": 11
+                    },
+                    {
+                        "Key": [
+                            "Deaths"
+                        ],
+                        "Value": 13
+                    },
+                    {
+                        "Key": [
+                            "LongestWinStreak",
+                            "Scav"
+                        ],
+                        "Value": 10
+                    },
+                    {
+                        "Key": [
+                            "ExitStatus",
+                            "Killed",
+                            "Scav"
+                        ],
+                        "Value": 11
+                    },
+                    {
+                        "Key": [
+                            "ExitStatus",
+                            "Left",
+                            "Scav"
+                        ],
+                        "Value": 2
+                    }
+                ]
+            }
+        }
+    },
+    "updated": 1729881973089
+}

--- a/src/pages/player/saved-profiles-issue#1000/standard-with-favorites.json
+++ b/src/pages/player/saved-profiles-issue#1000/standard-with-favorites.json
@@ -1,0 +1,1068 @@
+{
+    "aid": 4119078,
+    "info": {
+        "nickname": "stankrat",
+        "side": "Bear",
+        "experience": 10780174,
+        "memberCategory": 1026,
+        "selectedMemberCategory": 1024
+    },
+    "customization": {
+        "head": "60a6aaad42fd2735e4589978",
+        "body": "5f5e401747344c2e4f6c42c5",
+        "feet": "5f5e40400bc58666c37e7819",
+        "hands": "5f5f3fa30bc58666c37e782e"
+    },
+    "skills": {
+        "Common": [
+            {
+                "Id": "BotReload",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": -2147483648
+            },
+            {
+                "Id": "BotSound",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": -2147483648
+            },
+            {
+                "Id": "Endurance",
+                "Progress": 3232.635,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729316793
+            },
+            {
+                "Id": "Strength",
+                "Progress": 2579.65479,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1728956973
+            },
+            {
+                "Id": "Vitality",
+                "Progress": 2022.53662,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729316797
+            },
+            {
+                "Id": "Health",
+                "Progress": 2887.24268,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729316797
+            },
+            {
+                "Id": "StressResistance",
+                "Progress": 1509.837,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1728956979
+            },
+            {
+                "Id": "Metabolism",
+                "Progress": 5100,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1728697010
+            },
+            {
+                "Id": "Immunity",
+                "Progress": 693.2243,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1728192660
+            },
+            {
+                "Id": "Perception",
+                "Progress": 2110.51367,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1728956815
+            },
+            {
+                "Id": "Intellect",
+                "Progress": 141.54,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1728686861
+            },
+            {
+                "Id": "Attention",
+                "Progress": 1436.18823,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1728956821
+            },
+            {
+                "Id": "Charisma",
+                "Progress": 1358.71887,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729315786
+            },
+            {
+                "Id": "Pistol",
+                "Progress": 497.734253,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1728432044
+            },
+            {
+                "Id": "Revolver",
+                "Progress": 6.5,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1725078304
+            },
+            {
+                "Id": "SMG",
+                "Progress": 589.051758,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1728191957
+            },
+            {
+                "Id": "Assault",
+                "Progress": 1054.41992,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1728956979
+            },
+            {
+                "Id": "Shotgun",
+                "Progress": 330.1277,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1728597007
+            },
+            {
+                "Id": "Sniper",
+                "Progress": 1267.60828,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1728696022
+            },
+            {
+                "Id": "LMG",
+                "Progress": 70.37499,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1727738421
+            },
+            {
+                "Id": "HMG",
+                "Progress": 52,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1725552926
+            },
+            {
+                "Id": "Launcher",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "AttachedLauncher",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "Throwing",
+                "Progress": 526.3234,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1728956957
+            },
+            {
+                "Id": "Melee",
+                "Progress": 2.6,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1726819164
+            },
+            {
+                "Id": "DMR",
+                "Progress": 744.8616,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1728185191
+            },
+            {
+                "Id": "AimDrills",
+                "Progress": 1254.29053,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1728597168
+            },
+            {
+                "Id": "TroubleShooting",
+                "Progress": 79,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1728185191
+            },
+            {
+                "Id": "Surgery",
+                "Progress": 1055.84155,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1728696348
+            },
+            {
+                "Id": "CovertMovement",
+                "Progress": 937.0098,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1729316793
+            },
+            {
+                "Id": "Search",
+                "Progress": 903.5081,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1728597334
+            },
+            {
+                "Id": "MagDrills",
+                "Progress": 530.5719,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1728597007
+            },
+            {
+                "Id": "FieldMedicine",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "FirstAid",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "LightVests",
+                "Progress": 683.693665,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1728956979
+            },
+            {
+                "Id": "HeavyVests",
+                "Progress": 864.7404,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1728956979
+            },
+            {
+                "Id": "NightOps",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "SilentOps",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "WeaponTreatment",
+                "Progress": 300,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1724196235
+            },
+            {
+                "Id": "Auctions",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "Cleanoperations",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "Shadowconnections",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "Taskperformance",
+                "Progress": 0,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 0
+            },
+            {
+                "Id": "Crafting",
+                "Progress": 463.88,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1728686861
+            },
+            {
+                "Id": "HideoutManagement",
+                "Progress": 2362.99,
+                "PointsEarnedDuringSession": 0,
+                "LastAccess": 1728954431
+            }
+        ],
+        "Mastering": [
+            {
+                "Id": "AKM",
+                "Progress": 105
+            },
+            {
+                "Id": "PP19",
+                "Progress": 141
+            },
+            {
+                "Id": "AK74",
+                "Progress": 347
+            },
+            {
+                "Id": "VPO_215",
+                "Progress": 115
+            },
+            {
+                "Id": "VPO101",
+                "Progress": 24
+            },
+            {
+                "Id": "AKSU",
+                "Progress": 205
+            },
+            {
+                "Id": "MP443",
+                "Progress": 43
+            },
+            {
+                "Id": "SR2",
+                "Progress": 623
+            },
+            {
+                "Id": "DEAGLE",
+                "Progress": 3
+            },
+            {
+                "Id": "mosin",
+                "Progress": 29
+            },
+            {
+                "Id": "M590",
+                "Progress": 2
+            },
+            {
+                "Id": "PP-91",
+                "Progress": 34
+            },
+            {
+                "Id": "PPSH",
+                "Progress": 13
+            },
+            {
+                "Id": "MP133",
+                "Progress": 9
+            },
+            {
+                "Id": "P226",
+                "Progress": 1
+            },
+            {
+                "Id": "m9",
+                "Progress": 2
+            },
+            {
+                "Id": "UZI",
+                "Progress": 154
+            },
+            {
+                "Id": "m1911",
+                "Progress": 14
+            },
+            {
+                "Id": "SKS",
+                "Progress": 26
+            },
+            {
+                "Id": "APS",
+                "Progress": 9
+            },
+            {
+                "Id": "SV98",
+                "Progress": 91
+            },
+            {
+                "Id": "STM-9",
+                "Progress": 116
+            },
+            {
+                "Id": "MP153",
+                "Progress": 500
+            },
+            {
+                "Id": "MP5",
+                "Progress": 220
+            },
+            {
+                "Id": "RSH12",
+                "Progress": 2
+            },
+            {
+                "Id": "r700",
+                "Progress": 55
+            },
+            {
+                "Id": "MDR",
+                "Progress": 39
+            },
+            {
+                "Id": "M4",
+                "Progress": 2946
+            },
+            {
+                "Id": "M870",
+                "Progress": 7
+            },
+            {
+                "Id": "MP-18",
+                "Progress": 3
+            },
+            {
+                "Id": "MR43",
+                "Progress": 82
+            },
+            {
+                "Id": "MTS",
+                "Progress": 3
+            },
+            {
+                "Id": "SA-58",
+                "Progress": 0
+            },
+            {
+                "Id": "SAIGA",
+                "Progress": 4
+            },
+            {
+                "Id": "SVT-40",
+                "Progress": 5
+            },
+            {
+                "Id": "TOZ106",
+                "Progress": 40
+            },
+            {
+                "Id": "UZI-PRO",
+                "Progress": 53
+            },
+            {
+                "Id": "MP9",
+                "Progress": 153
+            },
+            {
+                "Id": "M60",
+                "Progress": 1
+            },
+            {
+                "Id": 57,
+                "Progress": 1151
+            },
+            {
+                "Id": "M3S90",
+                "Progress": 78
+            },
+            {
+                "Id": "GLOCK17",
+                "Progress": 35
+            },
+            {
+                "Id": "UMP45",
+                "Progress": 13
+            },
+            {
+                "Id": "SVD",
+                "Progress": 164
+            },
+            {
+                "Id": "USP",
+                "Progress": 0
+            },
+            {
+                "Id": "VSS",
+                "Progress": 0
+            },
+            {
+                "Id": "MK47",
+                "Progress": 81
+            },
+            {
+                "Id": "AUG",
+                "Progress": 269
+            },
+            {
+                "Id": "SR25",
+                "Progress": 13
+            },
+            {
+                "Id": "DVL",
+                "Progress": 72
+            },
+            {
+                "Id": "G36",
+                "Progress": 189
+            },
+            {
+                "Id": "mp7",
+                "Progress": 190
+            },
+            {
+                "Id": "MPX",
+                "Progress": 9
+            },
+            {
+                "Id": "VECTOR",
+                "Progress": 253
+            },
+            {
+                "Id": "PM",
+                "Progress": 0
+            },
+            {
+                "Id": "R11SRASS",
+                "Progress": 2062
+            },
+            {
+                "Id": "M1A",
+                "Progress": 212
+            },
+            {
+                "Id": "T5000",
+                "Progress": 9
+            },
+            {
+                "Id": "ASH12",
+                "Progress": 3
+            },
+            {
+                "Id": "AXMC",
+                "Progress": 0
+            },
+            {
+                "Id": "SPEAR",
+                "Progress": 1484
+            },
+            {
+                "Id": "KS23",
+                "Progress": 16
+            },
+            {
+                "Id": "RFB",
+                "Progress": 5
+            },
+            {
+                "Id": "Mk17",
+                "Progress": 0
+            },
+            {
+                "Id": "MCX",
+                "Progress": 2
+            },
+            {
+                "Id": "G28",
+                "Progress": 24
+            },
+            {
+                "Id": "VSK94",
+                "Progress": 14
+            },
+            {
+                "Id": "P90",
+                "Progress": 68
+            },
+            {
+                "Id": "PB",
+                "Progress": 0
+            }
+        ],
+        "Points": 0
+    },
+    "equipment": {
+        "Id": "66c5258bb984e098ff0c0d89",
+        "Items": [
+            {
+                "_id": "66c5258bb984e098ff0c0d89",
+                "_tpl": "55d7217a4bdc2d86028b456d"
+            },
+            {
+                "_id": "66d571bbcb9cb25c4401ac38",
+                "_tpl": "5c0126f40db834002a125382",
+                "parentId": "66c5258bb984e098ff0c0d89",
+                "slotId": "Scabbard",
+                "upd": {
+                    "Repairable": {
+                        "MaxDurability": 85,
+                        "Durability": 85
+                    }
+                }
+            },
+            {
+                "_id": "66c5258bb984e098ff0c0d79",
+                "_tpl": "665ee77ccf2d642e98220bca",
+                "parentId": "66c5258bb984e098ff0c0d89",
+                "slotId": "SecuredContainer"
+            },
+            {
+                "_id": "66c5258bb984e098ff0c0d87",
+                "_tpl": "65e080be269cbd5c5005e529",
+                "parentId": "66c5258bb984e098ff0c0d89",
+                "slotId": "Pockets"
+            },
+            {
+                "_id": "66ca610c30e9fe290d166c9d",
+                "_tpl": "60b0f988c4449e4cb624c1da",
+                "parentId": "66c5258bb984e098ff0c0d89",
+                "slotId": "ArmBand"
+            },
+            {
+                "_id": "67021882235618134308b5ea",
+                "_tpl": "5839a40f24597726f856b511",
+                "parentId": "66c5258bb984e098ff0c0d89",
+                "slotId": "FirstPrimaryWeapon",
+                "upd": {
+                    "Repairable": {
+                        "MaxDurability": 98.35,
+                        "Durability": 98.35
+                    },
+                    "Foldable": {
+                        "Folded": false
+                    },
+                    "FireMode": {
+                        "FireMode": "fullauto"
+                    }
+                }
+            },
+            {
+                "_id": "670218b7779a814164035b80",
+                "_tpl": "628a664bccaab13006640e47",
+                "parentId": "67021882235618134308b5ea",
+                "slotId": "mod_pistol_grip"
+            },
+            {
+                "_id": "670218b7779a814164035b7c",
+                "_tpl": "59ecc28286f7746d7a68aa8c",
+                "parentId": "67021882235618134308b5ea",
+                "slotId": "mod_stock"
+            },
+            {
+                "_id": "670218b7779a814164035b84",
+                "_tpl": "59ecc3dd86f7746dc827481c",
+                "parentId": "670218b7779a814164035b7c",
+                "slotId": "mod_stock"
+            },
+            {
+                "_id": "670218b7779a814164035b82",
+                "_tpl": "615d8f5dd92c473c770212ef",
+                "parentId": "67021882235618134308b5ea",
+                "slotId": "mod_muzzle"
+            },
+            {
+                "_id": "670218c3eabf5832a3073a09",
+                "_tpl": "615d8f8567085e45ef1409ca",
+                "parentId": "670218b7779a814164035b82",
+                "slotId": "mod_muzzle"
+            },
+            {
+                "_id": "670218b7779a814164035b7e",
+                "_tpl": "655cb6b5d680a544f30607fa",
+                "parentId": "67021882235618134308b5ea",
+                "slotId": "mod_reciever"
+            },
+            {
+                "_id": "670218b7779a814164035b7d",
+                "_tpl": "57c69dd424597774c03b7bbc",
+                "parentId": "670218b7779a814164035b7e",
+                "slotId": "mod_scope"
+            },
+            {
+                "_id": "670218b7779a814164035b86",
+                "_tpl": "618ba27d9008e4636a67f61d",
+                "parentId": "670218b7779a814164035b7d",
+                "slotId": "mod_scope",
+                "upd": {
+                    "Sight": {
+                        "ScopesCurrentCalibPointIndexes": [
+                            0
+                        ],
+                        "ScopesSelectedModes": [
+                            0
+                        ],
+                        "SelectedScope": 0,
+                        "ScopeZoomValue": 0
+                    }
+                }
+            },
+            {
+                "_id": "67021882235618134308b5f0",
+                "_tpl": "59d36a0086f7747e673f3946",
+                "parentId": "67021882235618134308b5ea",
+                "slotId": "mod_gas_block"
+            },
+            {
+                "_id": "670218b7779a814164035b7f",
+                "_tpl": "57ffa9f4245977728561e844",
+                "parentId": "67021882235618134308b5f0",
+                "slotId": "mod_handguard"
+            },
+            {
+                "_id": "670218b7779a814164035b83",
+                "_tpl": "56def37dd2720bec348b456a",
+                "parentId": "670218b7779a814164035b7f",
+                "slotId": "mod_tactical_000",
+                "upd": {
+                    "Light": {
+                        "IsActive": false,
+                        "SelectedMode": 0
+                    }
+                }
+            },
+            {
+                "_id": "66d85b3991e6584a2109979b",
+                "_tpl": "655df24fdf80b12750626d0a",
+                "parentId": "670218b7779a814164035b7f",
+                "slotId": "mod_foregrip"
+            },
+            {
+                "_id": "67021ad40ae6022811000026",
+                "_tpl": "56dff061d2720bb5668b4567",
+                "parentId": "67021882235618134308b5ea",
+                "slotId": "patron_in_weapon"
+            },
+            {
+                "_id": "66ec49ea5c1464b07f179627",
+                "_tpl": "55d482194bdc2d1d4e8b456b",
+                "parentId": "67021882235618134308b5ea",
+                "slotId": "mod_magazine",
+                "upd": {
+                    "SpawnedInSession": true
+                }
+            },
+            {
+                "_id": "67021126343452ec8e1754ba",
+                "_tpl": "628d0618d1ba6e4fa07ce5a4",
+                "parentId": "66c5258bb984e098ff0c0d89",
+                "slotId": "TacticalVest"
+            },
+            {
+                "_id": "67021126343452ec8e1754d1",
+                "_tpl": "66b5f693acff495a294927e3",
+                "parentId": "66c5258bb984e098ff0c0d89",
+                "slotId": "Earpiece"
+            },
+            {
+                "_id": "6707142cb27b7184b709d8a7",
+                "_tpl": "5ea17ca01412a1425304d1c0",
+                "parentId": "66c5258bb984e098ff0c0d89",
+                "slotId": "Headwear"
+            },
+            {
+                "_id": "6707142cb27b7184b709d8a8",
+                "_tpl": "657f9a55c6679fefb3051e19",
+                "parentId": "6707142cb27b7184b709d8a7",
+                "slotId": "Helmet_top",
+                "upd": {
+                    "Repairable": {
+                        "MaxDurability": 24,
+                        "Durability": 24
+                    }
+                }
+            },
+            {
+                "_id": "6707142cb27b7184b709d8a9",
+                "_tpl": "657f9a94ada5fadd1f07a589",
+                "parentId": "6707142cb27b7184b709d8a7",
+                "slotId": "Helmet_back",
+                "upd": {
+                    "Repairable": {
+                        "MaxDurability": 24,
+                        "Durability": 13.0961142
+                    }
+                }
+            },
+            {
+                "_id": "6708542a965ad29a440526de",
+                "_tpl": "6570aead4d84f81fd002a033",
+                "parentId": "66c5258bb984e098ff0c0d89",
+                "slotId": "FaceCover",
+                "upd": {
+                    "Repairable": {
+                        "MaxDurability": 25.82,
+                        "Durability": 20.284441
+                    }
+                }
+            }
+        ]
+    },
+    "achievements": {
+        "65141c80ec10ff011f17cc3e": 1703730881,
+        "65141c30ec10ff011f17cc3b": 1703732083,
+        "65141e37cf2f1c285e606361": 1703829876,
+        "6527ee4a647c29201011defe": 1704094252,
+        "65141eb5c31fcb0e163577dd": 1704859020,
+        "65141b9859647d2cb3213ca2": 1705389868,
+        "6513eb6e0dc723592b0f9095": 1710020468,
+        "65141bdfcf2f1c285e606446": 1711400988,
+        "6512eb3ddfb0ae1ee75a0376": 1711937243,
+        "6513ee11a3dd9b6aa7159b4a": 1713135936,
+        "6513ed89cf2f1c285e606068": 1713558961,
+        "6513f0a10dc723592b0f90cf": 1713589806,
+        "65141cd2cf2f1c285e606449": 1713683143,
+        "651419eea3dd9b6aa7159ee5": 1713695800,
+        "664f23e44702fd5db50ee732": 1719642403,
+        "65141dd6303df252af1c72c9": 1720414128,
+        "6513efa1b49e3253755f47eb": 1723255424,
+        "66c328aca91e7d66fa1b0b7b": 1724873275,
+        "66c328de9dc78468f4040f35": 1724975933,
+        "66e2a7e5919bad697104f4b3": 1727388061
+    },
+    "favoriteItems": [
+        {
+            "_id": "66d7b0ad620434ea3f0328e3",
+            "_tpl": "66572c82ad599021091c6118",
+            "upd": {
+                "SpawnedInSession": true,
+                "Resource": {
+                    "Value": 0
+                }
+            }
+        },
+        {
+            "_id": "66d80c55e8dbb9ae1e1b0e08",
+            "_tpl": "655c669103999d3c810c025b",
+            "upd": {
+                "SpawnedInSession": true,
+                "Resource": {
+                    "Value": 0
+                }
+            }
+        },
+        {
+            "_id": "66d65d6daef97674da0683f9",
+            "_tpl": "6662e9aca7e0b43baa3d5f74",
+            "upd": {
+                "SpawnedInSession": true,
+                "Resource": {
+                    "Value": 0
+                },
+                "Dogtag": {
+                    "AccountId": "6486079",
+                    "ProfileId": "606f498321c1e07e342c3fb4",
+                    "Nickname": "5368",
+                    "Side": "Bear",
+                    "Level": 21,
+                    "Time": "2024-09-03T04:03:27.115+03:00",
+                    "Status": "Killed by",
+                    "KillerAccountId": "4119078",
+                    "KillerProfileId": "5e6753e2ffb883068432ebe3",
+                    "KillerName": "stankrat",
+                    "WeaponName": "62e14904c2699c0ec93adc47 ShortName",
+                    "CarriedByGroupMember": false
+                }
+            }
+        },
+        {
+            "_id": "66deacca9be0fe92ea154895",
+            "_tpl": "6662e9aca7e0b43baa3d5f74",
+            "upd": {
+                "SpawnedInSession": true,
+                "Resource": {
+                    "Value": 0
+                },
+                "Dogtag": {
+                    "AccountId": "250",
+                    "ProfileId": "5e6fb819a3bd294ce20cf5e9",
+                    "Nickname": "Senpai_MooD",
+                    "Side": "Bear",
+                    "Level": 43,
+                    "Time": "2024-09-09T11:14:22.371+03:00",
+                    "Status": "Killed by",
+                    "KillerAccountId": "10751489",
+                    "KillerProfileId": "64d026b7990f3e82d6067393",
+                    "KillerName": "LACKVILL",
+                    "WeaponName": "5df8ce05b11454561e39243b ShortName",
+                    "CarriedByGroupMember": false
+                }
+            }
+        },
+        {
+            "_id": "66deacea02f11590080e0759",
+            "_tpl": "6662e9cda7e0b43baa3d5f76",
+            "upd": {
+                "SpawnedInSession": true,
+                "Resource": {
+                    "Value": 0
+                },
+                "Dogtag": {
+                    "AccountId": "11100673",
+                    "ProfileId": "652a7644c3bace77520649e6",
+                    "Nickname": "iip",
+                    "Side": "Bear",
+                    "Level": 52,
+                    "Time": "2024-09-09T11:13:05.873+03:00",
+                    "Status": "Killed by",
+                    "KillerAccountId": "4119078",
+                    "KillerProfileId": "5e6753e2ffb883068432ebe3",
+                    "KillerName": "stankrat",
+                    "WeaponName": "5e00903ae9dc277128008b87 ShortName",
+                    "CarriedByGroupMember": false
+                }
+            }
+        },
+        {
+            "_id": "66dd875de017bc70620cc40d",
+            "_tpl": "5d235a5986f77443f6329bc6",
+            "upd": {
+                "SpawnedInSession": true,
+                "StackObjectsCount": 1
+            }
+        },
+        {
+            "_id": "66dd875de017bc70620cc40e",
+            "_tpl": "5d235a5986f77443f6329bc6",
+            "upd": {
+                "SpawnedInSession": true,
+                "StackObjectsCount": 1
+            }
+        }
+    ],
+    "pmcStats": {
+        "eft": {
+            "totalInGameTime": 14782357,
+            "overAllCounters": {
+                "Items": [
+                    {
+                        "Key": [
+                            "Sessions",
+                            "Pmc"
+                        ],
+                        "Value": 541
+                    },
+                    {
+                        "Key": [
+                            "ExitStatus",
+                            "Killed",
+                            "Pmc"
+                        ],
+                        "Value": 243
+                    },
+                    {
+                        "Key": [
+                            "Kills"
+                        ],
+                        "Value": 1255
+                    },
+                    {
+                        "Key": [
+                            "Deaths"
+                        ],
+                        "Value": 247
+                    },
+                    {
+                        "Key": [
+                            "ExitStatus",
+                            "Survived",
+                            "Pmc"
+                        ],
+                        "Value": 266
+                    },
+                    {
+                        "Key": [
+                            "LongestWinStreak",
+                            "Pmc"
+                        ],
+                        "Value": 12
+                    },
+                    {
+                        "Key": [
+                            "ExitStatus",
+                            "Left",
+                            "Pmc"
+                        ],
+                        "Value": 4
+                    },
+                    {
+                        "Key": [
+                            "ExitStatus",
+                            "Runner",
+                            "Pmc"
+                        ],
+                        "Value": 9
+                    },
+                    {
+                        "Key": [
+                            "ExitStatus",
+                            "Transit",
+                            "Pmc"
+                        ],
+                        "Value": 17
+                    },
+                    {
+                        "Key": [
+                            "ExitStatus",
+                            "MissingInAction",
+                            "Pmc"
+                        ],
+                        "Value": 2
+                    }
+                ]
+            }
+        }
+    },
+    "scavStats": {
+        "eft": {
+            "totalInGameTime": 14782357,
+            "overAllCounters": {
+                "Items": [
+                    {
+                        "Key": [
+                            "Sessions",
+                            "Scav"
+                        ],
+                        "Value": 214
+                    },
+                    {
+                        "Key": [
+                            "ExitStatus",
+                            "Survived",
+                            "Scav"
+                        ],
+                        "Value": 143
+                    },
+                    {
+                        "Key": [
+                            "Kills"
+                        ],
+                        "Value": 121
+                    },
+                    {
+                        "Key": [
+                            "Deaths"
+                        ],
+                        "Value": 69
+                    },
+                    {
+                        "Key": [
+                            "LongestWinStreak",
+                            "Scav"
+                        ],
+                        "Value": 13
+                    },
+                    {
+                        "Key": [
+                            "ExitStatus",
+                            "Left",
+                            "Scav"
+                        ],
+                        "Value": 2
+                    },
+                    {
+                        "Key": [
+                            "ExitStatus",
+                            "Killed",
+                            "Scav"
+                        ],
+                        "Value": 67
+                    },
+                    {
+                        "Key": [
+                            "ExitStatus",
+                            "MissingInAction",
+                            "Scav"
+                        ],
+                        "Value": 2
+                    }
+                ]
+            }
+        }
+    },
+    "updated": 1729994217951
+}


### PR DESCRIPTION
<!-- 

⚠️ IMPORTANT ⚠️

- Please fill in all sections [in brackets]
- Please read the collapsible sections if you need help
- All comments in fenced brackets like this one are comments and will not be displayed

Please delete any sections below which you do not need to fill out. You may keep the collapsibe "help" section

-->
Changes courtesy of @AppleFrittr

# Responsive Design and UI overhaul to Player loadouts in tarkov.dev/players/* Issue #1000 
Targeted changes to provide a better user experience, especially on phone.

## Description 🗒️

Refer to Issue #1000.  The original loadout element caused page layout concerns, especially on smaller screens.  Overflow issues fixed and overall look of the element was changed dramatically to give the look and feel of the in game character screen.

### KEY CHANGES
1. A new data field was added to fetched items from the API - 'inspectImageLink' (file: src/features/items/do-fetch-items.mjs)
2. A new React hook was added to the hooks dir - 'useResponsiveScaling.jsx'.  This hook works in conjunction with components/item-image/index.js to scale up/down images passed from pages/player/index.js based on screen size - RESPONSIVE :smiley:
3. CSS media queries added to pages/player/index.css to match screen breakpoints set up in useResponsiveScaling.jsx.  Grid layout overhaul.
4. **IMPORTANT!!!!!!!!!!**  I commented out the CloudFlare turnstile component, import statement, and the call to fetchProfile() is useEffect() in src/pages/player/index.js for ease of development.  The CF turnstile prevents anything from happening on the page unless the capcha is passed.  Unfortunately a request from localhost doesn't cut it :face_with_diagonal_mouth:  These changes **NEED** to be reversed before merge!!!!!!  I left comments tagged with _issue#1000_ in the file itself to locate the changes easily.
5. In order to get a profile loaded into my local environment for testing, I saved a few dummy profiles from the live site and used the LoadProfile feature on the tarkov.dev/players/* page.  Those json files are located in src/pages/player/saved-profiles-issue#1000.  Since there is no way (not that I found) to navigate to a unique tarkov.dev/players/* page, just type it in directly to the address bar, example: tarkov.dev/palyers/regular/1.  This will bring up the unique player page with nothing loaded yet.  Simply click the Load Profile button and pick a file from the added directory.  Delete saved profiles directory before merge!
6. My linter/Prettier kind of went crazy on the files I worked on, bloating the changes; I'm unsure if that is standard or not.  Still learning :smile: 

## Examples 📸

![loadout1](https://github.com/user-attachments/assets/d7285122-dfc2-469e-814b-b32e393a71f5)
![responsive1](https://github.com/user-attachments/assets/1b769f59-34c0-462f-9583-9828c3ffe83c)
![responsive2](https://github.com/user-attachments/assets/05df9499-090e-4d4c-b54d-6867ac8c70bd)
![responsive3](https://github.com/user-attachments/assets/dc0045fd-11b9-4f16-b454-2ea04ee2aef5)


## Related Issues 🔗

I explored the site after my changes in my local environment and did not notice any changes to other image elements across the site :crossed_fingers: 

First PR, be gentle :smiley: 

---

<details>
<summary> Expand for Help </summary>

- Have questions about the review or deployment process? View our [contributing docs](https://github.com/the-hideout/tarkov-dev/blob/main/CONTRIBUTING.md)
- Need additional help and want to chat in real time? Join our [community Discord](https://discord.gg/WwTvNe356u)

> By submitting this pull request, you agree to our [code of conduct](https://github.com/the-hideout/tarkov-dev/blob/main/CODE_OF_CONDUCT.md)

</details>

Resolves #1000 