### PR TITLE
update branch-deploy version and ensure it uses `sha` instead of `ref`

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -10,6 +10,7 @@ permissions:
   deployments: write
   contents: write
   checks: read
+  statuses: read
 
 jobs:
   deploy:
@@ -19,7 +20,7 @@ jobs:
 
     steps:
 
-      - uses: github/branch-deploy@v9.9.1
+      - uses: github/branch-deploy@v9.10.0
         id: branch-deploy
         with:
           admins: the-hideout/core-contributors
@@ -34,7 +35,7 @@ jobs:
         if: ${{ steps.branch-deploy.outputs.continue == 'true' }}
         uses: actions/checkout@v4.1.1
         with:
-          ref: ${{ steps.branch-deploy.outputs.ref }}
+          ref: ${{ steps.branch-deploy.outputs.sha }}
 
       - uses: actions/setup-node@v4.1.0
         if: ${{ steps.branch-deploy.outputs.continue == 'true' }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: deployment check
-        uses: github/branch-deploy@v9.9.1
+        uses: github/branch-deploy@v9.10.0
         id: deployment-check
         with:
           merge_deploy_mode: "true" # tells the Action to use the merge commit workflow strategy

--- a/.github/workflows/unlock-on-merge.yml
+++ b/.github/workflows/unlock-on-merge.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: unlock on merge
-        uses: github/branch-deploy@v9.9.1
+        uses: github/branch-deploy@v9.10.0
         id: unlock-on-merge
         with:
           unlock_on_merge_mode: "true" # <-- indicates that this is the "Unlock on Merge Mode" workflow


### PR DESCRIPTION
This pull request updates `github/branch-deploy` and ensures it uses `sha` instead of `ref` for added safety