### PR TITLE
Sort Items menu sub items alphabetically

### DIFF
--- a/src/components/menu/index.js
+++ b/src/components/menu/index.js
@@ -193,7 +193,7 @@ const Menu = () => {
                     <li className="submenu-wrapper submenu-items overflow-member" key="menu-items" data-targetid="items">
                         <Link to="/items/">{t('Items')}</Link>
                         <ul className="overflow-hidden">
-                            {categoryPages.map((categoryPage) => (
+                            {categoryPages.sort((a, b) => t(a.displayText).localeCompare(t(b.displayText))).map((categoryPage) => (
                                 <MenuItem
                                     displayText={t(categoryPage.displayText)}
                                     key={categoryPage.key}


### PR DESCRIPTION
Current items menu is randomly sorted:
![image](https://github.com/user-attachments/assets/7957ea7f-417c-464a-ba99-c29dcd1a27b5)

This PR sorts that submenu alphabetically:
![image](https://github.com/user-attachments/assets/5812004b-8b89-4eba-b6f5-9303a05a6209)
