### PR TITLE
bump github/branch-deploy to `v10` and update branch-deploy settings

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -20,20 +20,18 @@ jobs:
 
     steps:
 
-      - uses: github/branch-deploy@v10.0.0-rc.1
+      - uses: github/branch-deploy@v10
         id: branch-deploy
         with:
           admins: the-hideout/core-contributors
           admins_pat: ${{ secrets.BRANCH_DEPLOY_ADMINS_PAT }}
-          skip_ci: development
-          skip_reviews: development
           environment_targets: production,development
           environment_urls: production|https://tarkov.dev,development|disabled
           sticky_locks: "true"
 
       - name: checkout
         if: ${{ steps.branch-deploy.outputs.continue == 'true' }}
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
         with:
           ref: ${{ steps.branch-deploy.outputs.sha }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: deployment check
-        uses: github/branch-deploy@v10.0.0-rc.1
+        uses: github/branch-deploy@v10
         id: deployment-check
         with:
           merge_deploy_mode: "true" # tells the Action to use the merge commit workflow strategy
@@ -24,7 +24,9 @@ jobs:
 
       - name: checkout
         if: ${{ steps.deployment-check.outputs.continue == 'true' }}
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.deployment-check.outputs.sha }}
 
       # check to ensure all JSON files are valid in the repository
       - name: json-yaml-validate

--- a/.github/workflows/unlock-on-merge.yml
+++ b/.github/workflows/unlock-on-merge.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: unlock on merge
-        uses: github/branch-deploy@v10.0.0-rc.1
+        uses: github/branch-deploy@v10
         id: unlock-on-merge
         with:
           unlock_on_merge_mode: "true" # <-- indicates that this is the "Unlock on Merge Mode" workflow


### PR DESCRIPTION
This pull request updates branch-deploy to the latest version. It also removes the `skip_reviews` and `skip_ci` settings as this is an open source project, making those options somewhat unsafe.