### PR TITLE
Fix filter z-index, map height

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -314,6 +314,10 @@ div.tippy-box[data-placement^='right'] > .tippy-arrow::before {
   margin: 0;
 }
 
+.filter-wrapper.open {
+    z-index: 2;
+}
+
 
 
 

--- a/src/pages/map/index.js
+++ b/src/pages/map/index.js
@@ -321,7 +321,10 @@ function Map() {
     const [mapHeight, setMapHeight] = useState(500);
     useLayoutEffect(() => {
         function updateSize() {
-            let viewableHeight = window.innerHeight - document.querySelector('.navigation')?.offsetHeight || 0;
+            const menuHeight = document.querySelector('.navigation')?.offsetHeight || 0;
+            const bannerHeight = document.querySelector('.MuiBox-root')?.offsetHeight || 0;
+            const cookieConsentHeight = document.querySelector('.CookieConsent')?.offsetHeight || 0;
+            let viewableHeight = window.innerHeight - menuHeight - bannerHeight - cookieConsentHeight;
             if (viewableHeight < 100) {
                 viewableHeight = window.innerHeight;
             }


### PR DESCRIPTION
The height of the interactive map container now sets itself properly depending on if the notification banner and/or cookie consent prompt are showing.

Also fixes column header showing over filter container when the filter container is opened on mobile.
Before:
![image](https://github.com/user-attachments/assets/69339eab-a280-446c-9064-49e280cc8d95)
After:
![image](https://github.com/user-attachments/assets/05dce09c-f5db-4533-ae96-329dbe51e797)
