### PR TITLE
Fix display of cheapest barter

### DIFF
--- a/src/components/barters-table/index.js
+++ b/src/components/barters-table/index.js
@@ -147,11 +147,7 @@ function BartersTable({ selectedTrader, nameFilter, itemFilter, showAll, useBart
 
         return barters
             .filter((barter) => {
-                if (!barter.rewardItems[0]) {
-                    return false;
-                }
-
-                return true;
+                return !!barter.rewardItems[0];
             })
             .filter((barter) => {
                 if (!itemFilter) {
@@ -355,7 +351,7 @@ function BartersTable({ selectedTrader, nameFilter, itemFilter, showAll, useBart
 
                 tradeData.savingsParts = [];
                 const cheapestPrice = getCheapestCashPrice(barterRewardItem, settings, showAll);
-                const cheapestBarter = getCheapestBarter(barterRewardItem, {barters, crafts: useCraftIngredients ? crafts : false, settings, allowAllSources: showAll});
+                const cheapestBarter = getCheapestBarter(barterRewardItem, {barters, crafts: useCraftIngredients ? crafts : false, settings, useBarterIngredients, useCraftIngredients, allowAllSources: showAll});
                 if (cheapestPrice.type === 'cash-sell') {
                     //this item cannot be purchased for cash
                     if (cheapestBarter) {

--- a/src/modules/format-cost-items.js
+++ b/src/modules/format-cost-items.js
@@ -74,7 +74,7 @@ function getItemBarters(item, barters, settings, allowAllSources) {
             continue;
         }
 
-        if (!allowAllSources && barter.taskUnlock && settings.useTarkovTracker && !settings.completedQuests.includes[barter.taskUnlock?.id]) {
+        if (!allowAllSources && barter.taskUnlock && settings.useTarkovTracker && !settings.completedQuests.includes(barter.taskUnlock.id)) {
             continue;
         }
 
@@ -168,7 +168,7 @@ function getItemCrafts(item, crafts, settings, allowAllSources) {
             return matchedCrafts;
         }
 
-        if (!allowAllSources && craft.taskUnlock && settings.useTarkovTracker && !settings.completedQuests.includes[craft.taskUnlock.id]) {
+        if (!allowAllSources && craft.taskUnlock && settings.useTarkovTracker && !settings.completedQuests.includes(craft.taskUnlock.id)) {
             return matchedCrafts;
         }
 


### PR DESCRIPTION
Due to logic and syntax errors, the cheapest barter for an item was not displaying correct.

Before fix:
![image](https://github.com/user-attachments/assets/9a91570f-34a1-4737-8a5b-d83040717b42)
After:
![image](https://github.com/user-attachments/assets/2cc9934a-a9d3-4dee-abf5-5001f8c51b9f)
