### PR TITLE
Show multiple options for planting items

### DIFF
--- a/src/pages/quest/index.js
+++ b/src/pages/quest/index.js
@@ -556,15 +556,41 @@ function Quest() {
                     height: preset.height,
                 };
             }
-            taskDetails = (
-                <>
-                    <ItemImage
-                        item={item}
-                        imageField="baseImageLink"
-                        linkToItem={true}
-                    />
-                </>
-            );
+            if (objective.items.length > 1) {
+                taskDetails = (
+                    <div>
+                        {t('Use any of:')}{' '}
+                        <ul className="quest-item-list">
+                            {objective.items.map((useItem, index) => {
+                                const item = items.find((i) => i.id === useItem.id);
+                                if (!item)
+                                    return null;
+                                return (
+                                    <li
+                                        key={`item-${index}-${item.id}`}
+                                    >
+                                        <ItemImage
+                                            item={item}
+                                            imageField="baseImageLink"
+                                            linkToItem={true}
+                                        />
+                                    </li>
+                                );
+                            })}
+                        </ul>
+                    </div>
+                );
+            } else {
+                taskDetails = (
+                    <>
+                        <ItemImage
+                            item={item}
+                            imageField="baseImageLink"
+                            linkToItem={true}
+                        />
+                    </>
+                );
+            }
         }
         if (objective.type === 'shoot') {
             let verb = t('Kill');


### PR DESCRIPTION
Some quests allow you to plant one out of multiple options of items. Currently, the website only displays one item:
![image](https://github.com/user-attachments/assets/f73823f7-ed47-49d0-bc3d-5dc4b7723dcb)
Fixed to show all possible items:
![image](https://github.com/user-attachments/assets/84184f0a-e49a-4047-b129-9c7337872a56)
