### PR TITLE
Add missing rig, backpack item grids

### DIFF
--- a/src/components/item-image/index.js
+++ b/src/components/item-image/index.js
@@ -78,7 +78,6 @@ function ItemImage({
                 return;
             }
             if (refImage.current.naturalWidth === 0) {
-                console.log('load failed')
                 setCustomImageLoadFailed(true);
             } else {
                 setMainImageLoaded(true);

--- a/src/components/item-image/index.js
+++ b/src/components/item-image/index.js
@@ -59,6 +59,7 @@ function ItemImage({
 
     const refImage = useRef();
     const [imageDimensions, setImageDimensions] = useState({ width: 0, height: 0});
+    const [imageNaturalDimensons, setNaturalImageDimensions] = useState({width: 1, height: 1});
     const [mainImageLoaded, setMainImageLoaded] = useState(false);
     const [customImageLoadFailed, setCustomImageLoadFailed] = useState(false);
     useEffect(() => {
@@ -69,6 +70,15 @@ function ItemImage({
             if (!refImage.current) {
                 return;
             }
+            if (refImage.current.naturalWidth === 0) {
+                setCustomImageLoadFailed(true);
+            } else {
+                setMainImageLoaded(true);
+            }
+            setNaturalImageDimensions({
+                width: refImage.current.naturalWidth,
+                height: refImage.current.naturalHeight,
+            });
             if (refImage.current.width === imageDimensions.width && refImage.current.height === imageDimensions.height) {
                 return;
             }
@@ -91,24 +101,6 @@ function ItemImage({
             intersectionObserver.disconnect();
             resizeObserver.disconnect();
         };
-    }, [imageDimensions]);
-
-    const imageNaturalDimensons = useMemo(() => {
-        const dimensions = {
-            width: 64,
-            height: 64,
-        };
-        if (!refImage.current) {
-            return dimensions;
-        }
-        if (refImage.current.naturalWidth === 0) {
-            setCustomImageLoadFailed(true);
-        } else {
-            setMainImageLoaded(true);
-        }
-        dimensions.width = refImage.current.naturalWidth;
-        dimensions.height = refImage.current.naturalHeight;
-        return dimensions;
     }, [imageDimensions]);
 
     const itemSize = useMemo(() => {

--- a/src/components/item-image/index.js
+++ b/src/components/item-image/index.js
@@ -59,8 +59,6 @@ function ItemImage({
 
     const refImage = useRef();
     const [imageDimensions, setImageDimensions] = useState({ width: 0, height: 0});
-    const [imageNaturalDimensons, setNaturalImageDimensions] = useState({width: 1, height: 1});
-    const [itemSize, setItemSize] = useState({width: 1, height: 1});
     const [mainImageLoaded, setMainImageLoaded] = useState(false);
     const [customImageLoadFailed, setCustomImageLoadFailed] = useState(false);
     useEffect(() => {
@@ -74,15 +72,6 @@ function ItemImage({
             if (refImage.current.width === imageDimensions.width && refImage.current.height === imageDimensions.height) {
                 return;
             }
-            if (refImage.current.naturalWidth === 0) {
-                setCustomImageLoadFailed(true);
-            } else {
-                setMainImageLoaded(true);
-            }
-            setNaturalImageDimensions({
-                width: refImage.current.naturalWidth,
-                height: refImage.current.naturalHeight,
-            });
             setImageDimensions({
                 width: refImage.current.width,
                 height: refImage.current.height,
@@ -104,37 +93,48 @@ function ItemImage({
         };
     }, [imageDimensions]);
 
-    useEffect(() => {
-        if (!item.width) {
-            return;
+    const imageNaturalDimensons = useMemo(() => {
+        const dimensions = {
+            width: 64,
+            height: 64,
+        };
+        if (!refImage.current) {
+            return dimensions;
         }
-        setItemSize({
-            width: item.width,
-            height: item.height,
-        });
-    }, [item]);
+        if (refImage.current.naturalWidth === 0) {
+            setCustomImageLoadFailed(true);
+        } else {
+            setMainImageLoaded(true);
+        }
+        dimensions.width = refImage.current.naturalWidth;
+        dimensions.height = refImage.current.naturalHeight;
+        return dimensions;
+    }, [imageDimensions]);
 
-    useEffect(() => {
+    const itemSize = useMemo(() => {
+        const size = {
+            width: 1,
+            height: 1,
+        };
+        if (item?.width) {
+            size.width = item.width;
+            size.height = item.height;
+        }
         if (!imageLink) {
-            return;
+            return size;
         }
         if (imageNaturalDimensons.width === 0) {
-            return;
+            return size;
         }
         if (customImageLoadFailed) {
-            setItemSize({
-                width: item.width,
-                height: item.height,
-            });
-            return;
+            return size;
         }
 
         const w = imageNaturalDimensons.width / 8;
         const h = imageNaturalDimensons.height / 8;
-        setItemSize({
-            width: (w - 1) / 63,
-            height: (h - 1) / 63,
-        });
+        size.width = (w - 1) / 63;
+        size.height = (h - 1) / 63;
+        return size;
     }, [item, imageLink, customImageLoadFailed, imageNaturalDimensons]);
 
     const imageUrl = useMemo(() => {

--- a/src/components/item-image/index.js
+++ b/src/components/item-image/index.js
@@ -59,11 +59,10 @@ function ItemImage({
 
     const refImage = useRef();
     const [imageDimensions, setImageDimensions] = useState({ width: 0, height: 0});
-    const [imageNaturalDimensons, setNaturalImageDimensions] = useState({width: 0, height: 0});
-    const [itemSize, setItemSize] = useState({width: item.width, height: item.height});
+    const [imageNaturalDimensons, setNaturalImageDimensions] = useState({width: 1, height: 1});
+    const [itemSize, setItemSize] = useState({width: 1, height: 1});
     const [mainImageLoaded, setMainImageLoaded] = useState(false);
     const [customImageLoadFailed, setCustomImageLoadFailed] = useState(false);
-
     useEffect(() => {
         if (!refImage.current) {
             return;
@@ -104,6 +103,16 @@ function ItemImage({
             resizeObserver.disconnect();
         };
     }, [imageDimensions]);
+
+    useEffect(() => {
+        if (!item.width) {
+            return;
+        }
+        setItemSize({
+            width: item.width,
+            height: item.height,
+        });
+    }, [item]);
 
     useEffect(() => {
         if (!imageLink) {

--- a/src/components/item-image/index.js
+++ b/src/components/item-image/index.js
@@ -70,17 +70,18 @@ function ItemImage({
             if (!refImage.current) {
                 return;
             }
-            if (refImage.current.naturalWidth === 0) {
-                setCustomImageLoadFailed(true);
-            } else {
-                setMainImageLoaded(true);
-            }
             setNaturalImageDimensions({
                 width: refImage.current.naturalWidth,
                 height: refImage.current.naturalHeight,
             });
             if (refImage.current.width === imageDimensions.width && refImage.current.height === imageDimensions.height) {
                 return;
+            }
+            if (refImage.current.naturalWidth === 0) {
+                console.log('load failed')
+                setCustomImageLoadFailed(true);
+            } else {
+                setMainImageLoaded(true);
             }
             setImageDimensions({
                 width: refImage.current.width,

--- a/src/data/item-grids.json
+++ b/src/data/item-grids.json
@@ -3464,5 +3464,19 @@
             "width": 1,
             "height": 2
         }
+    ],
+    "664a55d84a90fc2c8a6305c9": [
+        {
+            "row": 0,
+            "col": 0,
+            "width": 4,
+            "height": 2
+        },
+        {
+            "row": 0,
+            "col": 4,
+            "width": 1,
+            "height": 2
+        }
     ]
 }

--- a/src/data/item-grids.json
+++ b/src/data/item-grids.json
@@ -2998,5 +2998,211 @@
             "width": 6,
             "height": 2
         }
+    ],
+    "66b6296d7994640992013b17": [
+        {
+            "row": 0,
+            "col": 0,
+            "width": 1,
+            "height": 3
+        },
+        {
+            "row": 0,
+            "col": 1,
+            "width": 1,
+            "height": 3
+        },
+        {
+            "row": 0,
+            "col": 2,
+            "width": 1,
+            "height": 3
+        },
+        {
+            "row": 0,
+            "col": 3,
+            "width": 1,
+            "height": 3
+        },
+        {
+            "row": 3,
+            "col": 0,
+            "width": 2,
+            "height": 1
+        },
+        {
+            "row": 3,
+            "col": 2,
+            "width": 2,
+            "height": 1
+        },
+        {
+            "row": 4,
+            "col": 1,
+            "width": 2,
+            "height": 2
+        }
+    ],
+    "66b6295a8ca68c6461709efa": [
+        {
+            "row": 0,
+            "col": 0,
+            "width": 1,
+            "height": 3
+        },
+        {
+            "row": 0,
+            "col": 1,
+            "width": 1,
+            "height": 3
+        },
+        {
+            "row": 0,
+            "col": 2,
+            "width": 1,
+            "height": 3
+        },
+        {
+            "row": 3,
+            "col": 0,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 3,
+            "col": 1,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 3,
+            "col": 2,
+            "width": 1,
+            "height": 2
+        }
+    ],
+    "66b6295178bbc0200425f995": [
+        {
+            "row": 1,
+            "col": 0,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 0,
+            "col": 1,
+            "width": 1,
+            "height": 3
+        },
+        {
+            "row": 0,
+            "col": 2,
+            "width": 1,
+            "height": 3
+        },
+        {
+            "row": 1,
+            "col": 3,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 3,
+            "col": 0,
+            "width": 1,
+            "height": 1
+        },
+        {
+            "row": 3,
+            "col": 1,
+            "width": 2,
+            "height": 1
+        },
+        {
+            "row": 3,
+            "col": 3,
+            "width": 1,
+            "height": 1
+        }
+    ],
+    "674589d98dd67746010329e6": [
+        {
+            "row": 0,
+            "col": 0,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 0,
+            "col": 1,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 0,
+            "col": 2,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 0,
+            "col": 3,
+            "width": 1,
+            "height": 2
+        }
+    ],
+    "674da107c512807d1a0e7436": [
+        {
+            "row": 0,
+            "col": 0,
+            "width": 4,
+            "height": 5
+        },
+        {
+            "row": 0,
+            "col": 4,
+            "width": 2,
+            "height": 5
+        }
+    ],
+    "674da9cf0cb4bcde7103c07b": [
+        {
+            "row": 0,
+            "col": 0,
+            "width": 4,
+            "height": 5
+        },
+        {
+            "row": 0,
+            "col": 4,
+            "width": 2,
+            "height": 5
+        }
+    ],
+    "67458730df3c1da90b0b052b": [
+        {
+            "row": 0,
+            "col": 0,
+            "width": 2,
+            "height": 2
+        },
+        {
+            "row": 0,
+            "col": 2,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 0,
+            "col": 3,
+            "width": 2,
+            "height": 2
+        },
+        {
+            "row": 2,
+            "col": 0,
+            "width": 5,
+            "height": 7
+        }
     ]
 }

--- a/src/data/item-grids.json
+++ b/src/data/item-grids.json
@@ -3204,5 +3204,265 @@
             "width": 5,
             "height": 7
         }
+    ],
+    "67ab49aab9c7a1e18c095686": [
+        {
+            "row": 0,
+            "col": 0,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 0,
+            "col": 1,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 0,
+            "col": 2,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 0,
+            "col": 3,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 0,
+            "col": 4,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 2,
+            "col": 0,
+            "width": 1,
+            "height": 1
+        },
+        {
+            "row": 2,
+            "col": 1,
+            "width": 1,
+            "height": 1
+        },
+        {
+            "row": 2,
+            "col": 2,
+            "width": 1,
+            "height": 1
+        },
+        {
+            "row": 2,
+            "col": 3,
+            "width": 1,
+            "height": 1
+        },
+        {
+            "row": 2,
+            "col": 4,
+            "width": 1,
+            "height": 1
+        },
+        {
+            "row": 3,
+            "col": 0.5,
+            "width": 2,
+            "height": 2
+        },
+        {
+            "row": 3,
+            "col": 2.5,
+            "width": 2,
+            "height": 2
+        }
+    ],
+    "67ab3f146d7ece17bf0096ff": [
+        {
+            "row": 0,
+            "col": 0,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 0,
+            "col": 1,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 0,
+            "col": 2,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 0,
+            "col": 3,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 2,
+            "col": 0,
+            "width": 1,
+            "height": 1
+        },
+        {
+            "row": 2,
+            "col": 1,
+            "width": 1,
+            "height": 1
+        },
+        {
+            "row": 2,
+            "col": 2,
+            "width": 1,
+            "height": 1
+        },
+        {
+            "row": 2,
+            "col": 3,
+            "width": 1,
+            "height": 1
+        },
+        {
+            "row": 3,
+            "col": 0,
+            "width": 2,
+            "height": 2
+        },
+        {
+            "row": 3,
+            "col": 2,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 3,
+            "col": 3,
+            "width": 1,
+            "height": 2
+        }
+    ],
+    "67ab3ea96d7ece17bf0096f6": [
+        {
+            "row": 0,
+            "col": 0,
+            "width": 1,
+            "height": 3
+        },
+        {
+            "row": 0,
+            "col": 1,
+            "width": 1,
+            "height": 3
+        },
+        {
+            "row": 0,
+            "col": 2,
+            "width": 1,
+            "height": 3
+        },
+        {
+            "row": 0,
+            "col": 3,
+            "width": 1,
+            "height": 3
+        },
+        {
+            "row": 3,
+            "col": 0,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 3,
+            "col": 1,
+            "width": 2,
+            "height": 2
+        },
+        {
+            "row": 3,
+            "col": 3,
+            "width": 1,
+            "height": 2
+        }
+    ],
+    "67ab4b2d6f7ae4aa550bbcf6": [
+        {
+            "row": 0,
+            "col": 0,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 0,
+            "col": 1,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 0,
+            "col": 2,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 0,
+            "col": 3,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 2,
+            "col": 0,
+            "width": 1,
+            "height": 1
+        },
+        {
+            "row": 2,
+            "col": 1,
+            "width": 1,
+            "height": 1
+        },
+        {
+            "row": 2,
+            "col": 2,
+            "width": 1,
+            "height": 1
+        },
+        {
+            "row": 2,
+            "col": 3,
+            "width": 1,
+            "height": 1
+        },
+        {
+            "row": 3,
+            "col": 0,
+            "width": 1,
+            "height": 2
+        },
+        {
+            "row": 3,
+            "col": 1,
+            "width": 1,
+            "height": 1
+        },
+        {
+            "row": 3,
+            "col": 2,
+            "width": 1,
+            "height": 1
+        },
+        {
+            "row": 3,
+            "col": 3,
+            "width": 1,
+            "height": 2
+        }
     ]
 }

--- a/src/pages/api-docs/index.js
+++ b/src/pages/api-docs/index.js
@@ -135,7 +135,7 @@ function APIDocs() {
     'Accept': 'application/json',
   },
   body: JSON.stringify({query: \`{
-    items(name: "m855a1") {
+    items {
         id
         name
         shortName
@@ -153,7 +153,7 @@ function APIDocs() {
 
 const query = gql\`
 {
-    items(name: "m855a1") {
+    items {
         id
         name
         shortName
@@ -180,7 +180,7 @@ def run_query(query):
 
 new_query = """
 {
-    items(name: "m855a1") {
+    items {
         id
         name
         shortName
@@ -208,7 +208,7 @@ require 'json'
 uri = URI.parse("https://api.tarkov.dev/graphql")
 
 header = { "Content-Type": "application/json" }
-query = { "query": "{ items(name: \\"m855a1\\") {id name shortName } }" }
+query = { "query": "{ items {id name shortName } }" }
 
 # Create the HTTP object
 http = Net::HTTP.new(uri.host, uri.port)
@@ -230,7 +230,7 @@ puts response.body`}
                 <SyntaxHighlighter language="bash" style={atomOneDark}>
                     {`curl -X POST \
 -H "Content-Type: application/json" \
--d '{"query": "{ items(name: \\"m855a1\\") {id name shortName } }"}' \
+-d '{"query": "{ items {id name shortName } }"}' \
 https://api.tarkov.dev/graphql`}
                 </SyntaxHighlighter>
             </div>
@@ -240,7 +240,7 @@ https://api.tarkov.dev/graphql`}
                     {`$headers = ['Content-Type: application/json'];
 
 $query = '{
-  items(name: "m855a1") {
+  items {
     id
     name
     shortName
@@ -274,7 +274,7 @@ import java.net.http.HttpResponse;
 class Scratch {
     public static void main(String[] args) throws IOException, InterruptedException {
         HttpClient client = HttpClient.newBuilder().build();
-        String query = "{\\"query\\": \\"{ items(name: \\\\\\"m855a1\\\\\\") {id name shortName } }\\"}";
+        String query = "{\\"query\\": \\"{ items {id name shortName } }\\"}";
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create("https://api.tarkov.dev/graphql"))
                 .header("Content-Type", "application/json")
@@ -297,7 +297,7 @@ class Scratch {
                 <SyntaxHighlighter language="csharp" style={atomOneDark}>
                     {`var data = new Dictionary<string, string>()
 {
-    {"query", "{items(name: \\"m855a1\\") { id name shortName }}"}
+    {"query", "{items { id name shortName }}"}
 };
 
 using (var httpClient = new HttpClient())
@@ -335,7 +335,7 @@ import (
 )
 
 func main() {
-    body := strings.NewReader(\`{"query": "{ items(name: \\"m855a1\\") {id name shortName } }"}\`)
+    body := strings.NewReader(\`{"query": "{ items {id name shortName } }"}\`)
     req, err := http.NewRequest("POST", "https://api.tarkov.dev/graphql", body)
     if err != nil {
         log.Fatalln(err)
@@ -370,7 +370,7 @@ func main() {
                     {`local http = require "coro-http"
 
 coroutine.wrap(function()
-    local query = [[{"query": "{ items(name: "m855a1") {id name shortName } }"}]]
+    local query = [[{"query": "{ items {id name shortName } }"}]]
     local headers = {
         { "Content-Type", "application/json" },
         { "Accept", "application/json" }


### PR DESCRIPTION
Adds missing grid layout visuals for some rigs and backpacks.
Also updates the example queries on the API page to remove the `name` argument. Showing this argument caused confusion for those new to the API because they thought it was required.
Also fixes bugs with item image displaying.