### PR TITLE
Fix map label layers

### DIFF
--- a/src/data/maps.json
+++ b/src/data/maps.json
@@ -438,7 +438,7 @@
                         "position": [115, 104],
                         "text": "Oasis",
                         "size": 70,
-                        "top": 27,
+                        "top": 30,
                         "bottom": 22
                     },
                     {

--- a/src/data/maps.json
+++ b/src/data/maps.json
@@ -1728,7 +1728,7 @@
                     },
                     {
                         "position": [-207, -305],
-                        "text": "Lectuer Hall",
+                        "text": "Lecture Hall",
                         "top": 2,
                         "bottom": -0.8,
                         "size": 90

--- a/src/data/maps.json
+++ b/src/data/maps.json
@@ -437,12 +437,16 @@
                     {
                         "position": [115, 104],
                         "text": "Oasis",
-                        "size": 70
+                        "size": 70,
+                        "top": 27,
+                        "bottom": 22
                     },
                     {
                         "position": [115, 30],
                         "text": "ASAP Winery",
-                        "size": 70
+                        "size": 70,
+                        "top": 27,
+                        "bottom": 22
                     },
                     {
                         "position": [43, 150],
@@ -2407,20 +2411,20 @@
                     {
                         "position": [-171, -83],
                         "text": "West Wing",
-                        "bottom": 0,
-                        "top": 3
+                        "bottom": -100,
+                        "top": 100
                     },
                     {
                         "position": [-329, -83],
                         "text": "East Wing",
-                        "bottom": 0,
-                        "top": 3
+                        "bottom": -100,
+                        "top": 100
                     },
                     {
                         "position": [-252, -146],
                         "text": "Admin",
-                        "bottom": 0,
-                        "top": 3
+                        "bottom": -100,
+                        "top": 100
                     }
                 ]
             },

--- a/src/pages/map/index.js
+++ b/src/pages/map/index.js
@@ -794,7 +794,6 @@ function Map() {
                 } else if (typeof label.top !== 'undefined' && typeof label.bottom !== 'undefined') {
                     // calculate position as midpoint between top and bottom
                     positionY = ((label.top - label.bottom) / 2) + label.bottom;
-                    console.log(label.text, positionY);
                 }
                 const fontSize = label.size ? label.size : 100;
                 const rotation = label.rotation ? label.rotation : 0;

--- a/src/pages/map/index.js
+++ b/src/pages/map/index.js
@@ -621,35 +621,6 @@ function Map() {
             baseLayers.push(svgLayer);
         }
 
-        // Add labels
-
-        if (mapData.labels?.length > 0) {
-            const labelsGroup = L.layerGroup();
-            const defaultHeight = ((layerOptions.extents[0].height[1] - layerOptions.extents[0].height[0]) / 2) + layerOptions.extents[0].height[0];
-            for (const label of mapData.labels) {
-                const fontSize = label.size ? label.size : 100;
-                const height = label.position.length < 3 ? defaultHeight : label.position[2];
-                const rotation = label.rotation ? label.rotation : 0;
-                L.marker(pos({x: label.position[0], z: label.position[1]}), {
-                    icon: L.divIcon({
-                        html: `<div class="label" style="font-size: ${fontSize}%; transform: translate3d(-50%, -50%, 0) rotate(${rotation}deg)">${tMaps(label.text)}</div>`,
-                        className: 'map-area-label',
-                        layers: baseLayers,
-                    }),
-                    interactive: false,
-                    zIndexOffset: -100000,
-                    position: {
-                        x: label.position[0],
-                        y: height,
-                        z: label.position[1],
-                    },
-                    top: typeof label.top !== 'undefined' ? label.top : 1000,
-                    bottom: typeof label.bottom !== 'undefined' ? label.bottom : -1000,
-                }).addTo(labelsGroup);
-            }
-            addLayer(labelsGroup, 'place-names', 'Landmarks');
-        }
-
         // only add selector if there are multiple
         if (tileLayer && svgLayer) {
             layerControl.addBaseLayer(tileLayer, tMaps('Satellite'));
@@ -809,6 +780,46 @@ function Map() {
         let markerBounds = {
             'TL': {x:Number.MAX_SAFE_INTEGER, z:Number.MIN_SAFE_INTEGER},
             'BR': {x:Number.MIN_SAFE_INTEGER, z:Number.MAX_SAFE_INTEGER}
+        }
+
+        // Add labels
+        if (mapData.labels?.length > 0) {
+            const labelsGroup = L.layerGroup();
+            const mainLayerVerticalMidpoint = ((layerOptions.extents[0].height[1] - layerOptions.extents[0].height[0]) / 2) + layerOptions.extents[0].height[0];
+            for (const label of mapData.labels) {
+                let positionY = mainLayerVerticalMidpoint;
+                if (label.position.length > 2) {
+                    // if a position is expressly provided, use it
+                    positionY = label.position[2];
+                } else if (typeof label.top !== 'undefined' && typeof label.bottom !== 'undefined') {
+                    // calculate position as midpoint between top and bottom
+                    positionY = ((label.top - label.bottom) / 2) + label.bottom;
+                    console.log(label.text, positionY);
+                }
+                const fontSize = label.size ? label.size : 100;
+                const rotation = label.rotation ? label.rotation : 0;
+                const labelMarker = L.marker(pos({x: label.position[0], z: label.position[1]}), {
+                    icon: L.divIcon({
+                        html: `<div class="label" style="font-size: ${fontSize}%; transform: translate3d(-50%, -50%, 0) rotate(${rotation}deg)">${tMaps(label.text)}</div>`,
+                        className: 'map-area-label',
+                        layers: baseLayers,
+                    }),
+                    interactive: false,
+                    zIndexOffset: -100000,
+                    position: {
+                        x: label.position[0],
+                        y: positionY,
+                        z: label.position[1],
+                    },
+                    top: label.top ?? 1000,
+                    bottom: label.bottom ?? -1000,
+                });
+                labelMarker.position = labelMarker.options.position;
+                labelMarker.on('add', checkMarkerForActiveLayers);
+                labelMarker.addTo(labelsGroup);
+                checkMarkerBounds(label.position, markerBounds);
+            }
+            addLayer(labelsGroup, 'place-names', 'Landmarks');
         }
 
         // Add spawns


### PR DESCRIPTION
All map labels currently show when a map is loaded, regardless of whether some labels should only show when specific map layers are active. This fixes that bug so only the appropriate map labels are shown.