### PR TITLE
Include flea market fee in barter instaprofit calculation

### DIFF
--- a/src/components/barters-table/index.js
+++ b/src/components/barters-table/index.js
@@ -20,6 +20,7 @@ import FleaMarketLoadingIcon from '../FleaMarketLoadingIcon.jsx';
 
 import { formatCostItems, getCheapestCashPrice, getCheapestBarter } from '../../modules/format-cost-items.js';
 import { isAnyDogtag, isBothDogtags } from '../../modules/dogtags.js';
+import fleaMarketFee from '../../modules/flea-market-fee.mjs';
 
 import './index.css';
 
@@ -315,20 +316,21 @@ function BartersTable({ selectedTrader, nameFilter, itemFilter, showAll, useBart
                     costItems[0].pricePerUnit = GPCoinPrice;
                 }
 
+                let fleaFee = 0;
+                if (bestSellTo.vendor.normalizedName === 'flea-market') {
+                    fleaFee = fleaMarketFee(barterRewardItem.basePrice, bestSellTo.priceRUB, {count: howManyWeSell});
+                }
+
                 const tradeData = {
                     costItems: costItems,
                     cost: cost,
-                    instaProfit: (bestSellTo.priceRUB * howManyWeSell) - cost,
+                    instaProfit: (bestSellTo.priceRUB * howManyWeSell) - cost - fleaFee,
                     instaProfitSource: bestSellTo,
                     instaProfitDetails: [
                         {
                             name: bestSellTo.vendor.name,
                             value: bestSellTo.priceRUB * howManyWeSell,
                         },
-                        {
-                            name: t('Barter cost'),
-                            value: cost * -1,
-                        }
                     ],
                     reward: {
                         item: barterRewardItem,
@@ -342,6 +344,16 @@ function BartersTable({ selectedTrader, nameFilter, itemFilter, showAll, useBart
                     },
                     cached: barterRow.cached || barterRewardItem.cached,
                 };
+                if (fleaFee) {
+                    tradeData.instaProfitDetails.push({
+                        name: t('Flea Fee'),
+                        value: fleaFee * -1,
+                    });
+                }
+                tradeData.instaProfitDetails.push({
+                    name: t('Barter cost'),
+                    value: cost * -1,
+                });
 
                 if (barterRewardItem.priceCustom) {
                     tradeData.reward.sellValue = barterRewardItem.priceCustom;

--- a/src/components/crafts-table/index.js
+++ b/src/components/crafts-table/index.js
@@ -230,20 +230,12 @@ function CraftTable({ selectedStation, freeFuel, nameFilter, itemFilter, showAll
                         fleaPriceToUse = bestFleaPrice.bestPrice;
                         fleaFeeSingle = bestFleaPrice.bestPriceFee;
                     } else {
-                        fleaFeeSingle = fleaMarketFee(
-                            craftRewardItem.basePrice,
-                            fleaPriceToUse,
-                            1,
-                            meta?.flea?.sellOfferFeeRate,
-                            meta?.flea?.sellRequirementFeeRate,
-                        );
+                        fleaFeeSingle = fleaMarketFee(craftRewardItem.basePrice, fleaPriceToUse);
                     }
-                    fleaFeeTotal = fleaMarketFee(
-                        craftRewardItem.basePrice,
-                        fleaPriceToUse,
-                        craftRow.rewardItems[0].count,
-                        meta?.flea?.sellOfferFeeRate,
-                        meta?.flea?.sellRequirementFeeRate,
+                    fleaFeeTotal = fleaMarketFee(craftRewardItem.basePrice, fleaPriceToUse,
+                        {
+                            count: craftRow.rewardItems[0].count,
+                        },
                     );
                     if (fleaPriceToUse - fleaFeeSingle > tradeData.reward.sellValue) {
                         tradeData.reward.sellValue = fleaPriceToUse;

--- a/src/components/filter/index.js
+++ b/src/components/filter/index.js
@@ -138,7 +138,7 @@ function RangeFilter({
     );
 }
 
-function ToggleFilter({ label, onChange, checked = false, tooltipContent, disabled }) {
+function ToggleFilter({ label, onChange, checked, tooltipContent, disabled }) {
     return (
         <ConditionalWrapper
             condition={tooltipContent}

--- a/src/components/filter/index.js
+++ b/src/components/filter/index.js
@@ -138,7 +138,7 @@ function RangeFilter({
     );
 }
 
-function ToggleFilter({ label, onChange, checked, tooltipContent, disabled }) {
+function ToggleFilter({ label, onChange, checked = false, tooltipContent, disabled }) {
     return (
         <ConditionalWrapper
             condition={tooltipContent}

--- a/src/components/property-list/index.js
+++ b/src/components/property-list/index.js
@@ -55,7 +55,7 @@ function PropertyList({ properties, id }) {
                           </ConditionalWrapper>
                       </div>
                       <div className="item">
-                        <p>{value.value}</p>
+                        <div>{value.value}</div>
                       </div>
                   </div>
                 );

--- a/src/features/items/do-fetch-items.mjs
+++ b/src/features/items/do-fetch-items.mjs
@@ -3,6 +3,14 @@ import fetch  from 'cross-fetch';
 import APIQuery from '../../modules/api-query.mjs';
 import fleaMarketFee from '../../modules/flea-market-fee.mjs';
 
+const localStorageWriteJson = (key, value) => {
+    try {
+        localStorage.setItem(key, JSON.stringify(value));
+    } catch (error) {
+        /* noop */
+    }
+};
+
 class ItemsQuery extends APIQuery {
     constructor() {
         super('items');
@@ -506,6 +514,8 @@ class ItemsQuery extends APIQuery {
         }
 
         const flea = miscData.data.fleaMarket;
+        localStorageWriteJson('Ti', flea.sellOfferFeeRate);
+        localStorageWriteJson('Tr', flea.sellRequirementFeeRate);
 
         const allItems = itemData.data.items.map((rawItem) => {
             // calculate grid
@@ -551,7 +561,7 @@ class ItemsQuery extends APIQuery {
             };
 
             // calculate flea market fee
-            const fee = fleaMarketFee(rawItem.basePrice, rawItem.lastLowPrice, 1, flea.sellOfferFeeRate, flea.sellRequirementFeeRate);
+            const fee = fleaMarketFee(rawItem.basePrice, rawItem.lastLowPrice);
             rawItem.fee = fee;
 
             const container = rawItem.properties?.slots || rawItem.properties?.grids;

--- a/src/features/settings/settingsSlice.js
+++ b/src/features/settings/settingsSlice.js
@@ -102,7 +102,8 @@ const localStorageWriteJson = (key, value) => {
     }
 };
 
-const defaultSettings = {hasFlea: localStorageReadJson('useFlea', true),
+const defaultSettings = {
+    hasFlea: localStorageReadJson('useFlea', true),
     playerLevel: 72,
     pmcFaction: localStorageReadJson('pmcFaction', 'NONE'),
     useTarkovTracker: localStorageReadJson('useTarkovTracker', false),
@@ -149,6 +150,8 @@ const settingsSlice = createSlice({
         hideRemoteControl: localStorageReadJson('hide-remote-control', false),
         playerPosition: localStorageReadJson('playerPosition', null),
         gameMode: localStorageReadJson('gameMode', 'regular'),
+        Ti: localStorageReadJson('Ti', 0.03),
+        Tr: localStorageReadJson('Tr', 0.03),
     },
     reducers: {
         setTarkovTrackerAPIKey: (state, action) => {

--- a/src/modules/flea-market-fee.mjs
+++ b/src/modules/flea-market-fee.mjs
@@ -14,7 +14,30 @@ const localStorageReadJson = (key, defaultValue) => {
     return defaultValue;
 };
 
-export default function fleaMarketFee(basePrice, sellPrice, count = 1, Ti = 0.05, Tr = 0.10) {
+const localStorageReadGameModeJson = (key, defaultValue) => {
+    try {
+        const gameMode = JSON.parse(localStorage.getItem('gameMode') ?? '"regular"');
+        const settingsString = localStorage.getItem(`${gameMode}Settings`);
+
+        if (typeof settingsString === 'string') {
+            const settings = JSON.parse(settingsString);
+            if (typeof settings[key] !== 'undefined') {
+                return settings[key];
+            }
+        }
+    } catch (error) {
+        /* noop */
+    }
+
+    return defaultValue;
+};
+
+export default function fleaMarketFee(basePrice, sellPrice, options = {}) {
+    const count = options.count ?? 1;
+    const intelligenceCenter = options.intelligenceCenter ?? localStorageReadGameModeJson('intelligence-center', 3);
+    const hideoutManagement = options.hideoutManagement ?? localStorageReadGameModeJson('hideout-management', 0);
+    const Ti = options.Ti ?? localStorageReadJson('Ti', 0.03);
+    const Tr = options.Tr ?? localStorageReadJson('Tr', 0.03);
     let V0 = basePrice;
     let VR = sellPrice;
     //let Ti = 0.05;
@@ -23,8 +46,6 @@ export default function fleaMarketFee(basePrice, sellPrice, count = 1, Ti = 0.05
     let PR = Math.log10(VR / V0);
     let Q = count;
     let IC = 1;
-    const intelligenceCenter = localStorageReadJson('intelligence-center', 3);
-    const hideoutManagement = localStorageReadJson('hideout-management', 0);
 
 
     if (VR < V0) {

--- a/src/pages/barters/index.js
+++ b/src/pages/barters/index.js
@@ -42,7 +42,7 @@ function Barters() {
         'includeCraftIngredients',
         false,
     );
-    const hideDogtagBarters = useSelector((state) => state.settings.hideDogtagBarters);
+    const hideDogtagBarters = useSelector((state) => state.settings[state.settings.gameMode].hideDogtagBarters);
 
     const dispatch = useDispatch();
     const { data: allTraders } = useTradersData();


### PR DESCRIPTION
Currently, the barter instaprofit number doesn't include flea market fees:
![image](https://github.com/user-attachments/assets/572f8768-ec6f-404d-9a57-73e31aef827b)
This is misleading, as fees can actually make barters unprofitable to flip. This PR subtracts the flea fee from the profit:
![image](https://github.com/user-attachments/assets/0c2dd254-e183-40b6-8b8e-c8f4e507324a)
