### PR TITLE
Inventory Slot Labels on Player Profile Page

### DIFF
--- a/src/pages/player/index.css
+++ b/src/pages/player/index.css
@@ -16,17 +16,30 @@
 
 .grid-container.main {
     grid-template-columns: auto auto auto;
+    margin-right: 10px;
+    margin-bottom: 10px;
 }
 
 .grid-container.side {
-    margin-left: 10px;
     grid-template-columns: auto;
 }
 
 .grid-container>div {
-    background-color: rgb( from var(--color-black) r g b / 0.4);
     text-align: center;
     font-size: 20px;
+    border: 4px solid var(--color-black-light);
+}
+
+.slot {
+    height: max-content;
+}
+
+.slot-label {
+    text-align: left;
+    font-size: 14px;
+    padding: 3px;
+    background-color: rgb( from var(--color-black) r g b / 0.4);
+    font-weight: bolder;    
 }
 
 .weapon {
@@ -77,3 +90,9 @@ ul.favorite-item-list li {
 .current-wipe-achievement {
     font-weight: bold;
 }
+
+@media screen and (min-width: 1920px) {
+    .inventory {
+      margin-left: 12.5rem;
+    }
+  }

--- a/src/pages/player/index.css
+++ b/src/pages/player/index.css
@@ -6,6 +6,7 @@
 
 .inventory {
     display: flow-root;
+    overflow-x: scroll;
 }
 
 .grid-container {

--- a/src/pages/player/index.js
+++ b/src/pages/player/index.js
@@ -1133,22 +1133,62 @@ function Player() {
                         <h2><Icon path={mdiBagPersonal} size={1.5} className="icon-with-text" />{t('Loadout')}</h2>
                         <div className="inventory">
                             <div className="grid-container main">
-                                <div className="earpiece">{getLoadoutInSlot('Earpiece')}</div>
-                                <div className="headwear">{getLoadoutInSlot('Headwear')}</div>
-                                <div className="face_cover">{getLoadoutInSlot('FaceCover')}</div>
-                                <div className="armband">{getLoadoutInSlot('ArmBand')}</div>
-                                <div className="body_armor">{getLoadoutInSlot('ArmorVest')}</div>
-                                <div className="eyewear">{getLoadoutInSlot('Eyewear')}</div>
-                                <div className="weapon on_sling">{getLoadoutInSlot('FirstPrimaryWeapon')}</div>
-                                <div className="holster">{getLoadoutInSlot('Holster')}</div>
-                                <div className="weapon on_back">{getLoadoutInSlot('SecondPrimaryWeapon')}</div>
-                                <div className="sheath">{getLoadoutInSlot('Scabbard')}</div>
+                                <div className="earpiece">
+                                    <div>Earpiece</div>
+                                    {getLoadoutInSlot('Earpiece')}
+                                </div>
+                                <div className="headwear">
+                                    <div>Headwear
+                                    </div>
+                                    {getLoadoutInSlot('Headwear')}
+                                </div>
+                                <div className="face_cover">
+                                    <div>Face Cover</div>
+                                    {getLoadoutInSlot('FaceCover')}
+                                </div>
+                                <div className="armband">
+                                    <div>Armband</div>
+                                    {getLoadoutInSlot('ArmBand')}
+                                </div>
+                                <div className="body_armor">
+                                    <div>Body Armor</div>
+                                    {getLoadoutInSlot('ArmorVest')}
+                                </div>
+                                <div className="eyewear">
+                                    <div>Eyewear</div>
+                                    {getLoadoutInSlot('Eyewear')}
+                                </div>
+                                <div className="weapon on_sling">
+                                    <div>On Sling</div>
+                                    {getLoadoutInSlot('FirstPrimaryWeapon')}
+                                </div>
+                                <div className="holster">
+                                    <div>Hoslter</div>
+                                    {getLoadoutInSlot('Holster')}
+                                </div>
+                                <div className="weapon on_back">
+                                    <div>On Back</div>
+                                    {getLoadoutInSlot('SecondPrimaryWeapon')}
+                                </div>
+                                <div className="sheath">
+                                    <div>Sheath</div>
+                                    {getLoadoutInSlot('Scabbard')}
+                                </div>
                             </div>
                             <div className="grid-container side">
-                                <div className="tactical_rig">{getLoadoutInSlot('TacticalVest')}</div>
+                                <div className="tactical_rig">
+                                    <div>Tactical Rig</div>
+                                    {getLoadoutInSlot('TacticalVest')}
+                                </div>
                                 <div className="pockets_and_special_slots">{getLoadoutInSlot('Pockets')}</div>
-                                <div className="backpack">{getLoadoutInSlot('Backpack')}</div>
-                                <div className="pouch">{getLoadoutInSlot('SecuredContainer')}</div>
+                                <div className="backpack">
+                                    <div>Backpack</div>
+                                    {getLoadoutInSlot('Backpack')}
+                                </div>
+                                <div className="pouch">
+                                    <div>Pouch</div>
+                                    {getLoadoutInSlot('SecuredContainer')}
+                                </div>
                             </div>
                         </div>
                     </>

--- a/src/pages/player/index.js
+++ b/src/pages/player/index.js
@@ -1133,60 +1133,59 @@ function Player() {
                         <h2><Icon path={mdiBagPersonal} size={1.5} className="icon-with-text" />{t('Loadout')}</h2>
                         <div className="inventory">
                             <div className="grid-container main">
-                                <div className="earpiece">
-                                    <div>Earpiece</div>
+                                <div className="earpiece slot">
+                                    <div className="slot-label">EARPIECE</div>
                                     {getLoadoutInSlot('Earpiece')}
                                 </div>
-                                <div className="headwear">
-                                    <div>Headwear
-                                    </div>
+                                <div className="headwear slot">
+                                    <div className="slot-label">HEADWEAR</div>
                                     {getLoadoutInSlot('Headwear')}
                                 </div>
-                                <div className="face_cover">
-                                    <div>Face Cover</div>
+                                <div className="face_cover slot">
+                                    <div className="slot-label">FACE COVER</div>
                                     {getLoadoutInSlot('FaceCover')}
                                 </div>
-                                <div className="armband">
-                                    <div>Armband</div>
+                                <div className="armband slot">
+                                    <div className="slot-label">ARMBAND</div>
                                     {getLoadoutInSlot('ArmBand')}
                                 </div>
-                                <div className="body_armor">
-                                    <div>Body Armor</div>
+                                <div className="body_armor slot">
+                                    <div className="slot-label">BODY ARMOR</div>
                                     {getLoadoutInSlot('ArmorVest')}
                                 </div>
-                                <div className="eyewear">
-                                    <div>Eyewear</div>
+                                <div className="eyewear slot">
+                                    <div className="slot-label">EYEWEAR</div>
                                     {getLoadoutInSlot('Eyewear')}
                                 </div>
-                                <div className="weapon on_sling">
-                                    <div>On Sling</div>
+                                <div className="weapon on_sling slot">
+                                    <div className="slot-label">ON SLING</div>
                                     {getLoadoutInSlot('FirstPrimaryWeapon')}
                                 </div>
-                                <div className="holster">
-                                    <div>Hoslter</div>
+                                <div className="holster slot">
+                                    <div className="slot-label">HOLSTER</div>
                                     {getLoadoutInSlot('Holster')}
                                 </div>
-                                <div className="weapon on_back">
-                                    <div>On Back</div>
+                                <div className="weapon on_back slot">
+                                    <div className="slot-label">ON BACK</div>
                                     {getLoadoutInSlot('SecondPrimaryWeapon')}
                                 </div>
-                                <div className="sheath">
-                                    <div>Sheath</div>
+                                <div className="sheath slot">
+                                    <div className="slot-label">SHEATH</div>
                                     {getLoadoutInSlot('Scabbard')}
                                 </div>
                             </div>
                             <div className="grid-container side">
-                                <div className="tactical_rig">
-                                    <div>Tactical Rig</div>
+                                <div className="tactical_rig slot">
+                                    <div className="slot-label">TACTICAL RIG</div>
                                     {getLoadoutInSlot('TacticalVest')}
                                 </div>
-                                <div className="pockets_and_special_slots">{getLoadoutInSlot('Pockets')}</div>
-                                <div className="backpack">
-                                    <div>Backpack</div>
+                                <div className="pockets_and_special_slots slot-label">{getLoadoutInSlot('Pockets')}</div>
+                                <div className="backpack slot">
+                                    <div className="slot-label">BACKPACK</div>
                                     {getLoadoutInSlot('Backpack')}
                                 </div>
-                                <div className="pouch">
-                                    <div>Pouch</div>
+                                <div className="pouch slot">
+                                    <div className="slot-label">POUCH</div>
                                     {getLoadoutInSlot('SecuredContainer')}
                                 </div>
                             </div>


### PR DESCRIPTION
<!-- 

⚠️ IMPORTANT ⚠️

- Please fill in all sections [in brackets]
- Please read the collapsible sections if you need help
- All comments in fenced brackets like this one are comments and will not be displayed

Please delete any sections below which you do not need to fill out. You may keep the collapsible "help" section

-->

# Inventory Slot Labels

Slot labels and layout adjustments to inventory on the player page of tarkov.dev.

## Description 🗒️

The first of several PR's targeted at resolving Issue #1000.  This PR adds inventory slot labels to inventory grid on the player page.  Minor adjustments to the layout and styling to bring the inventory element in-line with the remainder of the page.  *IMPORTANT* - No scaling adjustments to the item images; viewing on mobile is not ideal BUT a horizontal scroll was added to inventory element to ensure overall page layout remains consistent.

Great job with the changes to the page to help with ease of development - made this process much smoother!

## Examples 📸

Images are of a desktop view of tarkov.dev
Full Inventory
![full_inventory](https://github.com/user-attachments/assets/283ce732-3a1d-4648-aa35-0a4b38465b26)

Empty Inventory
![empty_inventory](https://github.com/user-attachments/assets/531f2053-943f-4edb-8a19-2176a15096e5)

## Related Issues 🔗

Issue #1000 - Responsive Design Overhaul to Player Page

<!-- OPTIONAL: If this PR fixes, closes, or resolves an issue; please link that issue here -->

---

<details>
<summary> Expand for Help </summary>

- Have questions about the review or deployment process? View our [contributing docs](https://github.com/the-hideout/tarkov-dev/blob/main/CONTRIBUTING.md)
- Need additional help and want to chat in real time? Join our [community Discord](https://discord.gg/WwTvNe356u)

> By submitting this pull request, you agree to our [code of conduct](https://github.com/the-hideout/tarkov-dev/blob/main/CODE_OF_CONDUCT.md)

</details>
