### PR TITLE
Display health of individual boss body parts

### DIFF
--- a/src/features/bosses/do-fetch-bosses.mjs
+++ b/src/features/bosses/do-fetch-bosses.mjs
@@ -15,6 +15,7 @@ class BossesQuery extends APIQuery {
                 imagePosterLink
                 health {
                     id
+                    bodyPart
                     max
                 }
                 equipment {

--- a/src/pages/boss/index.js
+++ b/src/pages/boss/index.js
@@ -247,14 +247,13 @@ function BossPage(params) {
     // Display health stats
     if (bossData.health) {
         const totalHealth = bossData.health.reduce((totalHealth, current) => {
-            console.log(current);
             totalHealth += current.max;
             return totalHealth;
         }, 0);
         bossProperties['health'] = {
             value: bossData.health.map((current) => {
                 return `${current.bodyPart}: ${current.max}`;
-            }, 0).join(', '),
+            }).join(', '),
             label: `${t('Health')} (${totalHealth}) 🖤`,
             tooltip: t('Total boss health'),
         };

--- a/src/pages/boss/index.js
+++ b/src/pages/boss/index.js
@@ -246,12 +246,16 @@ function BossPage(params) {
 
     // Display health stats
     if (bossData.health) {
+        const totalHealth = bossData.health.reduce((totalHealth, current) => {
+            console.log(current);
+            totalHealth += current.max;
+            return totalHealth;
+        }, 0);
         bossProperties['health'] = {
-            value: bossData.health.reduce((totalHealth, current) => {
-                totalHealth += current.max;
-                return totalHealth;
-            }, 0),
-            label: `${t('Health')} 🖤`,
+            value: bossData.health.map((current) => {
+                return `${current.bodyPart}: ${current.max}`;
+            }, 0).join(', '),
+            label: `${t('Health')} (${totalHealth}) 🖤`,
             tooltip: t('Total boss health'),
         };
     }


### PR DESCRIPTION
Previously only showed total health for bosses:
![image](https://github.com/user-attachments/assets/e5842453-96fa-4767-ad3a-732e03019a8a)

Now shows total and individual limb health pools:
![image](https://github.com/user-attachments/assets/93da92c6-7b3d-4686-83c4-5058d095fdd3)
