### PR TITLE
Hide completed quest objectives

### DIFF
--- a/src/pages/map/index.js
+++ b/src/pages/map/index.js
@@ -1466,7 +1466,7 @@ function Map() {
                                 iconUrl: `${process.env.PUBLIC_URL}/maps/interactive/quest_item.png`,
                                 iconSize: [24, 24],
                                 popupAnchor: [0, -12],
-                                className: quest.active ? 'active-quest-marker' : 'inactive-quest-marker',
+                                className: quest.active && !obj.complete ? 'active-quest-marker' : 'inactive-quest-marker',
                             });
                             const questItemMarker = L.marker(pos(position), {
                                 icon: questItemIcon,
@@ -1505,7 +1505,7 @@ function Map() {
                             iconUrl: `${process.env.PUBLIC_URL}/maps/interactive/quest_objective.png`,
                             iconSize: [24, 24],
                             popupAnchor: [0, -12],
-                            className: quest.active ? 'active-quest-marker' : 'inactive-quest-marker',
+                            className: quest.active && !obj.complete ? 'active-quest-marker' : 'inactive-quest-marker',
                         });
                         
                         const zoneMarker = L.marker(pos(zone.position), {


### PR DESCRIPTION
<!-- 

⚠️ IMPORTANT ⚠️

- Please fill in all sections [in brackets]
- Please read the collapsible sections if you need help
- All comments in fenced brackets like this one are comments and will not be displayed

Please delete any sections below which you do not need to fill out. You may keep the collapsible "help" section

-->

# Hide completed quest objectives

Completed objectives of active quest now hidden when the `Only Active Tasks` options is checked.