### PR TITLE
[Devcontainer] Add Bind Mount for git-ssh inside container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,9 @@
     "dockerComposeFile": "docker-compose.yml",
     "service": "dev",
     "workspaceFolder": "/tarkov-dev",
+    "mounts": [ // Mount local ssh dir into container for git-ssh compatability
+      "type=bind,source=${localEnv:HOME}/.ssh,target=/root/.ssh,readonly"
+    ],
     "features": {
       "ghcr.io/devcontainers/features/github-cli:1": {
         "installDirectlyFromGitHubRelease": true,


### PR DESCRIPTION
# [SSH Compatibility]

## Description 🗒️

In order to fully utilize the dev container as a proper dev environment for maintainers it would be useful to mount in the local ssh dir for people who use ssh keys for git. 

_Totally missed this in my first WIP pass at the container setup._  😔

As part of review for this PR I would love a wishlist of items from maintainers on what would make this container more useable so I can start to implement stuff I might have forgotten or otherwise not thought of. 

