### PR TITLE
Fix input filters for item cost barter tooltip

### DIFF
--- a/src/components/item-cost/index.js
+++ b/src/components/item-cost/index.js
@@ -151,8 +151,8 @@ function ItemCost({
             <BarterTooltip
                 barter={priceDetails}
                 allowAllSources={allowAllSources}
-                barters={barters}
-                crafts={crafts}
+                barters={useBarterIngredients ? barters : false}
+                crafts={useCraftIngredients ? crafts : false}
             />
         );
     }
@@ -168,8 +168,8 @@ function ItemCost({
             <BarterTooltip
                 barter={priceDetails}
                 allowAllSources={allowAllSources}
-                barters={barters}
-                crafts={crafts}
+                barters={useBarterIngredients ? barters : false}
+                crafts={useCraftIngredients ? crafts : false}
             />
         );
     }


### PR DESCRIPTION
The filters to use barters and crafts as sources for items was properly using those filters to show the prices of items required for crafts, but the barter tooltip was not properly respecting those filters.
Before:
![image](https://github.com/user-attachments/assets/634803ae-52e1-4a13-a246-7e8b131e0ddb)
The "use crafts for item sources" filter is not selected, and the cost of the scav vest is properly showing the 19k flea market price of the required slickers, but the barter tooltip shows the crafting price of 17k for the slickers.
With the fix:
![image](https://github.com/user-attachments/assets/c33a60f3-0415-4be0-99e4-1f3c171f4381)
