### PR TITLE
Fix sorting achievements table by playersCompletedPercent

### DIFF
--- a/src/pages/player/index.js
+++ b/src/pages/player/index.js
@@ -335,6 +335,7 @@ function Player() {
                         </div>
                     );
                 },
+                sortType: 'basic',
             },
             {
                 Header: t('Completed'),


### PR DESCRIPTION
<!-- 

⚠️ IMPORTANT ⚠️

- Please fill in all sections [in brackets]
- Please read the collapsible sections if you need help
- All comments in fenced brackets like this one are comments and will not be displayed

Please delete any sections below which you do not need to fill out. You may keep the collapsible "help" section

-->

# Fix sorting achievements table by playersCompletedPercent

sorting achievements by completion% interpreted the value as strings before sorting (stupid default) so it was broken

i am sure that this is an issue in other places as well

## Examples 📸

![firefox_xtymD59ZM6](https://github.com/user-attachments/assets/623dab3f-08b5-475d-bb0e-3e993caedc22)

![firefox_pnU6vh1p6Q](https://github.com/user-attachments/assets/fd3027fd-2cae-4116-b0e2-d0c042976569)

---

<details>
<summary> Expand for Help </summary>

- Have questions about the review or deployment process? View our [contributing docs](https://github.com/the-hideout/tarkov-dev/blob/main/CONTRIBUTING.md)
- Need additional help and want to chat in real time? Join our [community Discord](https://discord.gg/WwTvNe356u)

> By submitting this pull request, you agree to our [code of conduct](https://github.com/the-hideout/tarkov-dev/blob/main/CODE_OF_CONDUCT.md)

</details>
