### PR TITLE
Make map settings control collapsible

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -85,6 +85,7 @@ const Player = React.lazy(() => import('./pages/player/index.js'));
 const PlayerForward = React.lazy(() => import('./pages/player/player-forward.js'));
 const Converter = React.lazy(() => import('./pages/converter/index.js'));
 const About = React.lazy(() => import('./pages/about/index.js'));
+const OtherTools = React.lazy(() => import('./pages/other-tools/index.js'));
 
 const APIDocs = React.lazy(() => import('./pages/api-docs/index.js'));
 
@@ -956,6 +957,16 @@ function App() {
                         element={[
                             <Suspense fallback={<Loading />} key="suspense-converter-wrapper">
                                 <Converter key="converter-wrapper" />
+                            </Suspense>,
+                            remoteControlSessionElement,
+                        ]}
+                    />
+                    <Route
+                        path={'/other-tools'}
+                        key="other-tools"
+                        element={[
+                            <Suspense fallback={<Loading />} key="suspense-converter-wrapper">
+                                <OtherTools key="other-tools-wrapper" />
                             </Suspense>,
                             remoteControlSessionElement,
                         ]}

--- a/src/modules/leaflet-control-map-settings.js
+++ b/src/modules/leaflet-control-map-settings.js
@@ -2,37 +2,108 @@ import L from 'leaflet';
 
 L.Control.MapSettings = L.Control.extend({
     onAdd: function(map) {
-        var container = L.DomUtil.create('div');
-        container.classList.add('leaflet-control-map-settings');
+        const className = 'leaflet-control-map-settings';
+        var container = this._container = L.DomUtil.create('div', className);
+        var collapsed = this.options.collapsed;
 
-        var checkbox = L.DomUtil.create('input');
-        checkbox.id = 'only-active-quest-markers';
-        checkbox.setAttribute('type', 'checkbox');
-        if (!!this.options.checked) {
-            checkbox.setAttribute('checked', !!this.options.checked);
-            checkbox.checked = true;
-        }
-        checkbox.addEventListener('click', (e) => {
-            if (checkbox.checked) {
-                map._container.classList.add('only-active-quest-markers');
-            } else {
-                map._container.classList.remove('only-active-quest-markers');
+        L.DomEvent.disableClickPropagation(container);
+        L.DomEvent.disableScrollPropagation(container);
+
+        var form = this._form = L.DomUtil.create('form', className + '-list');
+        container.appendChild(form);
+
+        if (collapsed) {
+            this._map.on('click', this._collapse, this);
+    
+            if (!L.Browser.android) {
+                L.DomEvent.on(container, {
+                    mouseenter: this._expand,
+                    mouseleave: this._collapse
+                }, this);
             }
-            this.options.settingChanged('showOnlyActiveTasks', checkbox.checked);
-        });
-        container.append(checkbox);
+        }
 
-        var label = L.DomUtil.create('label');
-        label.setAttribute('for', 'only-active-quest-markers');
-        label.textContent = this.options.activeTasksLabel ?? 'Only Active Tasks';
-        container.append(label);
+        var link = this._layersLink = L.DomUtil.create('a', className + '-toggle', container);
+        link.href = '#';
+        link.title = 'Layers';
+    
+        if (L.Browser.touch) {
+            L.DomEvent.on(link, 'click', L.DomEvent.stop);
+            L.DomEvent.on(link, 'click', this._expand, this);
+        } else {
+            L.DomEvent.on(link, 'focus', this._expand, this);
+        }
+    
+        if (!collapsed) {
+            this._expand();
+        }
+
+        // show only active quests setting
+        var activeQuestMarkersDiv = L.DomUtil.create('div', `${className}-active-quests`, form);
+        var activeQuestMarkersCheckbox = L.DomUtil.create('input', undefined, activeQuestMarkersDiv);
+        activeQuestMarkersCheckbox.id = 'only-active-quest-markers';
+        activeQuestMarkersCheckbox.setAttribute('type', 'checkbox');
+        if (!!this.options.checked) {
+            activeQuestMarkersCheckbox.setAttribute('checked', !!this.options.checked);
+            activeQuestMarkersCheckbox.checked = true;
+        }
+        L.DomEvent.on(activeQuestMarkersCheckbox, 'click', this._onActiveQuestMarkersToggle, this);
+
+        var activeQuestMarkersLabel = L.DomUtil.create('label', undefined, activeQuestMarkersDiv);
+        activeQuestMarkersLabel.setAttribute('for', 'only-active-quest-markers');
+        activeQuestMarkersLabel.textContent = this.options.activeTasksLabel ?? 'Only Active Tasks';
+
+        L.DomUtil.create('div', `${className}-separator player-location-help-separator`, form);
+
+        // show location labels setting
+        var playerLocationDiv = L.DomUtil.create('div', `${className}-player-location-help`, form);
+        var playerLocationLink = L.DomUtil.create('a', undefined, playerLocationDiv);
+        playerLocationLink.setAttribute('href', '/other-tools#tarkov-monitor');
+        playerLocationLink.setAttribute('target', '_blank');
+        playerLocationLink.textContent = this.options.playerLocationLabel ?? 'Use TarkovMonitor to show your position';
 
         return container;
     },
 
     onRemove: function(map) {
         // Nothing to do here
-    }
+    },
+
+    _onActiveQuestMarkersToggle: function (event) {
+        L.DomEvent.stopPropagation(event);
+        //L.DomEvent.preventDefault(event);
+        if (event.target.checked) {
+            this._map._container.classList.add('only-active-quest-markers');
+        } else {
+            this._map._container.classList.remove('only-active-quest-markers');
+        }
+        this.options.settingChanged('showOnlyActiveTasks', event.target.checked);
+    },
+
+    _expand: function () {
+        L.DomUtil.addClass(this._container, 'leaflet-control-map-settings-expanded');
+        this._form.style.height = null;
+        var acceptableHeight = this._map.getSize().y - (this._container.offsetTop + 50);
+        if (acceptableHeight < this._form.clientHeight) {
+            L.DomUtil.addClass(this._form, 'leaflet-control-map-settings-scrollbar');
+            this._form.style.height = acceptableHeight + 'px';
+        } else {
+            L.DomUtil.removeClass(this._form, 'leaflet-control-map-settings-scrollbar');
+        }
+    
+        return this;
+    },
+    
+    _expandIfNotCollapsed: function () {
+        if (this._map && !this.options.collapsed) {
+            this._expand();
+        }
+        return this;
+    },
+    
+    _collapse: function () {
+        this._container.className = this._container.className.replace(' leaflet-control-map-settings-expanded', '');
+    },
 });
 
 L.control.mapSettings = function(opts) {

--- a/src/pages/map/index.js
+++ b/src/pages/map/index.js
@@ -17,6 +17,7 @@ import '../../modules/leaflet-control-groupedlayer.js';
 import '../../modules/leaflet-control-raid-info.js';
 import '../../modules/leaflet-control-map-search.js';
 import '../../modules/leaflet-control-map-settings.js';
+import '../../styles/mapSettings.css';
 
 import { setPlayerPosition } from '../../features/settings/settingsSlice.mjs';
 
@@ -460,10 +461,12 @@ function Map() {
             position: 'bottomright',
             checked: mapSettingsRef.current.showOnlyActiveTasks,
             activeTasksLabel: t('Only Active Tasks'),
+            playerLocationLabel: t('Use TarkovMonitor to show your position'),
             settingChanged: (settingName, settingValue) => {
                 mapSettingsRef.current[settingName] = settingValue;
                 updateSavedMapSettings();
             },
+            collapsed: true,
         }).addTo(map);
 
         map.raidInfoControl = L.control.raidInfo({
@@ -1741,6 +1744,7 @@ function Map() {
 
         // Add player position
         if (playerPosition && (playerPosition.map === mapData.key || playerPosition.map === null)) {
+            map._container.classList.add('player-position-shown');
             const positionLayer = L.layerGroup();
             let addRotation = mapData.coordinateRotation;
             if (addRotation === 90 || addRotation === 270) {

--- a/src/pages/other-tools/index.css
+++ b/src/pages/other-tools/index.css
@@ -1,0 +1,23 @@
+.boss-list-wrapper {
+    display: flex;
+    flex-flow: wrap;
+    justify-content: center;
+}
+
+.boss-page-wrapper {
+    min-height: 0;
+}
+
+.boss-list-wrapper img {
+    width: 128px;
+    height: 128px;
+}
+
+.boss-sub-text {
+    margin: .75rem;
+    text-align: center;
+    font-size: 16px;
+    font-weight: 400;
+}
+
+@media screen and (min-width: 800px) {}

--- a/src/pages/other-tools/index.js
+++ b/src/pages/other-tools/index.js
@@ -1,0 +1,71 @@
+import { Icon } from '@mdi/react';
+import { Trans, useTranslation } from 'react-i18next';
+
+import { mdiTextSearch, mdiTools } from '@mdi/js';
+
+import SEO from '../../components/SEO.jsx';
+import { ReactComponent as DiscordIcon } from '../../images/Discord.svg';
+
+import './index.css';
+
+function OtherTools(props) {
+    const { t } = useTranslation();
+    return [
+        <SEO 
+            title={`${t('More Tools')} - ${t('Escape from Tarkov')} - ${t('Tarkov.dev')}`}
+            description={t('other-tools-page-description', 'This page includes information the additional tools available through Tarkov.dev.')}
+            key="seo-wrapper"
+        />,
+        <div className={'page-wrapper'} key="other-tools-page-wrapper">
+            <h1 className="center-title">
+                <Icon
+                    path={mdiTools}
+                    size={1.5}
+                    className="icon-with-text"
+                />
+                {t('More Tools')}
+            </h1>
+            <div className="information-section map-block" id="tarkov-monitor">
+                <h2>
+                    <span className="icon">
+                        <Icon 
+                        path={mdiTextSearch} 
+                        size={1}
+                        className="icon-with-text"
+                        />
+                    </span>
+                    <a href="https://github.com/the-hideout/TarkovMonitor" target="_blank" rel="noreferrer">TarkovMonitor</a>
+                </h2>
+                <div className="page-wrapper other-tools-page-wrapper">
+                    <Trans>
+                        <p>
+                        Tarkov Monitor is an open-source application that automates certain features (such as marking quests complete on Tarkov Tracker), 
+                        provides audio notifications on certain events (e.g., when you've matched into a raid), 
+                        and enables additional functionality on the Tarkov.dev website, such as showing your position on the maps when you take a screenshot. 
+                        More information, including installation and setup instructions, is available at the <a href="https://github.com/the-hideout/TarkovMonitor" target="_blank" rel="noreferrer">TarkovMonitor repository</a>.
+                        </p>
+                    </Trans>
+                </div>
+            </div>
+            <div className="information-section map-block" id="stash">
+                <h2>
+                    <span className="icon">
+                        <DiscordIcon className="icon-with-text"/>
+                    </span>
+                    {t('Stash Discord Bot')}
+                </h2>
+                <div className="page-wrapper other-tools-page-wrapper">
+                    <Trans>
+                        <p>
+                        Stash is Tarkov.dev's <a href="https://github.com/the-hideout/stash" target="_blank" rel="noreferrer">open source</a> Discord bot. The bot has commands 
+                        for looking up item prices, barter and craft details, quest information, and more. There's also a toggle for game mode (PVP/PVE). 
+                        <a href="https://discord.com/api/oauth2/authorize?client_id=955521336904667227&permissions=309237664832&scope=bot%20applications.commands" target="_blank" rel="noreferrer">Add Stash to your server</a>!
+                        </p>
+                    </Trans>
+                </div>
+            </div>
+        </div>,
+    ];
+}
+
+export default OtherTools;

--- a/src/styles/mapSettings.css
+++ b/src/styles/mapSettings.css
@@ -1,0 +1,82 @@
+.leaflet-control-map-settings-toggle {
+	background-position: 50% 50%;
+	background-repeat: no-repeat;
+	display: block;
+}
+.leaflet-control-map-settings {
+	box-shadow: 0 1px 5px rgba(0,0,0,0.4);
+	background: #fff;
+	border-radius: 5px;
+}
+.leaflet-control-map-settings-toggle {
+	background-image: url('data:image/svg+xml,<svg width="24" height="24" viewBox="0 0 24 24" fill="white" xmlns="http://www.w3.org/2000/svg" stroke="black" stroke-width="0.75"><path d="M19.43 12.98c.04-.32.07-.65.07-.98s-.03-.66-.07-.98l2.11-1.65a.5.5 0 0 0 .12-.64l-2-3.46a.5.5 0 0 0-.6-.22l-2.49 1a7.03 7.03 0 0 0-1.7-.98l-.38-2.65a.5.5 0 0 0-.5-.42h-4a.5.5 0 0 0-.5.42l-.38 2.65c-.63.23-1.2.55-1.7.98l-2.49-1a.5.5 0 0 0-.6.22l-2 3.46a.5.5 0 0 0 .12.64l2.11 1.65c-.04.32-.07.65-.07.98s.03.66.07.98l-2.11 1.65a.5.5 0 0 0-.12.64l2 3.46a.5.5 0 0 0 .6.22l2.49-1c.5.43 1.07.79 1.7.98l.38 2.65a.5.5 0 0 0 .5.42h4a.5.5 0 0 0 .5-.42l.38-2.65c.63-.23 1.2-.55 1.7-.98l2.49 1a.5.5 0 0 0 .6-.22l2-3.46a.5.5 0 0 0-.12-.64l-2.11-1.65zM12 15.5a3.5 3.5 0 1 1 0-7 3.5 3.5 0 0 1 0 7z"/></svg>');
+	width: 36px;
+	height: 36px;
+}
+.leaflet-touch .leaflet-control-map-settings-toggle {
+	width: 44px;
+	height: 44px;
+}
+.leaflet-control-map-settings .leaflet-control-map-settings-list,
+.leaflet-control-map-settings-expanded .leaflet-control-map-settings-toggle {
+	display: none;
+}
+.leaflet-control-map-settings-expanded .leaflet-control-map-settings-list {
+	display: block;
+	position: relative;
+}
+.leaflet-control-map-settings-list {
+	border: 0;
+	margin: 0;
+	padding: 0;
+}
+.leaflet-control-map-settings-expanded {
+	padding: 6px 10px 6px 6px;
+	color: #333;
+	background: #fff;
+}
+.leaflet-control-map-settings-scrollbar {
+	overflow-y: scroll;
+	overflow-x: hidden;
+	padding-right: 5px;
+}
+.leaflet-control-map-settings-selector {
+	margin-top: 2px;
+	position: relative;
+	top: 1px;
+}
+.leaflet-control-map-settings label {
+	display: block;
+	font-size: 13px;
+	font-size: 1.08333em;
+}
+.leaflet-control-map-settings-separator {
+	height: 0;
+	border-top: 1px solid #999;
+	margin: 5px 5px 5px 5px;
+}
+.leaflet-touch .leaflet-control-map-settings {
+	box-shadow: none;
+}
+.leaflet-touch .leaflet-control-map-settings{
+	border: 2px solid rgba(0,0,0,0.2);
+	background-clip: padding-box;
+}
+.leaflet-control-map-settings-active-quests {
+    display: flex;
+}
+.leaflet-control-map-settings a {
+    color: var(--color-gold-two);
+}
+
+.leaflet-control-map-settings-player-location-help {
+	background-image: url("../../public/maps/interactive/player-position.png");
+    background-repeat: no-repeat;
+    background-size: 24px 24px;
+    padding-left: 27px;
+}
+
+.player-position-shown .leaflet-control-map-settings-player-location-help,
+.player-position-shown .player-location-help-separator {
+    display: none;
+}


### PR DESCRIPTION
The map settings control is now a proper control that is collapsible.
Before:
![image](https://github.com/user-attachments/assets/e23434ea-a632-437b-9119-9d55b623b4d4)
After:
Collapsed
![image](https://github.com/user-attachments/assets/9e8639a1-3d91-4e06-a4b8-4e144c6a5cfe)
Expanded
![image](https://github.com/user-attachments/assets/432308b1-c8eb-43a2-98d9-ba2f657d9fad)

The control also includes a note about showing player position on the map. Also added a page giving a brief explanation of TarkovMonitor and Stash bot.