### PR TITLE
Add sort type to Player %

### DIFF
--- a/src/pages/achievements/index.js
+++ b/src/pages/achievements/index.js
@@ -77,13 +77,13 @@ function Achievements() {
                 Header: t('Player %'),
                 id: 'playersCompletedPercent',
                 accessor: 'adjustedPlayersCompletedPercent',
-                Cell: (props) => {
-                    return (
-                        <div className="center-content">
-                            {props.value}%
-                        </div>
-                    );
-                },
+                Cell: (props) => (
+                    <div className="center-content">
+                        {props.value}%
+                    </div>
+                ),
+                sortType: (rowA, rowB) =>
+                    rowA.original.adjustedPlayersCompletedPercent - rowB.original.adjustedPlayersCompletedPercent,
             },
             {
                 Header: t('Rarity'),


### PR DESCRIPTION

# [Fix sorting player % on Achievements page]

## Description 🗒️
The current achievements page does not have a sortType attribute for Player % which breaks sorting for that field as Javascript will javascript. 

## Examples 📸
Current Production: 
<img width="1259" alt="Screenshot 2025-07-03 at 10 15 10 AM" src="https://github.com/user-attachments/assets/481c0982-6d82-4429-add5-b734d4f5cd7b" />

Fix proposed in this branch
<img width="1298" alt="Screenshot 2025-07-03 at 10 15 53 AM" src="https://github.com/user-attachments/assets/309e3942-351c-4669-ad61-67438b271aa9" />


## Related Issues 🔗
Discord [#bug-issues](https://discord.com/channels/956236955815907388/956239773742288896/1390097520071282758)
