### PR TITLE
Use item handbook category data

### DIFF
--- a/scripts/build-sitemap.mjs
+++ b/scripts/build-sitemap.mjs
@@ -140,6 +140,11 @@ async function build_sitemap() {
         sitemap = addPath(sitemap, `/items/${itemCategory.normalizedName}`);
     }
 
+    const itemHandbookCategories = await graphqlRequest('{handbookCategories{normalizedName}}');
+    for (const itemCategory of itemCategories.data.handbookCategories) {
+        sitemap = addPath(sitemap, `/items/handbook/${itemCategory.normalizedName}`);
+    }
+
     for (const categoryPage of categoryPages) {
         sitemap = addPath(sitemap, `/items/${categoryPage.key}`);
     }

--- a/src/App.js
+++ b/src/App.js
@@ -66,6 +66,7 @@ const Provisions = React.lazy(() => import('./pages/items/provisions/index.js'))
 const Rigs = React.lazy(() => import('./pages/items/rigs/index.js'));
 const Suppressors = React.lazy(() => import('./pages/items/suppressors/index.js'));
 const BsgCategory = React.lazy(() => import('./pages/items/bsg-category/index.js'));
+const HandbookCategory = React.lazy(() => import('./pages/items/handbook-category/index.js'));
 const BitcoinFarmCalculator = React.lazy(() => import('./pages/bitcoin-farm-calculator/index.js'));
 const Quests = React.lazy(() => import('./pages/quests/index.js'));
 const Quest = React.lazy(() => import('./pages/quest/index.js'));
@@ -682,6 +683,16 @@ function App() {
                         element={[
                             <Suspense fallback={<Loading />} key="suspense-items-category-wrapper">
                                 <BsgCategory />
+                            </Suspense>,
+                            remoteControlSessionElement,
+                        ]}
+                    />
+                    <Route
+                        path="/items/handbook/:handbookCategoryName"
+                        key="items-handbook-category-route"
+                        element={[
+                            <Suspense fallback={<Loading />} key="suspense-items-category-wrapper">
+                                <HandbookCategory />
                             </Suspense>,
                             remoteControlSessionElement,
                         ]}

--- a/src/components/small-item-table/index.js
+++ b/src/components/small-item-table/index.js
@@ -231,6 +231,7 @@ function SmallItemTable(props) {
         maxPropertyFilter,
         maxPrice,
         bsgCategoryFilter,
+        handbookCategoryFilter,
         showContainedItems,
         weight,
         showNetPPS,
@@ -572,6 +573,17 @@ function SmallItemTable(props) {
 
                 return item.categories.some(category => categoriesFilter.includes(category.id));
             })
+            .filter((item) => {
+                if (!handbookCategoryFilter) {
+                    return true;
+                }
+                let categoriesFilter = handbookCategoryFilter;
+                if (!Array.isArray(categoriesFilter)) {
+                    categoriesFilter = [categoriesFilter];
+                }
+
+                return item.handbookCategories.some(category => categoriesFilter.includes(category.id));
+            })
             .filter(item => {
                 if (!containedInFilter) {
                     return true;
@@ -908,6 +920,7 @@ function SmallItemTable(props) {
         maxPropertyFilter,
         maxPrice,
         bsgCategoryFilter,
+        handbookCategoryFilter,
         showNetPPS,
         materialDestructibilityMap,
         materialRepairabilityMap,

--- a/src/features/items/do-fetch-items.mjs
+++ b/src/features/items/do-fetch-items.mjs
@@ -18,6 +18,9 @@ class ItemsQuery extends APIQuery {
                         name
                         normalizedName
                     }
+                    handbookCategories {
+                        id
+                    }
                     name
                     shortName
                     basePrice

--- a/src/features/meta/do-fetch-meta.mjs
+++ b/src/features/meta/do-fetch-meta.mjs
@@ -35,6 +35,15 @@ class MetaQuery extends APIQuery {
                     id
                 }
             }
+            handbookCategories(lang: ${language}) {
+                id
+                name
+                normalizedName
+                parent {
+                    id
+                }
+                imageLink
+            }
             playerLevels {
                 level
                 exp
@@ -82,6 +91,7 @@ class MetaQuery extends APIQuery {
                 !metaData.data.fleaMarket || 
                 !metaData.data.armorMaterials || !metaData.data.armorMaterials.length || 
                 !metaData.data.itemCategories || !metaData.data.itemCategories.length ||
+                !metaData.data.handbookCategories || !metaData.data.handbookCategories.length ||
                 !metaData.data.playerLevels 
             ) {
                 return Promise.reject(new Error(metaData.errors[0].message));
@@ -95,6 +105,7 @@ class MetaQuery extends APIQuery {
             flea: metaData.data.fleaMarket,
             armor: metaData.data.armorMaterials,
             categories: metaData.data.itemCategories,
+            handbookCategories: metaData.data.handbookCategories,
             playerLevels: metaData.data.playerLevels,
             skills: metaData.data.skills,
             mastering: metaData.data.mastering,

--- a/src/modules/leaflet-control-map-search.js
+++ b/src/modules/leaflet-control-map-search.js
@@ -81,7 +81,7 @@ L.Control.MapSearch = L.Control.extend({
                     (acc, marker) => {
                         if (foundQuest.some((quest) => quest.id === marker.options.questId)) {
                             acc.objectiveMarkers.push(marker);
-                        } else {
+                        } else if (marker.options.markerType !== 'playerPosition') {
                             acc.nonObjectiveMarkers.push(marker);
                         }
 

--- a/src/modules/property-format.js
+++ b/src/modules/property-format.js
@@ -36,7 +36,11 @@ const itemLinkFormat = (inputItem) => {
 };
 
 const itemCategoryLinkFormat = inputCategory => {
-    return <Link to={`/items/${inputCategory.normalizedName}`} key={inputCategory.normalizedName}>{inputCategory.name}</Link>;
+    let categoryImage = '';
+    if (inputCategory.imageLink) {
+        categoryImage = <img style={{verticalAlign: 'middle'}} src={inputCategory.imageLink} alt=""></img>
+    }
+    return <Link to={`/items/handbook/${inputCategory.normalizedName}`} key={inputCategory.normalizedName}>{categoryImage}{inputCategory.name}</Link>;
 };
 
 const formatter = (key, value, id) => {

--- a/src/pages/item/index.js
+++ b/src/pages/item/index.js
@@ -202,6 +202,9 @@ function Item() {
                     ...extraProps,
                 },
                 ...bestPrice(item, meta?.flea?.sellOfferFeeRate, meta?.flea?.sellRequirementFeeRate),
+                handbookCategories: item.handbookCategories.map(cat => {
+                    return meta?.handbookCategories?.find(c => c.id === cat.id);
+                }).filter(Boolean),
             };
         }
         return item;
@@ -738,7 +741,7 @@ The max profitable price is impacted by the intel center and hideout management 
                         {t('Stats')}
                     </h2>
                     {hasProperties
-                        ? (<PropertyList properties={{...currentItemData.properties, categories: currentItemData.categories}} id={currentItemData.id} />)
+                        ? (<PropertyList properties={{...currentItemData.properties, categories: currentItemData.handbookCategories}} id={currentItemData.id} />)
                         : (<LoadingSmall />)
                     }
                 </div>

--- a/src/pages/items/handbook-category/index.js
+++ b/src/pages/items/handbook-category/index.js
@@ -1,0 +1,96 @@
+import { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
+
+import SEO from '../../../components/SEO.jsx';
+import ErrorPage from '../../error-page/index.js';
+import { Filter, InputFilter, ToggleFilter } from '../../../components/filter/index.js';
+import SmallItemTable from '../../../components/small-item-table/index.js';
+
+import QueueBrowserTask from '../../../modules/queue-browser-task.js';
+
+import useMetaData from '../../../features/meta/index.js';
+
+function HandbookCategory() {
+    const defaultQuery = new URLSearchParams(window.location.search).get(
+        'search',
+    );
+    const [showAllItemSources, setShowAllItemSources] = useState(false);
+    const [nameFilter, setNameFilter] = useState(defaultQuery || '');
+    let { handbookCategoryName } = useParams();
+    const { t } = useTranslation();
+
+    const { data: meta } = useMetaData();
+    const category = meta.handbookCategories.find(cat => handbookCategoryName === cat.normalizedName);
+
+    const handleNameFilterChange = useCallback(
+        (e) => {
+            if (typeof window !== 'undefined') {
+                const name = e.target.value.toLowerCase();
+
+                // schedule this for the next loop so that the UI
+                // has time to update but we do the filtering as soon as possible
+                QueueBrowserTask.task(() => {
+                    setNameFilter(name);
+                });
+            }
+        },
+        [setNameFilter],
+    );
+
+    if (!category) {
+        return <ErrorPage />;
+    }
+
+    let categoryImage = ' - ';
+    if (category.imageLink) {
+        categoryImage = <img src={category.imageLink} alt="" style={{objectFit: 'contain', verticalAlign: 'middle', marginLeft: '5px', marginRight: '5px'}}/>
+    }
+
+    return [
+        <SEO 
+            title={`${category.name} - ${t('Escape from Tarkov')} - ${t('Tarkov.dev')}`}
+            description={t('bsg-category-description', 'Find out everything you need to know about {{category}} in Escape from Tarkov.', { category: category.name })}
+            key="seo-wrapper"
+        />,
+        <div className="display-wrapper" key={'display-wrapper'}>
+            <div className="page-headline-wrapper">
+                <h1>
+                    {t('Escape from Tarkov')}
+                    {categoryImage}
+                    {category.name}
+                </h1>
+                <Filter center>
+                    <ToggleFilter
+                        checked={showAllItemSources}
+                        label={t('Ignore settings')}
+                        onChange={(e) =>
+                            setShowAllItemSources(!showAllItemSources)
+                        }
+                        tooltipContent={
+                            <>
+                                {t('Shows all sources of items regardless of your settings')}
+                            </>
+                        }
+                    />
+                    <InputFilter
+                        defaultValue={nameFilter}
+                        onChange={handleNameFilterChange}
+                        placeholder={t('filter on item')}
+                    />
+                </Filter>
+            </div>
+
+            <SmallItemTable
+                nameFilter={nameFilter}
+                handbookCategoryFilter={category.id}
+                showAllSources={showAllItemSources}
+                traderValue={1}
+                fleaValue={2}
+                cheapestPrice={3}
+            />
+        </div>,
+    ];
+}
+
+export default HandbookCategory;

--- a/src/pages/map/index.js
+++ b/src/pages/map/index.js
@@ -681,6 +681,14 @@ function Map() {
         return bounds.contains(pos(position));
     };
 
+    const refreshMapSearch = () => {
+        const searchBar = mapRef.current?.searchControl?._container.getElementsByClassName('maps-search-wrapper-search-bar')[0];
+        if (!searchBar) {
+            return;
+        }
+        searchBar.dispatchEvent(new Event('input'));
+    };
+
     // load base layers when map changed
     useEffect (() => {
         if (!currentMap || !mapRef.current) {
@@ -1508,6 +1516,8 @@ function Map() {
             L.rectangle(getBounds(mapData.bounds), {color: '#00ff0055', weight: 1}).addTo(map);
         }
 
+        refreshMapSearch();
+
         // Set default zoom level
         // map.fitBounds(bounds);
         // map.fitWorld({maxZoom: Math.max(mapData.maxZoom-3, mapData.minZoom)});
@@ -1641,6 +1651,7 @@ function Map() {
                 break;
             }
         }
+        refreshMapSearch();
     }, [mapData, quests, addLayer]);
 
     // for markers requiring game items
@@ -1830,6 +1841,7 @@ function Map() {
                 break;
             }
         }
+        refreshMapSearch();
     }, [mapData, items, metaData, addLayer, t, tMaps, getPoiLinkElement]);
 
     useEffect(() => {
@@ -1878,8 +1890,7 @@ function Map() {
             addLayer(positionLayer, 'player_position', 'Misc');
             activateMarkerLayer({target: positionMarker});
             mapRef.current.panTo(pos(playerPosition.position), {animate: true});
-            const searchBar = map.searchControl._container.getElementsByClassName('maps-search-wrapper-search-bar')[0];
-            searchBar.dispatchEvent(new Event('input'));
+            refreshMapSearch();
         }
     }, [mapData, playerPosition, addLayer, dispatch, tMaps]);
     

--- a/src/pages/map/index.js
+++ b/src/pages/map/index.js
@@ -1812,7 +1812,7 @@ function Map() {
                 //className: layerIncludesMarker(heightLayer, item) ? '' : 'off-level',
             });
                   
-            const positionMarker = L.marker(pos(playerPosition.position), {icon: playerIcon, zIndexOffset: 1000, position: playerPosition.position}).addTo(positionLayer);
+            const positionMarker = L.marker(pos(playerPosition.position), {icon: playerIcon, zIndexOffset: 1000, position: playerPosition.position, markerType: 'playerPosition'}).addTo(positionLayer);
             const closeButton = L.DomUtil.create('a');
             closeButton.innerHTML = tMaps('Clear');
             closeButton.addEventListener('click', () => {
@@ -1825,7 +1825,9 @@ function Map() {
             //layerControl.addOverlay(positionLayer, tMaps('Player'), tMaps('Misc'));
             addLayer(positionLayer, 'player_position', 'Misc');
             activateMarkerLayer({target: positionMarker});
-            mapRef.current.panTo(pos(playerPosition.position), {animate: true})
+            mapRef.current.panTo(pos(playerPosition.position), {animate: true});
+            const searchBar = map.searchControl._container.getElementsByClassName('maps-search-wrapper-search-bar')[0];
+            searchBar.dispatchEvent(new Event('input'));
         }
     }, [mapData, playerPosition, addLayer, dispatch, tMaps]);
     


### PR DESCRIPTION
Uses item handbook categories, including images.
Categories on item detail pages:
<img width="316" height="122" alt="image" src="https://github.com/user-attachments/assets/58b1ad66-9fc5-4ec3-b62b-1ff89d5663a9" />
Titles in handbook category pages:
<img width="613" height="60" alt="image" src="https://github.com/user-attachments/assets/aaf83750-ec5b-4565-b3b1-2ed47f5185ee" />

Loose loot on maps is now grouped by category:
<img width="370" height="302" alt="image" src="https://github.com/user-attachments/assets/46d2b701-b453-45ec-bd31-6a71a643902e" />
<img width="212" height="282" alt="image" src="https://github.com/user-attachments/assets/b4afab0e-1170-4b4a-82c0-99a634c3db8c" />
