### PR TITLE
Add ignore settings to loot tier Page

### DIFF
--- a/src/pages/loot-tiers/index.js
+++ b/src/pages/loot-tiers/index.js
@@ -186,9 +186,9 @@ function LootTier(props) {
                 }
 
                 // Use flea market if: 
-                // 1. User has flea enabled AND ignore setting is off, OR
+                // 1. User has flea enabled 
                 // 2. Ignore setting is on (regardless of user's flea setting)
-                const shouldUseFlea = (hasFlea && !ignoreFleaSetting) || ignoreFleaSetting;
+                const shouldUseFlea = hasFlea || ignoreFleaSetting;
                 
                 if (shouldUseFlea && !item.types.includes('noFlea')) {
                     const fleaFee = fleaMarketFee(item.basePrice, item.lastLowPrice);

--- a/src/pages/loot-tiers/index.js
+++ b/src/pages/loot-tiers/index.js
@@ -49,6 +49,7 @@ function LootTier(props) {
     const [numberFilter, setNumberFilter] = useState(DEFAULT_MAX_ITEMS);
     const [minPrice, setMinPrice] = useStateWithLocalStorage('minPrice', 0);
     const hasFlea = useSelector((state) => state.settings[state?.settings?.gameMode ?? 'regular'].hasFlea);
+    const [showAllItemSources, setShowAllItemSources] = useState(false);
     const [includeMarked, setIncludeMarked] = useStateWithLocalStorage(
         'includeMarked',
         false,
@@ -401,6 +402,18 @@ function LootTier(props) {
                     onChange={(e) => setGroupByType(!groupByType)}
                     checked={groupByType}
                 />
+                <ToggleFilter
+                        checked={showAllItemSources}
+                        label={t('Ignore settings')}
+                        onChange={(e) =>
+                            setShowAllItemSources(!showAllItemSources)
+                        }
+                        tooltipContent={
+                            <>
+                                {t('Shows all sources of items regardless of your settings')}
+                            </>
+                        }
+                    />
                 <SelectFilter
                     placeholder={t('Select...')}
                     defaultValue={filters.types?.map((filter) => {

--- a/src/pages/loot-tiers/index.js
+++ b/src/pages/loot-tiers/index.js
@@ -49,7 +49,10 @@ function LootTier(props) {
     const [numberFilter, setNumberFilter] = useState(DEFAULT_MAX_ITEMS);
     const [minPrice, setMinPrice] = useStateWithLocalStorage('minPrice', 0);
     const hasFlea = useSelector((state) => state.settings[state?.settings?.gameMode ?? 'regular'].hasFlea);
-    const [showAllItemSources, setShowAllItemSources] = useState(false);
+    const [ignoreFleaSetting, setIgnoreFleaSetting] = useStateWithLocalStorage(
+        'ignoreFleaSetting',
+        false,
+    );
     const [includeMarked, setIncludeMarked] = useStateWithLocalStorage(
         'includeMarked',
         false,
@@ -182,8 +185,12 @@ function LootTier(props) {
                     itemTypes = item.types.filter((type) => type !== 'wearable');
                 }
 
-
-                if (hasFlea && !item.types.includes('noFlea')) {
+                // Use flea market if: 
+                // 1. User has flea enabled AND ignore setting is off, OR
+                // 2. Ignore setting is on (regardless of user's flea setting)
+                const shouldUseFlea = (hasFlea && !ignoreFleaSetting) || ignoreFleaSetting;
+                
+                if (shouldUseFlea && !item.types.includes('noFlea')) {
                     const fleaFee = fleaMarketFee(item.basePrice, item.lastLowPrice);
                     const fleaPrice = item.lastLowPrice - fleaFee;
                     if (fleaPrice >= priceRUB) {
@@ -213,7 +220,7 @@ function LootTier(props) {
 
                 return true;
             });
-    }, [hasFlea, items]);
+    }, [hasFlea, items, ignoreFleaSetting]);
 
     const typeFilteredItems = useMemo(() => {
         const innerTypeFilteredItems = itemData.filter((item) => {
@@ -403,10 +410,10 @@ function LootTier(props) {
                     checked={groupByType}
                 />
                 <ToggleFilter
-                        checked={showAllItemSources}
+                        checked={ignoreFleaSetting}
                         label={t('Ignore settings')}
                         onChange={(e) =>
-                            setShowAllItemSources(!showAllItemSources)
+                            setIgnoreFleaSetting(!ignoreFleaSetting)
                         }
                         tooltipContent={
                             <>


### PR DESCRIPTION
# [Add Ignore settings to Loot Tier]

<!-- REQUIRED: Place a short description of your change here -->

## Description 🗒️
Add the Ignore settings filter to the Loot Tier page

## Examples 📸
<img width="1495" height="592" alt="Screenshot 2025-09-17 at 1 06 15 PM" src="https://github.com/user-attachments/assets/dfd8bc6b-c026-446b-9dbb-3322024faa1b" />

<!-- OPTIONAL: Screenshots with examples for your changes if they are UI related -->

## Related Issues 🔗
[Issue 634](https://github.com/the-hideout/tarkov-dev/issues/634) this feature was requested. 

<!-- OPTIONAL: If this PR fixes, closes, or resolves an issue; please link that issue here -->

---


I personally do not use this feature and I am not entirely sure if `useState(false)` is sufficient for this page or what exact settings this is supposed to affect. Please let me know if i barked up the wrong tree with this one. 

Resolves #634 