### PR TITLE
bump branch-deploy to v11

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
 
-      - uses: github/branch-deploy@v10
+      - uses: github/branch-deploy@v11
         id: branch-deploy
         with:
           admins: the-hideout/core-contributors

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: deployment check
-        uses: github/branch-deploy@v10
+        uses: github/branch-deploy@v11
         id: deployment-check
         with:
           merge_deploy_mode: "true" # tells the Action to use the merge commit workflow strategy

--- a/.github/workflows/unlock-on-merge.yml
+++ b/.github/workflows/unlock-on-merge.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: unlock on merge
-        uses: github/branch-deploy@v10
+        uses: github/branch-deploy@v11
         id: unlock-on-merge
         with:
           unlock_on_merge_mode: "true" # <-- indicates that this is the "Unlock on Merge Mode" workflow


### PR DESCRIPTION
This pull request updates the `github/branch-deploy` action to the latest major release (`v11`) which is in pre-release and I want to test it out here.