### PR TITLE
Use player level

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,5 +1,5 @@
-@import url('./styles/singleEntity.css');
-@import url('./styles/mapSearch.css');
+@import url("./styles/singleEntity.css");
+@import url("./styles/mapSearch.css");
 
 /* Variables start */
 :root {
@@ -31,20 +31,20 @@
 
 body {
     background-color: var(--color-gunmetal-dark);
-    background-image: url('images/background-1.png');
+    background-image: url("images/background-1.png");
     color: var(--color-gold-one);
     margin: 0;
     padding: 0;
     height: 100%;
     font-family:
-        'bender',
+        "bender",
         -apple-system,
         system-ui,
         BlinkMacSystemFont,
-        'Segoe UI',
-        'Roboto',
-        'Helvetica Neue',
-        'Arial',
+        "Segoe UI",
+        "Roboto",
+        "Helvetica Neue",
+        "Arial",
         sans-serif;
     font-style: normal;
     font-weight: 400;
@@ -56,7 +56,7 @@ body {
 }
 
 code {
-    font-family: 'source-code-pro', 'Menlo', 'Monaco', 'Consolas', 'Courier New', monospace;
+    font-family: "source-code-pro", "Menlo", "Monaco", "Consolas", "Courier New", monospace;
 }
 
 body * {
@@ -77,7 +77,7 @@ button {
 }
 
 button,
-input[type='submit'] {
+input[type="submit"] {
     background-color: var(--color-gold-two);
     border: 0;
     color: var(--color-black);
@@ -85,8 +85,8 @@ input[type='submit'] {
     padding: 0;
 }
 
-input[type='text'],
-input[type='number'] {
+input[type="text"],
+input[type="number"] {
     padding: 12px;
     max-height: 40px;
     border: 2px solid var(--color-gold-two);
@@ -94,17 +94,17 @@ input[type='number'] {
     color: var(--color-gold-one);
 }
 
-input[type='text']:focus,
-input[type='number']:focus {
+input[type="text"]:focus,
+input[type="number"]:focus {
     outline: none;
     border: 2px solid var(--color-gold-one);
 }
 
-input[type='text'].number {
+input[type="text"].number {
     width: 80px;
 }
 
-input[name='session-id'] {
+input[name="session-id"] {
     padding-left: 20px;
 }
 
@@ -165,7 +165,7 @@ cite {
 }
 
 .time-wrapper div {
-    font-family: 'source-code-pro', 'Menlo', 'Monaco', 'Consolas', 'Courier New', monospace;
+    font-family: "source-code-pro", "Menlo", "Monaco", "Consolas", "Courier New", monospace;
 }
 
 .map-image-wrapper {
@@ -292,6 +292,10 @@ cite {
 
 .filter-wrapper.open {
     z-index: 2;
+}
+
+.level-locked {
+    color: var(--color-red);
 }
 
 @media screen and (width >= 800px) {

--- a/src/components/center-cell/index.jsx
+++ b/src/components/center-cell/index.jsx
@@ -1,5 +1,9 @@
-const CenterCell = ({ children, nowrap = false, value }) => {
-    return <div className={`center-content ${nowrap ? "nowrap-content" : ""}`}>{children || value}</div>;
+const CenterCell = ({ children, className, nowrap = false, value }) => {
+    return (
+        <div className={`center-content ${nowrap ? "nowrap-content" : ""}${className ? ` ${className}` : ""}`}>
+            {children || value}
+        </div>
+    );
 };
 
 export default CenterCell;

--- a/src/components/crafts-table/index.jsx
+++ b/src/components/crafts-table/index.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, useCallback } from "react";
 import { useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
@@ -34,13 +34,6 @@ function CraftTable({
 }) {
     const { t } = useTranslation();
     const settings = useSelector((state) => state.settings[state.settings.gameMode]);
-    const { includeFlea, hasJaeger, completedQuests } = useMemo(() => {
-        return {
-            includeFlea: settings.hasFlea,
-            hasJaeger: settings.jaeger !== 0,
-            completedQuests: settings.completedQuests,
-        };
-    }, [settings]);
     const stations = useSelector(selectAllStations);
     const skills = useSelector(selectAllSkills);
     const [skippedBySettings, setSkippedBySettings] = useState(false);
@@ -54,6 +47,21 @@ function CraftTable({
     const { data: handbook } = useHandbookData();
 
     const { data: hideout } = useHideoutData();
+
+    const { fleaUnlocked, hasJaeger, completedQuests } = useMemo(() => {
+        return {
+            fleaUnlocked: handbook.fleaMarket.enabled && settings.playerLevel >= handbook.fleaMarket.minPlayerLevel,
+            hasJaeger: settings.jaeger !== 0,
+            completedQuests: settings.completedQuests,
+        };
+    }, [settings, handbook]);
+
+    const availableOnFlea = useCallback(
+        (item) => {
+            return showAll || (handbook.fleaMarket.enabled && settings.playerLevel >= item.minLevelForFlea);
+        },
+        [settings, handbook],
+    );
 
     const data = useMemo(() => {
         let addedStations = {};
@@ -222,7 +230,11 @@ function CraftTable({
                     fleaPriceToUse = craftRewardItem.lastLowPrice;
                 }
 
-                if (!tradeData.cached && !craftRewardItem.types.includes("noFlea") && (showAll || includeFlea)) {
+                if (
+                    !tradeData.cached &&
+                    !craftRewardItem.types.includes("noFlea") &&
+                    availableOnFlea(craftRewardItem)
+                ) {
                     const bestFleaPrice = bestPrice(
                         craftRewardItem,
                         handbook?.fleaMarket?.sellOfferFeeRate,
@@ -342,7 +354,6 @@ function CraftTable({
         barters,
         hideout,
         completedQuests,
-        includeFlea,
         hasJaeger,
         itemFilter,
         stations,
@@ -355,6 +366,7 @@ function CraftTable({
         sortState,
         useCraftIngredients,
         useBarterIngredients,
+        availableOnFlea,
     ]);
 
     const columns = useMemo(
@@ -454,7 +466,7 @@ function CraftTable({
                     return <ValueCell value={props.value} valueCount={props.row.original.reward.count} />;
                 },
             },
-            ...(includeFlea
+            ...(fleaUnlocked
                 ? [
                       {
                           Header: t("Flea throughput/h"),
@@ -509,7 +521,7 @@ function CraftTable({
                 },
             },
         ],
-        [t, includeFlea, selectedStation, showAll, crafts, barters, useCraftIngredients, useBarterIngredients],
+        [t, fleaUnlocked, selectedStation, showAll, crafts, barters, useCraftIngredients, useBarterIngredients],
     );
 
     let extraRow = false;

--- a/src/components/crafts-table/index.jsx
+++ b/src/components/crafts-table/index.jsx
@@ -58,7 +58,11 @@ function CraftTable({
 
     const availableOnFlea = useCallback(
         (item) => {
-            return showAll || (handbook.fleaMarket.enabled && settings.playerLevel >= item.minLevelForFlea);
+            return (
+                showAll ||
+                (handbook.fleaMarket.enabled &&
+                    settings.playerLevel >= Math.max(handbook.fleaMarket.minPlayerLevel, item.minLevelForFlea))
+            );
         },
         [settings, handbook],
     );

--- a/src/components/filter/index.jsx
+++ b/src/components/filter/index.jsx
@@ -84,7 +84,7 @@ function RangeFilter({
     max,
     marks,
     onChange,
-    reverse = false,
+    track = "normal",
     style = {},
     size = "medium",
     step = 1,
@@ -94,7 +94,7 @@ function RangeFilter({
         marks = Object.keys(marks).map((val) => {
             return {
                 label: String(marks[val]),
-                value: val,
+                value: parseInt(val),
             };
         });
     }
@@ -102,7 +102,6 @@ function RangeFilter({
         <div className={"filter-slider-wrapper"}>
             <div className={"filter-slider-label"}>{label}</div>
             <Slider
-                range={true}
                 defaultValue={defaultValue}
                 value={value}
                 step={step}
@@ -110,7 +109,7 @@ function RangeFilter({
                 max={max}
                 marks={marks}
                 onChange={onChange}
-                reverse={reverse}
+                track={track}
                 style={{
                     width: "170px",
                     ...style,
@@ -354,6 +353,7 @@ function InputFilter({
     tooltip,
     inputMode,
     parentRef,
+    isDisabled = false,
 }) {
     return (
         <ConditionalWrapper
@@ -379,6 +379,7 @@ function InputFilter({
                     min={min}
                     max={max}
                     ref={parentRef}
+                    disabled={isDisabled}
                 />
             </label>
         </ConditionalWrapper>

--- a/src/components/items-summary-table/index.jsx
+++ b/src/components/items-summary-table/index.jsx
@@ -22,7 +22,7 @@ import BarterTooltip from "../barter-tooltip/index.jsx";
 import formatPrice from "../../modules/format-price.js";
 import { getCheapestPrice } from "../../modules/format-cost-items.js";
 
-import useItemsData from "../../features/items/index.js";
+import useItemsData, { useHandbookData } from "../../features/items/index.js";
 import useBartersData from "../../features/barters/index.js";
 import useCraftsData from "../../features/crafts/index.js";
 import useTradersData from "../../features/traders/index.js";
@@ -45,6 +45,7 @@ function ItemsSummaryTable({ includeItems, includeTraders, includeStations }) {
     const { data: crafts } = useCraftsData();
     const { data: traders } = useTradersData();
     const { data: stations } = useHideoutData();
+    const { data: handbook } = useHandbookData();
 
     const data = useMemo(() => {
         const requiredItems = items
@@ -337,7 +338,9 @@ function ItemsSummaryTable({ includeItems, includeTraders, includeStations }) {
                             tipContent.push(
                                 <div key={"no-flea-tooltip"}>{t("This item can't be sold on the Flea Market")}</div>,
                             );
-                        } else if (!settings.hasFlea) {
+                        } else if (
+                            !(handbook.fleaMarket.enabled && settings.playerLevel >= props.row.original.minLevelForFlea)
+                        ) {
                             priceContent.push(
                                 <Icon
                                     path={mdiCloseOctagon}
@@ -346,6 +349,7 @@ function ItemsSummaryTable({ includeItems, includeTraders, includeStations }) {
                                     key="no-prices-icon"
                                 />,
                             );
+
                             tipContent.push(<div key={"no-flea-tooltip"}>{t("Flea Market not available")}</div>);
                         } else {
                             let tipText = t("Not scanned on the Flea Market");
@@ -395,7 +399,7 @@ function ItemsSummaryTable({ includeItems, includeTraders, includeStations }) {
         ];
 
         return useColumns;
-    }, [t, items, barters, crafts, stations, settings]);
+    }, [t, items, barters, crafts, stations, settings, handbook]);
 
     const extraRow = (
         <>

--- a/src/components/items-summary-table/index.jsx
+++ b/src/components/items-summary-table/index.jsx
@@ -339,7 +339,11 @@ function ItemsSummaryTable({ includeItems, includeTraders, includeStations }) {
                                 <div key={"no-flea-tooltip"}>{t("This item can't be sold on the Flea Market")}</div>,
                             );
                         } else if (
-                            !(handbook.fleaMarket.enabled && settings.playerLevel >= props.row.original.minLevelForFlea)
+                            !(
+                                handbook.fleaMarket.enabled &&
+                                settings.playerLevel >=
+                                    Math.max(props.row.original.minLevelForFlea, handbook.fleaMarket.minPlayerLevel)
+                            )
                         ) {
                             priceContent.push(
                                 <Icon

--- a/src/components/quest-table/index.jsx
+++ b/src/components/quest-table/index.jsx
@@ -430,7 +430,12 @@ function QuestTable({
                     if (!props.value) {
                         return "";
                     }
-                    return <CenterCell value={props.value} />;
+                    return (
+                        <CenterCell
+                            className={settings.playerLevel < props.value ? "level-locked" : undefined}
+                            value={props.value}
+                        />
+                    );
                 },
                 position: minimumLevel,
             });

--- a/src/components/small-item-table/index.jsx
+++ b/src/components/small-item-table/index.jsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useCallback } from "react";
 import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
@@ -273,6 +273,13 @@ function SmallItemTable(props) {
         return { materialDestructibilityMap: destruct, materialRepairabilityMap: repair };
     }, [handbook]);
 
+    const availableOnFlea = useCallback(
+        (item) => {
+            return handbook.fleaMarket.enabled && settings.playerLevel >= item.minLevelForFlea;
+        },
+        [settings, handbook],
+    );
+
     // Create a constant of all data returned
     const { data: items, status: itemsStatus } = useItemsData();
 
@@ -322,7 +329,11 @@ function SmallItemTable(props) {
                 itemLink: `/item/${itemData.normalizedName}`,
                 types: itemData.types,
                 buyFor: itemData.buyFor.filter((buyFor) => {
-                    if (!showAllSources && !settings.hasFlea && buyFor.vendor.normalizedName === "flea-market") {
+                    if (
+                        !showAllSources &&
+                        buyFor.vendor.normalizedName === "flea-market" &&
+                        !availableOnFlea(itemData)
+                    ) {
                         return false;
                     }
                     if (!showAllSources && settings[buyFor.vendor.normalizedName] < buyFor.vendor.minTraderLevel) {
@@ -349,7 +360,8 @@ function SmallItemTable(props) {
                 sellFor: itemData.sellFor,
                 buyOnFleaPrice: itemData.buyFor.find(
                     (buyPrice) =>
-                        buyPrice.vendor.normalizedName === "flea-market" && (showAllSources || settings.hasFlea),
+                        buyPrice.vendor.normalizedName === "flea-market" &&
+                        (showAllSources || availableOnFlea(itemData)),
                 ),
                 barters: barters.filter((barter) => {
                     if (!barter.rewardItems[0]) {
@@ -377,6 +389,7 @@ function SmallItemTable(props) {
                 height: itemData.height,
                 cached: itemData.cached,
                 pricePerSlot: 0,
+                minLevelForFlea: itemData.minLevelForFlea,
             };
 
             formattedItem.sellForTradersBest = itemData.sellFor.reduce((best, sellFor) => {
@@ -398,7 +411,7 @@ function SmallItemTable(props) {
                 return best;
             }, undefined);
 
-            if (!showAllSources && !settings.hasFlea) {
+            if (!showAllSources && !availableOnFlea(formattedItem)) {
                 formattedItem.buyOnFleaPrice = 0;
             }
 
@@ -418,7 +431,7 @@ function SmallItemTable(props) {
             }
             formattedItem.cheapestObtainPrice = Number.MAX_SAFE_INTEGER;
             formattedItem.cheapestObtainInfo = null;
-            if (formattedItem.cheapestBarter && (settings.hasFlea || showAllSources)) {
+            if (formattedItem.cheapestBarter && (availableOnFlea(formattedItem) || showAllSources)) {
                 //console.log(formattedItem.cheapestBarter.barter, settings[formattedItem.cheapestBarter.barter.trader.normalizedName]);
                 //if (!showAllSources && settings[buyFor.vendor.normalizedName] < buyFor.vendor.minTraderLevel)
                 formattedItem.cheapestObtainPrice = formattedItem.cheapestBarter.pricePerUnit;
@@ -430,7 +443,11 @@ function SmallItemTable(props) {
                     formattedItem.cheapestObtainInfo = buyFor;
                 }
             }
-            if (!formattedItem.cheapestObtainInfo && (settings.hasFlea || showAllSources) && !traderBuybackFilter) {
+            if (
+                !formattedItem.cheapestObtainInfo &&
+                (availableOnFlea(formattedItem) || showAllSources) &&
+                !traderBuybackFilter
+            ) {
                 const cheapestCraft = getCheapestCraft(itemData, {
                     crafts,
                     settings,
@@ -1943,7 +1960,7 @@ function SmallItemTable(props) {
                             tipContent.push(
                                 <div key={"no-flea-tooltip"}>{t("This item can't be sold on the Flea Market")}</div>,
                             );
-                        } else if (!settings.hasFlea) {
+                        } else if (!availableOnFlea(props.row.original)) {
                             priceContent.push(
                                 <Icon
                                     path={mdiCloseOctagon}

--- a/src/components/small-item-table/index.jsx
+++ b/src/components/small-item-table/index.jsx
@@ -275,7 +275,10 @@ function SmallItemTable(props) {
 
     const availableOnFlea = useCallback(
         (item) => {
-            return handbook.fleaMarket.enabled && settings.playerLevel >= item.minLevelForFlea;
+            return (
+                handbook.fleaMarket.enabled &&
+                settings.playerLevel >= Math.max(item.minLevelForFlea, handbook.fleaMarket.minPlayerLevel)
+            );
         },
         [settings, handbook],
     );

--- a/src/features/items/do-fetch-items.mjs
+++ b/src/features/items/do-fetch-items.mjs
@@ -49,6 +49,7 @@ class ItemsQuery extends APIQuery {
                     buyFor {
                         ...ItemPriceFragment
                     }
+                    minLevelForFlea
                     containsItems {
                         count
                         item {

--- a/src/features/quests/index.js
+++ b/src/features/quests/index.js
@@ -75,7 +75,7 @@ export const selectQuestsWithActive = createSelector(
                     return false;
                 }
                 if (settings[settings.gameMode].playerLevel < quest.minPlayerLevel) {
-                    //return false;
+                    return false;
                 }
                 if (
                     quest.factionName !== "Any" &&

--- a/src/features/settings/settingsSlice.mjs
+++ b/src/features/settings/settingsSlice.mjs
@@ -8,7 +8,6 @@ export const fetchTarkovTrackerProgress = createAsyncThunk(
         }
 
         const returnData = {
-            hasFlea: true,
             playerLevel: 72,
             pmcFaction: "NONE",
             hideout: {},
@@ -56,7 +55,6 @@ export const fetchTarkovTrackerProgress = createAsyncThunk(
             }
             return completedObjectives;
         }, []);
-        returnData.hasFlea = progressData.playerLevel >= 15 ? true : false;
 
         returnData.playerLevel = progressData.playerLevel;
 
@@ -139,7 +137,6 @@ export const localStorageWriteJsonGameMode = (key, value) => {
 };
 
 const defaultSettings = {
-    "hasFlea": localStorageReadJson("useFlea", true),
     "playerLevel": 72,
     "pmcFaction": localStorageReadJson("pmcFaction", "NONE"),
     "useTarkovTracker": localStorageReadJson("useTarkovTracker", false),
@@ -199,8 +196,8 @@ const settingsSlice = createSlice({
             state[state.gameMode].tarkovTrackerAPIKey = action.payload;
             localStorageWriteJson(`${state.gameMode}Settings`, state[state.gameMode]);
         },
-        toggleFlea: (state, action) => {
-            state[state.gameMode].hasFlea = action.payload;
+        setPlayerLevel: (state, action) => {
+            state[state.gameMode].playerLevel = action.payload;
             localStorageWriteJson(`${state.gameMode}Settings`, state[state.gameMode]);
         },
         setMinDogtagLevel: (state, action) => {
@@ -288,8 +285,6 @@ const settingsSlice = createSlice({
                 state[state.gameMode].failedQuests = action.payload.questsFailed;
                 state[state.gameMode].objectivesCompleted = action.payload.objectivesCompleted;
                 state[state.gameMode].objectivesCompletionProgress = action.payload.objectivesCompletionProgress;
-                const fleaEnabled = localStorageReadJson("fleaEnabled", true);
-                state[state.gameMode].hasFlea = action.payload.hasFlea && fleaEnabled;
                 state[state.gameMode].playerLevel = action.payload.playerLevel;
                 state[state.gameMode].pmcFaction = action.payload.pmcFaction;
 
@@ -355,7 +350,7 @@ export const selectCompletedQuests = createSelector([selectSettings], (settings)
 
 export const {
     setTarkovTrackerAPIKey,
-    toggleFlea,
+    setPlayerLevel,
     setMinDogtagLevel,
     setStationOrTraderLevel,
     toggleTarkovTracker,

--- a/src/modules/format-cost-items.js
+++ b/src/modules/format-cost-items.js
@@ -14,7 +14,7 @@ function getCheapestCashPrice(item, settings = {}, allowAllSources = false) {
             return false;
         }
         if (buyFor.vendor.normalizedName === "flea-market") {
-            return allowAllSources || settings.hasFlea;
+            return allowAllSources || settings.playerLevel >= item.minLevelForFlea;
         }
         if (!allowAllSources && settings[buyFor.vendor.normalizedName] < buyFor.vendor.minTraderLevel) {
             return false;

--- a/src/pages/boss/index.jsx
+++ b/src/pages/boss/index.jsx
@@ -254,7 +254,7 @@ function BossPage(params) {
             }
         }
         const ele = (
-            <span>
+            <span key={`spawn-map-${map.id}`}>
                 <span key={`spawn-map-${map.id}`}>{`${displayPercent}% `}</span>
                 <Link to={`/map/${map.normalizedName}`}>{`(${map.name})`}</Link>
             </span>

--- a/src/pages/item/index.jsx
+++ b/src/pages/item/index.jsx
@@ -1,7 +1,7 @@
-import React, { useMemo, useState, useEffect, useCallback } from "react";
+import { useMemo, useState, useEffect, useCallback } from "react";
 import { useParams, Link, useNavigate } from "react-router-dom";
 import { useSelector, useDispatch } from "react-redux";
-import { Tooltip } from "@mui/material";
+import { Tooltip, Badge } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import Select from "react-select";
 
@@ -70,16 +70,6 @@ function TraderPrice({ currency, price, priceRUB }) {
     }
 
     return formatPrice(priceRUB);
-}
-
-function priceIsLocked(buyFor, settings) {
-    let className = "";
-    if (buyFor.vendor.trader && settings[buyFor.vendor.normalizedName] < buyFor.vendor.minTraderLevel) {
-        className = " locked";
-    } else if (buyFor.vendor.normalizedName === "flea-market" && !settings.hasFlea) {
-        className = " locked";
-    }
-    return className;
 }
 
 function Item() {
@@ -223,6 +213,22 @@ function Item() {
         }
         return item;
     }, [items, itemName, handbook, itemsStatus, loadingData, maps]);
+
+    const priceIsLocked = useCallback(
+        (item, buyFor) => {
+            let className = "";
+            if (buyFor.vendor.trader && settings[buyFor.vendor.normalizedName] < buyFor.vendor.minTraderLevel) {
+                className = " locked";
+            } else if (
+                buyFor.vendor.normalizedName === "flea-market" &&
+                (!handbook.fleaMarket.enabled || settings.playerLevel < item.minLevelForFlea)
+            ) {
+                className = " locked";
+            }
+            return className;
+        },
+        [settings, handbook],
+    );
 
     const questsRequiringCount = useMemo(() => {
         if (!currentItemData || currentItemData.id === "loading") {
@@ -557,14 +563,26 @@ The max profitable price is impacted by the intel center and hideout management 
                                             className={`text-and-image-information-wrapper ${sellForTradersIsTheBest ? "" : "best-profit"}`}
                                             key={`${currentItemData.id}-flea-market-price-sell`}
                                         >
-                                            <img
-                                                alt="Flea market"
-                                                height="86"
-                                                width="86"
-                                                src={`${process.env.PUBLIC_URL}/images/traders/flea-market-portrait.png`}
-                                                loading="lazy"
-                                                // title = {`Sell ${currentItemData.name} on the Flea market`}
-                                            />
+                                            <Badge
+                                                badgeContent={currentItemData.minLevelForFlea}
+                                                color={
+                                                    settings.playerLevel >= currentItemData.minLevelForFlea
+                                                        ? "success"
+                                                        : "warning"
+                                                }
+                                                title={t("Player level: {{playerLevel}}", {
+                                                    playerLevel: currentItemData.minLevelForFlea,
+                                                })}
+                                            >
+                                                <img
+                                                    alt="Flea market"
+                                                    height="86"
+                                                    width="86"
+                                                    src={`${process.env.PUBLIC_URL}/images/traders/flea-market-portrait.png`}
+                                                    loading="lazy"
+                                                    // title = {`Sell ${currentItemData.name} on the Flea market`}
+                                                />
+                                            </Badge>
                                             <div className="price-wrapper">
                                                 {fleaSellIcon}
                                                 {fleaSellPriceDisplay}
@@ -670,17 +688,41 @@ The max profitable price is impacted by the intel center and hideout management 
                                                         </Link>
                                                     )}
                                                 >
-                                                    <img
-                                                        alt={buyForSource.vendor.name}
-                                                        height="86"
-                                                        width="86"
-                                                        loading="lazy"
-                                                        src={`${process.env.PUBLIC_URL}/images/traders/${buyForSource.vendor.normalizedName}-portrait.png`}
-                                                    />
+                                                    <ConditionalWrapper
+                                                        condition={buyForSource.vendor.normalizedName === "flea-market"}
+                                                        wrapper={(children) => (
+                                                            <Badge
+                                                                badgeContent={
+                                                                    buyForSource.vendor.normalizedName === "flea-market"
+                                                                        ? currentItemData.minLevelForFlea
+                                                                        : null
+                                                                }
+                                                                color={
+                                                                    settings.playerLevel >=
+                                                                    currentItemData.minLevelForFlea
+                                                                        ? "success"
+                                                                        : "warning"
+                                                                }
+                                                                title={t("Player level: {{playerLevel}}", {
+                                                                    playerLevel: currentItemData.minLevelForFlea,
+                                                                })}
+                                                            >
+                                                                {children}
+                                                            </Badge>
+                                                        )}
+                                                    >
+                                                        <img
+                                                            alt={buyForSource.vendor.name}
+                                                            height="86"
+                                                            width="86"
+                                                            loading="lazy"
+                                                            src={`${process.env.PUBLIC_URL}/images/traders/${buyForSource.vendor.normalizedName}-portrait.png`}
+                                                        />
+                                                    </ConditionalWrapper>
                                                 </ConditionalWrapper>
                                             </div>
                                             <div
-                                                className={`price-wrapper ${index === 0 ? "best-profit" : ""}${priceIsLocked(buyForSource, settings)}`}
+                                                className={`price-wrapper ${index === 0 ? "best-profit" : ""}${priceIsLocked(currentItemData, buyForSource, settings)}`}
                                             >
                                                 <TraderPrice
                                                     currency={buyForSource.currency}

--- a/src/pages/item/index.jsx
+++ b/src/pages/item/index.jsx
@@ -221,7 +221,8 @@ function Item() {
                 className = " locked";
             } else if (
                 buyFor.vendor.normalizedName === "flea-market" &&
-                (!handbook.fleaMarket.enabled || settings.playerLevel < item.minLevelForFlea)
+                (!handbook.fleaMarket.enabled ||
+                    settings.playerLevel < Math.max(item.minLevelForFlea, handbook.fleaMarket.minPlayerLevel))
             ) {
                 className = " locked";
             }
@@ -564,14 +565,19 @@ The max profitable price is impacted by the intel center and hideout management 
                                             key={`${currentItemData.id}-flea-market-price-sell`}
                                         >
                                             <Badge
-                                                badgeContent={currentItemData.minLevelForFlea}
+                                                badgeContent={
+                                                    currentItemData.minLevelForFlea ||
+                                                    handbook.fleaMarket.minPlayerLevel
+                                                }
                                                 color={
                                                     settings.playerLevel >= currentItemData.minLevelForFlea
                                                         ? "success"
                                                         : "warning"
                                                 }
                                                 title={t("Player level: {{playerLevel}}", {
-                                                    playerLevel: currentItemData.minLevelForFlea,
+                                                    playerLevel:
+                                                        currentItemData.minLevelForFlea ||
+                                                        handbook.fleaMarket.minPlayerLevel,
                                                 })}
                                             >
                                                 <img
@@ -694,7 +700,8 @@ The max profitable price is impacted by the intel center and hideout management 
                                                             <Badge
                                                                 badgeContent={
                                                                     buyForSource.vendor.normalizedName === "flea-market"
-                                                                        ? currentItemData.minLevelForFlea
+                                                                        ? currentItemData.minLevelForFlea ||
+                                                                          handbook.fleaMarket.minPlayerLevel
                                                                         : null
                                                                 }
                                                                 color={
@@ -704,7 +711,9 @@ The max profitable price is impacted by the intel center and hideout management 
                                                                         : "warning"
                                                                 }
                                                                 title={t("Player level: {{playerLevel}}", {
-                                                                    playerLevel: currentItemData.minLevelForFlea,
+                                                                    playerLevel:
+                                                                        currentItemData.minLevelForFlea ||
+                                                                        handbook.fleaMarket.minPlayerLevel,
                                                                 })}
                                                             >
                                                                 {children}

--- a/src/pages/items/armors/index.jsx
+++ b/src/pages/items/armors/index.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { Trans, useTranslation } from "react-i18next";
 
 import { Icon } from "@mdi/react";
@@ -32,6 +32,9 @@ function Armors(props) {
     const [maxArmorClassPlate, setMaxArmorClassPlate] = useStateWithLocalStorage("maxArmorClassPlate", 6);
     const [maxPrice, setMaxPrice] = useStateWithLocalStorage("armorMaxPrice", "");
     const { t } = useTranslation();
+
+    const defaultSoftArmor = useRef([minArmorClassSoft, maxArmorClassSoft]);
+    const defaultPlateArmor = useRef([minArmorClassPlate, maxArmorClassPlate]);
 
     const handleSoftArmorClassChange = ([min, max]) => {
         setMinArmorClassSoft(min);
@@ -88,7 +91,7 @@ function Armors(props) {
                         type="number"
                     />
                     <RangeFilter
-                        defaultValue={[minArmorClassSoft, maxArmorClassSoft]}
+                        defaultValue={defaultSoftArmor.current}
                         label={t("Soft armor class")}
                         min={0}
                         max={6}
@@ -98,7 +101,7 @@ function Armors(props) {
                         }}
                     />
                     <RangeFilter
-                        defaultValue={[minArmorClassPlate, maxArmorClassPlate]}
+                        defaultValue={defaultPlateArmor.current}
                         label={t("Plate armor class")}
                         min={0}
                         max={6}

--- a/src/pages/items/rigs/index.jsx
+++ b/src/pages/items/rigs/index.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, useRef } from "react";
 import { Trans, useTranslation } from "react-i18next";
 
 import { Icon } from "@mdi/react";
@@ -13,12 +13,12 @@ import useStateWithLocalStorage from "../../../hooks/useStateWithLocalStorage.js
 import useItemsData from "../../../features/items/index.js";
 
 const marks = {
-    0: 25,
-    5: 20,
-    10: 15,
-    15: 10,
-    20: 5,
-    25: 0,
+    0: 0,
+    5: 5,
+    10: 10,
+    15: 15,
+    20: 20,
+    25: 25,
 };
 
 function Rigs() {
@@ -34,13 +34,18 @@ function Rigs() {
 
     const displayItems = useMemo(() => items.filter((item) => item.types.includes("rig")), [items]);
 
-    let maxSlots = Math.max(...displayItems.map((displayItem) => displayItem.properties.capacity || 0));
-    if (maxSlots === Infinity) {
-        maxSlots = 1;
-    }
+    const maxSlots = useMemo(() => {
+        let max = Math.max(...displayItems.map((displayItem) => displayItem.properties.capacity || 0));
+        if (max === Infinity) {
+            max = 1;
+        }
+        return max;
+    }, [displayItems]);
 
-    const handleMinSlotsChange = (newValueLabel) => {
-        setMinSlots(maxSlots - newValueLabel);
+    const minSlotDefault = useRef(minSlots);
+
+    const handleMinSlotsChange = (e) => {
+        setMinSlots(parseInt(e.target.value));
     };
 
     return [
@@ -71,12 +76,12 @@ function Rigs() {
                         checked={includeArmoredRigs}
                     />
                     <SliderFilter
-                        defaultValue={25 - minSlots}
+                        defaultValue={minSlotDefault.current}
                         label={t("Min slots")}
                         min={0}
-                        max={25}
+                        max={maxSlots}
                         marks={marks}
-                        reverse
+                        track={"inverted"}
                         onChange={handleMinSlotsChange}
                     />
                     <ToggleFilter label={t("3-slot")} onChange={(e) => setHas3Slot(!has3Slot)} checked={has3Slot} />

--- a/src/pages/loot-tiers/index.jsx
+++ b/src/pages/loot-tiers/index.jsx
@@ -18,7 +18,7 @@ import capitalizeFirst from "../../modules/capitalize-first.js";
 import itemSearch from "../../modules/item-search.js";
 import fleaMarketFee from "../../modules/flea-market-fee.mjs";
 
-import useItemsData from "../../features/items/index.js";
+import useItemsData, { useHandbookData } from "../../features/items/index.js";
 
 import "./index.css";
 
@@ -41,9 +41,9 @@ const arrayChunk = (inputArray, chunkLength) => {
 };
 
 function LootTier(props) {
+    const settings = useSelector((state) => state.settings[state.settings.gameMode]);
     const [numberFilter, setNumberFilter] = useState(DEFAULT_MAX_ITEMS);
     const [minPrice, setMinPrice] = useStateWithLocalStorage("minPrice", 0);
-    const hasFlea = useSelector((state) => state.settings[state?.settings?.gameMode ?? "regular"].hasFlea);
     const [ignoreFleaSetting, setIgnoreFleaSetting] = useStateWithLocalStorage("ignoreFleaSetting", false);
     const [includeMarked, setIncludeMarked] = useStateWithLocalStorage("includeMarked", false);
     const [groupByType, setGroupByType] = useStateWithLocalStorage("groupByType", false);
@@ -138,6 +138,8 @@ function LootTier(props) {
 
     const { data: items } = useItemsData();
 
+    const { data: handbook } = useHandbookData();
+
     const itemData = useMemo(() => {
         return items
             .map((item) => {
@@ -174,7 +176,8 @@ function LootTier(props) {
                 // Use flea market if:
                 // 1. User has flea enabled
                 // 2. Ignore setting is on (regardless of user's flea setting)
-                const shouldUseFlea = hasFlea || ignoreFleaSetting;
+                const shouldUseFlea =
+                    ignoreFleaSetting || (handbook.fleaMarket.enabled && settings.playerLevel >= item.minLevelForFlea);
 
                 if (shouldUseFlea && !item.types.includes("noFlea")) {
                     const fleaFee = fleaMarketFee(item.basePrice, item.lastLowPrice);
@@ -206,7 +209,7 @@ function LootTier(props) {
 
                 return true;
             });
-    }, [hasFlea, items, ignoreFleaSetting]);
+    }, [settings, items, handbook, ignoreFleaSetting]);
 
     const typeFilteredItems = useMemo(() => {
         const innerTypeFilteredItems = itemData.filter((item) => {

--- a/src/pages/loot-tiers/index.jsx
+++ b/src/pages/loot-tiers/index.jsx
@@ -177,7 +177,9 @@ function LootTier(props) {
                 // 1. User has flea enabled
                 // 2. Ignore setting is on (regardless of user's flea setting)
                 const shouldUseFlea =
-                    ignoreFleaSetting || (handbook.fleaMarket.enabled && settings.playerLevel >= item.minLevelForFlea);
+                    ignoreFleaSetting ||
+                    (handbook.fleaMarket.enabled &&
+                        settings.playerLevel >= Math.max(handbook.fleaMarket.minPlayerLevel, item.minLevelForFlea));
 
                 if (shouldUseFlea && !item.types.includes("noFlea")) {
                     const fleaFee = fleaMarketFee(item.basePrice, item.lastLowPrice);

--- a/src/pages/quest/index.jsx
+++ b/src/pages/quest/index.jsx
@@ -199,7 +199,11 @@ function Quest() {
         }
         if (currentQuest.minPlayerLevel) {
             props.minPlayerLevel = {
-                value: currentQuest.minPlayerLevel,
+                value: (
+                    <span className={settings.playerLevel < currentQuest.minPlayerLevel ? "level-locked" : undefined}>
+                        {currentQuest.minPlayerLevel}
+                    </span>
+                ),
                 label: t("Minimum PMC Level"),
                 order: 1,
             };

--- a/src/pages/settings/index.css
+++ b/src/pages/settings/index.css
@@ -42,6 +42,12 @@
     display: none;
 }
 
+.basic-multi-select.language,
+.basic-multi-select.game-mode,
+.basic-multi-select.tracker-domain {
+    margin-left: 10px;
+}
+
 @media screen and (width >= 1280px) {
     .settings-group-wrapper {
         justify-content: flex-start;

--- a/src/pages/settings/index.jsx
+++ b/src/pages/settings/index.jsx
@@ -13,7 +13,7 @@ import CheekiBreekiEffect from "../../components/cheeki-breeki-effect/index.jsx"
 import {
     //selectAllTraders as traderSettings,
     selectAllStations,
-    toggleFlea,
+    setPlayerLevel,
     setMinDogtagLevel,
     selectAllSkills,
     setTarkovTrackerAPIKey,
@@ -70,13 +70,13 @@ function Settings() {
     //const allTraders = useSelector(traderSettings);
     const allStations = useSelector(selectAllStations);
     const allSkills = useSelector(selectAllSkills);
-    const hasFlea = useSelector((state) => state.settings[state.settings.gameMode].hasFlea);
     const useTarkovTracker = useSelector((state) => state.settings[state.settings.gameMode].useTarkovTracker);
     const hideDogtagBarters = useSelector((state) => state.settings[state.settings.gameMode].hideDogtagBarters);
     const gameMode = useSelector((state) => state.settings.gameMode);
     const trackerDomain = useSelector((state) => state.settings.tarkovTrackerDomain);
     const [selectedTrackerDomain, setSelectedTrackerDomain] = useState(trackerDomain);
     const trackerTokenRef = useRef();
+    const playerLevelRef = useRef();
 
     const stationRefs = {
         "bitcoin-farm": useRef(null),
@@ -94,7 +94,8 @@ function Settings() {
     const { data: allTraders } = useTradersData();
 
     const traders = useMemo(() => {
-        return allTraders.filter((t) => t.normalizedName !== "lightkeeper" && t.normalizedName !== "btr-driver");
+        const skipTraders = ["lightkeeper", "btr-driver", "radio-station", "taran", "mr-kerman", "voevoda"];
+        return allTraders.filter((t) => !skipTraders.includes(t.normalizedName));
     }, [allTraders]);
 
     const { data: hideout } = useHideoutData();
@@ -172,23 +173,23 @@ function Settings() {
         />,
         <div className={"page-wrapper"}>
             <h1>{t("Settings")}</h1>
-            <div className="language-toggle-wrapper settings-group-wrapper">
-                <h2>{t("Language")}</h2>
-                <Select
-                    placeholder={i18n.language}
-                    options={langOptions}
-                    className="basic-multi-select"
-                    classNamePrefix="select"
-                    onChange={(event) => {
-                        handleLangChange({
-                            target: language,
-                            value: event.value,
-                        });
-                    }}
-                />
-            </div>
             <div className={"settings-group-wrapper"}>
                 <h2>{t("General")}</h2>
+                <label className={"single-filter-wrapper language-toggle-wrapper"}>
+                    <span className={"single-filter-label"}>{t("Language")}</span>
+                    <Select
+                        placeholder={i18n.language}
+                        options={langOptions}
+                        className="basic-multi-select language"
+                        classNamePrefix="select"
+                        onChange={(event) => {
+                            handleLangChange({
+                                target: language,
+                                value: event.value,
+                            });
+                        }}
+                    />
+                </label>
                 <label className={"single-filter-wrapper"}>
                     <span className={"single-filter-label"}>{t("Game mode")}</span>
                     <Select
@@ -209,12 +210,19 @@ function Settings() {
                         }}
                     />
                 </label>
-                <ToggleFilter
-                    label={t("Has flea")}
-                    onChange={() => dispatch(toggleFlea(!hasFlea))}
-                    checked={hasFlea}
-                    disabled={useTarkovTracker}
+                <InputFilter
+                    parentRef={playerLevelRef}
+                    label={t("Player level")}
+                    defaultValue={useSelector((state) => state.settings[state.settings.gameMode].playerLevel)}
+                    type="text"
+                    placeholder={t("Level")}
+                    onChange={(event) => {
+                        dispatch(setPlayerLevel(event.target.value));
+                    }}
+                    isDisabled={useTarkovTracker}
                 />
+            </div>
+            <div className={"settings-group-wrapper"}>
                 <ToggleFilter
                     label={t("Use TarkovTracker")}
                     onChange={() => dispatch(toggleTarkovTracker(!useTarkovTracker))}


### PR DESCRIPTION
Changes the site to use the player's level to determine if items are available for purchase/sale on the flea market. Also classifies quests as locked if the player's level doesn't meet the minimum requirement.

Resolves #1219 
Resolves #1193 