### PR TITLE
Display plates on armors page

### DIFF
--- a/src/components/small-item-table/index.jsx
+++ b/src/components/small-item-table/index.jsx
@@ -243,6 +243,7 @@ function SmallItemTable(props) {
         attachesToItemFilter,
         showSlotValue,
         showPresets,
+        showCompatiblePlates,
         showRestrictedType,
         attachmentMap,
         showGunDefaultPresetImages,
@@ -893,6 +894,39 @@ function SmallItemTable(props) {
             });
         }
 
+        if (showCompatiblePlates) {
+            returnData.forEach((item) => {
+                item.subRows = items
+                    .filter((linkedItem) => {
+                        return item.properties?.armorSlots?.some((slot) =>
+                            slot.allowedPlates?.some((plate) => plate.id === linkedItem.id),
+                        );
+                    })
+                    .filter((plate) => {
+                        if (plateArmorFilter && (plateArmorFilter[0] !== 0 || plateArmorFilter[1] !== 6)) {
+                            return (
+                                plate.properties.class >= plateArmorFilter[0] &&
+                                plate.properties.class <= plateArmorFilter[1]
+                            );
+                        }
+                        return true;
+                    })
+                    .sort((a, b) => {
+                        return b.name.localeCompare(a.name);
+                    })
+                    .map((item) => formatItem(item))
+                    .filter((item) => {
+                        if (!maxPrice) {
+                            return true;
+                        }
+                        return item.cheapestObtainPrice <= maxPrice;
+                    });
+            });
+            returnData.sort((a, b) => {
+                return a.name.localeCompare(b.name);
+            });
+        }
+
         if (attachmentMap) {
             returnData.forEach((item) => {
                 item.subRows = items
@@ -1012,6 +1046,7 @@ function SmallItemTable(props) {
         showAttachTo,
         attachesToItemFilter,
         showPresets,
+        showCompatiblePlates,
         attachmentMap,
         showGunDefaultPresetImages,
         useBarterIngredients,
@@ -1080,7 +1115,7 @@ function SmallItemTable(props) {
 
     const columns = useMemo(() => {
         const useColumns = [];
-        if (showAttachments || showAttachTo || showPresets || attachmentMap) {
+        if (showAttachments || showAttachTo || showPresets || showCompatiblePlates || attachmentMap) {
             useColumns.push({
                 id: "expander",
                 Header: ({ getToggleAllRowsExpandedProps, isAllRowsExpanded }) =>
@@ -2033,7 +2068,7 @@ function SmallItemTable(props) {
             const column = useColumns[i];
             if (Number.isInteger(column.position)) {
                 let position = parseInt(column.position);
-                if (showAttachments || showAttachTo || showPresets || attachmentMap) {
+                if (showAttachments || showAttachTo || showPresets || showCompatiblePlates || attachmentMap) {
                     position++;
                 }
                 if (position < 1) {
@@ -2106,6 +2141,7 @@ function SmallItemTable(props) {
         showSlotValue,
         showAllSources,
         showPresets,
+        showCompatiblePlates,
         showRestrictedType,
         attachmentMap,
         settings,

--- a/src/components/small-item-table/index.jsx
+++ b/src/components/small-item-table/index.jsx
@@ -324,6 +324,23 @@ function SmallItemTable(props) {
 
     const data = useMemo(() => {
         const formatItem = (itemData) => {
+            let maxDurability =
+                itemData.properties.armorSlots?.reduce((total, slot) => {
+                    if (!slot.allowedPlates) {
+                        total += slot.durability;
+                    }
+                    return total;
+                }, 0) || itemData.properties.durability;
+            let effectiveDurability = Math.floor(
+                itemData.properties?.durability / materialDestructibilityMap[itemData.properties?.material?.id],
+            );
+            effectiveDurability =
+                itemData.properties.armorSlots?.reduce((total, slot) => {
+                    if (!slot.allowedPlates) {
+                        total += Math.floor(slot.durability / materialDestructibilityMap[slot?.armorMaterial]);
+                    }
+                    return total;
+                }, 0) || effectiveDurability;
             const formattedItem = {
                 id: itemData.id,
                 name: itemData.name,
@@ -397,12 +414,16 @@ function SmallItemTable(props) {
                 ratio: (itemData.properties.capacity / (itemData.width * itemData.height)).toFixed(2),
                 size: itemData.properties.capacity,
                 slots: itemData.width * itemData.height,
-                armorClass: itemData.properties.class,
+                armorClass:
+                    itemData.properties.armorSlots?.reduce((max, slot) => {
+                        if (slot.allowedPlates) {
+                            return max;
+                        }
+                        return Math.max(max, slot.class);
+                    }, 0) || itemData.properties.class,
                 armorZone: getArmorZoneString(itemData.properties.zones || itemData.properties.headZones),
-                maxDurability: itemData.properties.durability,
-                effectiveDurability: Math.floor(
-                    itemData.properties?.durability / materialDestructibilityMap[itemData.properties?.material?.id],
-                ),
+                maxDurability,
+                effectiveDurability,
                 repairability: materialRepairabilityMap[itemData.properties?.material?.id],
                 stats: `${Math.round((itemData.properties.speedPenalty || 0) * 100)}% / ${Math.round((itemData.properties.turnPenalty || 0) * 100)}% / ${itemData.properties.ergoPenalty || 0}`,
                 weight: itemData.weight,
@@ -1657,7 +1678,6 @@ function SmallItemTable(props) {
                 },
                 position: blindnessProtection,
                 sortType: (a, b) => {
-                    console.log(a);
                     return (a.values.blindnessProtection ?? 0) - (b.values.blindnessProtection ?? 0);
                 },
             });

--- a/src/pages/items/armors/index.jsx
+++ b/src/pages/items/armors/index.jsx
@@ -120,6 +120,7 @@ function Armors(props) {
                 plateArmorFilter={[minArmorClassPlate, maxArmorClassPlate]}
                 maxPrice={maxPrice}
                 useClassEffectiveDurability={useClassEffectiveDurability}
+                showCompatiblePlates
                 armorClass
                 armorZones
                 cheapestPrice={1}


### PR DESCRIPTION
Armors page now has arrows to show subrows below each armor:
<img width="1258" height="645" alt="image" src="https://github.com/user-attachments/assets/084f340e-6e14-4c23-90a3-997165b64917" />
When expanded, it shows the compatible plates for that armor:
<img width="1249" height="704" alt="image" src="https://github.com/user-attachments/assets/67030c15-b994-456e-b3ca-f3c16ffa5b8f" />
