### PR TITLE
Warn that prestige does not apply in PVE mode

### DIFF
--- a/src/components/menu/index.jsx
+++ b/src/components/menu/index.jsx
@@ -93,8 +93,19 @@ const Menu = () => {
     const { visibleCount } = useMenuOverflow(desktopMenuRef, measuringRef, menuData);
 
     const visibleItems = useMemo(() => {
+        // remove Prestige menu item in pve mode
+        for (const menuTab of menuData) {
+            if (gameMode !== "pve") {
+                break;
+            }
+            if (menuTab.id !== "progression") {
+                continue;
+            }
+            menuTab.items = menuTab.items.filter((menuItem) => menuItem.to !== "/prestige");
+            break;
+        }
         return menuData.slice(0, visibleCount);
-    }, [menuData, visibleCount]);
+    }, [menuData, visibleCount, gameMode]);
 
     const overflowItems = useMemo(() => {
         return menuData.slice(visibleCount);

--- a/src/pages/prestige/index.jsx
+++ b/src/pages/prestige/index.jsx
@@ -1,11 +1,19 @@
 import { useMemo, useState, useCallback } from "react";
 import { useParams, Link } from "react-router-dom";
 import { useSelector } from "react-redux";
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import ImageViewer from "react-simple-image-viewer";
 
 import { Icon } from "@mdi/react";
-import { mdiFormatListCheckbox, mdiGift, mdiRedo, mdiArrowLeftBold, mdiArrowRightBold } from "@mdi/js";
+import {
+    mdiFormatListCheckbox,
+    mdiGift,
+    mdiRedo,
+    mdiArrowLeftBold,
+    mdiArrowRightBold,
+    mdiTrophyAward,
+    mdiTrendingUp,
+} from "@mdi/js";
 
 import SEO from "../../components/SEO.jsx";
 import ErrorPage from "../error-page/index.jsx";
@@ -257,6 +265,53 @@ function Prestige() {
             </>
         );
     }, [currentPrestige, items, t, handbook]);
+
+    if (gameMode === "pve") {
+        return [
+            <SEO
+                title={`${t("Prestige")} - ${t("Escape from Tarkov")} - ${t("Tarkov.dev")}`}
+                description={t(
+                    "tasks-page-description",
+                    "Find out everything you need to know about prestige in Escape from Tarkov. Learn complete them and the rewards you can earn.",
+                )}
+                key="seo-wrapper"
+            />,
+            <div className={"page-wrapper"} key="quests-page-wrapper">
+                <div className="quests-headline-wrapper" key="quests-headline">
+                    <h1 className="quests-page-title">
+                        <Icon path={mdiTrophyAward} size={1.5} className="icon-with-text" />
+                        {t("Prestige")}
+                    </h1>
+                </div>
+                <div className="information-section prestige-block">
+                    <h2>
+                        <span className="icon">
+                            <Icon path={mdiTrendingUp} size={1} className="icon-with-text" />
+                        </span>
+                        {t("N/A")}
+                    </h2>
+                    <div className="page-wrapper prestige-page-wrapper"></div>
+                    <div className="prestiges-wrapper">
+                        <div>
+                            <p>
+                                {t("Prestige is not available in {{gameMode}} mode.", {
+                                    gameMode: t(`game_mode_${gameMode}`),
+                                })}
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div>
+                    {/* prettier-ignore */}
+                    <Trans i18nKey={'prestige-page-p'}>
+                        <p>
+                            Prestige in Escape from Tarkov provides access to a number of unique cosmetic items.
+                        </p>
+                    </Trans>
+                </div>
+            </div>,
+        ];
+    }
 
     if (!currentPrestige && (prestigesStatus === "succeeded" || prestigesStatus === "failed")) {
         return <ErrorPage />;

--- a/src/pages/prestige/list.jsx
+++ b/src/pages/prestige/list.jsx
@@ -1,4 +1,6 @@
+import { useMemo } from "react";
 import { Link } from "react-router-dom";
+import { useSelector } from "react-redux";
 import { Trans, useTranslation } from "react-i18next";
 
 import { Icon } from "@mdi/react";
@@ -13,6 +15,20 @@ import "./index.css";
 function Prestiges() {
     const { data: prestiges } = usePrestigeData();
     const { t } = useTranslation();
+
+    const gameMode = useSelector((state) => state.settings.gameMode);
+
+    const noPrestigesWarning = useMemo(() => {
+        if (gameMode === "pve") {
+            return (
+                <div>
+                    <p>
+                        {t("Prestige is not available in {{gameMode}} mode.", { gameMode: t(`game_mode_${gameMode}`) })}
+                    </p>
+                </div>
+            );
+        }
+    }, [gameMode]);
 
     return [
         <SEO
@@ -38,6 +54,7 @@ function Prestiges() {
                     {t("Levels")}
                 </h2>
                 <div className="page-wrapper prestige-page-wrapper"></div>
+                {noPrestigesWarning}
                 <div className="prestiges-wrapper">
                     {prestiges.map((prestige) => {
                         return (

--- a/src/translations/de/translation.json
+++ b/src/translations/de/translation.json
@@ -737,5 +737,6 @@
   "K:D": "K:D",
   "PMC Kills": "PMC-Kills",
   "PMC K:D": "PMC K:D",
-  "No hideout stations match filter settings.": "Keine Hideout-Stationen entsprechen den Filtereinstellungen."
+  "No hideout stations match filter settings.": "Keine Hideout-Stationen entsprechen den Filtereinstellungen.",
+  "Prestige is not available in {{gameMode}} mode.": "Prestige is not available in {{gameMode}} mode."
 }

--- a/src/translations/en/translation.json
+++ b/src/translations/en/translation.json
@@ -737,5 +737,6 @@
   "K:D": "K:D",
   "PMC Kills": "PMC Kills",
   "PMC K:D": "PMC K:D",
-  "No hideout stations match filter settings.": "No hideout stations match filter settings."
+  "No hideout stations match filter settings.": "No hideout stations match filter settings.",
+  "Prestige is not available in {{gameMode}} mode.": "Prestige is not available in {{gameMode}} mode."
 }

--- a/src/translations/es/translation.json
+++ b/src/translations/es/translation.json
@@ -737,5 +737,6 @@
   "K:D": "K:D",
   "PMC Kills": "PMC Kills",
   "PMC K:D": "PMC K:D",
-  "No hideout stations match filter settings.": "No hideout stations match filter settings."
+  "No hideout stations match filter settings.": "No hideout stations match filter settings.",
+  "Prestige is not available in {{gameMode}} mode.": "Prestige is not available in {{gameMode}} mode."
 }

--- a/src/translations/fr/translation.json
+++ b/src/translations/fr/translation.json
@@ -749,5 +749,6 @@
   "K:D": "K:D",
   "PMC Kills": "PMC Kills",
   "PMC K:D": "PMC K:D",
-  "No hideout stations match filter settings.": "No hideout stations match filter settings."
+  "No hideout stations match filter settings.": "No hideout stations match filter settings.",
+  "Prestige is not available in {{gameMode}} mode.": "Prestige is not available in {{gameMode}} mode."
 }

--- a/src/translations/it/translation.json
+++ b/src/translations/it/translation.json
@@ -744,5 +744,6 @@
   "K:D": "K:D",
   "PMC Kills": "PMC Kills",
   "PMC K:D": "PMC K:D",
-  "No hideout stations match filter settings.": "No hideout stations match filter settings."
+  "No hideout stations match filter settings.": "No hideout stations match filter settings.",
+  "Prestige is not available in {{gameMode}} mode.": "Prestige is not available in {{gameMode}} mode."
 }

--- a/src/translations/ja/translation.json
+++ b/src/translations/ja/translation.json
@@ -751,5 +751,6 @@
   "K:D": "K:D",
   "PMC Kills": "PMC Kills",
   "PMC K:D": "PMC K:D",
-  "No hideout stations match filter settings.": "No hideout stations match filter settings."
+  "No hideout stations match filter settings.": "No hideout stations match filter settings.",
+  "Prestige is not available in {{gameMode}} mode.": "Prestige is not available in {{gameMode}} mode."
 }

--- a/src/translations/pl/translation.json
+++ b/src/translations/pl/translation.json
@@ -751,5 +751,6 @@
   "K:D": "K:D",
   "PMC Kills": "PMC Kills",
   "PMC K:D": "PMC K:D",
-  "No hideout stations match filter settings.": "No hideout stations match filter settings."
+  "No hideout stations match filter settings.": "No hideout stations match filter settings.",
+  "Prestige is not available in {{gameMode}} mode.": "Prestige is not available in {{gameMode}} mode."
 }

--- a/src/translations/pt/translation.json
+++ b/src/translations/pt/translation.json
@@ -744,5 +744,6 @@
   "K:D": "K:D",
   "PMC Kills": "PMC Kills",
   "PMC K:D": "PMC K:D",
-  "No hideout stations match filter settings.": "No hideout stations match filter settings."
+  "No hideout stations match filter settings.": "No hideout stations match filter settings.",
+  "Prestige is not available in {{gameMode}} mode.": "Prestige is not available in {{gameMode}} mode."
 }

--- a/src/translations/ru/translation.json
+++ b/src/translations/ru/translation.json
@@ -751,5 +751,6 @@
   "K:D": "K:D",
   "PMC Kills": "PMC Kills",
   "PMC K:D": "PMC K:D",
-  "No hideout stations match filter settings.": "No hideout stations match filter settings."
+  "No hideout stations match filter settings.": "No hideout stations match filter settings.",
+  "Prestige is not available in {{gameMode}} mode.": "Prestige is not available in {{gameMode}} mode."
 }

--- a/src/translations/zh/translation.json
+++ b/src/translations/zh/translation.json
@@ -738,5 +738,6 @@
   "K:D": "K:D",
   "PMC Kills": "PMC Kills",
   "PMC K:D": "PMC K:D",
-  "No hideout stations match filter settings.": "No hideout stations match filter settings."
+  "No hideout stations match filter settings.": "No hideout stations match filter settings.",
+  "Prestige is not available in {{gameMode}} mode.": "Prestige is not available in {{gameMode}} mode."
 }


### PR DESCRIPTION
Instead of showing errors on prestige pages while in PVE mode, warn that prestige is not available in that mode.