### PR TITLE
Add JSON API documentation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -91,6 +91,7 @@ const TarkovMonitorPage = React.lazy(() => import("./pages/tarkov-monitor/index.
 const StashBotPage = React.lazy(() => import("./pages/stash-bot/index.js"));
 
 const APIDocs = React.lazy(() => import("./pages/api-docs/index.jsx"));
+const APIGraphQL = React.lazy(() => import("./pages/api-graphql/index.jsx"));
 
 let socket = false;
 let socketMonitorInterval = false;
@@ -765,6 +766,16 @@ function App() {
                             element={[
                                 <Suspense fallback={<Loading />} key="suspense-api-docs-wrapper">
                                     <APIDocs key="api-docs-wrapper" />
+                                </Suspense>,
+                                remoteControlSessionElement,
+                            ]}
+                        />
+                        <Route
+                            path={"/api-graphql/"}
+                            key="api-graphql-route"
+                            element={[
+                                <Suspense fallback={<Loading />} key="suspense-api-docs-wrapper">
+                                    <APIGraphQL key="api-docs-wrapper" />
                                 </Suspense>,
                                 remoteControlSessionElement,
                             ]}

--- a/src/components/item-image/index.jsx
+++ b/src/components/item-image/index.jsx
@@ -39,6 +39,7 @@ function ItemImage({
     className,
     style,
     imageLink,
+    autoDowngrade = false,
 }) {
     const { t } = useTranslation();
     const navigate = useNavigate();
@@ -153,7 +154,20 @@ function ItemImage({
 
     const imageUrl = useMemo(() => {
         if (!imageLink || customImageLoadFailed || !customImageLoaded) {
-            return item[imageField];
+            let url = item[imageField];
+            if (!autoDowngrade || (!url.includes("unknown-item") && imageField !== "baseImageLink")) {
+                return url;
+            }
+            const imageSizes = ["image8xLink", "image512pxLink", "baseImageLink"];
+            for (let i = 0; i < imageSizes.length; i++) {
+                const newUrl = item[imageSizes[i]];
+                if (newUrl.includes("unknown-item")) {
+                    continue;
+                }
+                url = newUrl;
+                break;
+            }
+            return url;
         }
         return imageLink;
     }, [item, imageField, imageLink, customImageLoadFailed, customImageLoaded]);

--- a/src/pages/api-docs/index.jsx
+++ b/src/pages/api-docs/index.jsx
@@ -23,22 +23,12 @@ function APIDocs() {
             <h1>{t("Tarkov.dev API")}</h1>
             <h2>{t("About")}</h2>
             {/* prettier-ignore */}
-            <Trans i18nKey={'api-about-p'}>
+            <Trans i18nKey={'api-json-about-p'}>
                 <div className="section-text-wrapper">
-                    The API is written in GraphQL and we try our hardest to follow spec and not to make breaking changes. 
-                    To learn about what queries you can make and how the schema is structured, visit the playground and read the documentation by clicking the book icon in the upper left corner. 
-                    Once you're ready to try some queries, you can also test them out in the playground. To learn about GraphQL queries generally, the GraphQL Foundation has helpful resources.
-                    <ul>
-                        <li>
-                            <a href="https://api.tarkov.dev/" target="_blank" rel="noopener noreferrer">Tarkov.dev GraphQL playground</a>
-                        </li>
-                        <li>
-                            <a href="https://graphql.org/learn/" target="_blank" rel="noopener noreferrer">GraphQL Foundation resources</a>
-                        </li>
-                    </ul>
+                    The API serves JSON responses to simple GET requests.
                 </div>
                 <div className="section-text-wrapper">
-                    Once you're ready to send API queries from outside the playground, the endpoint is: <a href="https://api.tarkov.dev/graphql" target="_blank" rel="noopener noreferrer">https://api.tarkov.dev/graphql</a>.
+                    A list of available endpoints can be found at: <a href="https://json.tarkov.dev/endpoints" target="_blank" rel="noopener noreferrer">https://json.tarkov.dev/endpoints</a>.
                 </div>
             </Trans>
             <h2>{t("FAQ")}</h2>
@@ -49,25 +39,19 @@ function APIDocs() {
             <div className="section-text-wrapper">
                 <h3>{t("Is it open source?")}</h3>
                 {/* prettier-ignore */}
-                <Trans i18nKey={'api-faq-open-source-p'}>
-                    Of course! Source code for the API can be found in its GitHub repo: <a href="https://github.com/the-hideout/tarkov-api" target="_blank" rel="noopener noreferrer">github.com/the-hideout/tarkov-api</a>.
+                <Trans i18nKey={'api-json-faq-open-source-p'}>
+                    The source code for the API can be found here: <a href="https://github.com/the-hideout/tarkov-data-manager" target="_blank" rel="noopener noreferrer">github.com/the-hideout/tarkov-data-manager</a>.
                 </Trans>
             </div>
             <div className="section-text-wrapper">
                 <h3>{t("Is there a rate limit?")}</h3>
-                {/* prettier-ignore */}
-                <Trans i18nKey={'api-faq-rate-limit-p'}>
-                    We occasionally get hit with a lot of traffic from bad actors that require implementing rate limits.
-                    Price data is updated every 5 minutes, so there's really no need to query faster than that.
-                    Use common sense, and you should be fine.
-                </Trans>
+                {t("No")}
             </div>
             <div className="section-text-wrapper">
                 <h3>{t("What about caching?")}</h3>
                 {/* prettier-ignore */}
-                <Trans i18nKey={'api-faq-caching-p'}>
-                    Since our data is updated every 5 minutes, we also cache all GraphQL queries for 5 minutes as well.
-                    This helps to greatly reduce the load on our servers while making your requests speedy quick!
+                <Trans i18nKey={'api-json-faq-caching-p'}>
+                    Data is cached until new data is available.
                 </Trans>
             </div>
             <div className="section-text-wrapper">
@@ -100,305 +84,50 @@ function APIDocs() {
                     <li>{t("Our network of scanners")}</li>
                 </ul>
             </div>
-            <h2>{t("Examples")}</h2>
+            <h2>{t("Localization")}</h2>
+            <div className="section-text-wrapper">
+                <p>
+                    {t(
+                        'Localizations (translations) are available for the languages listed in the languages property of the endpoint response. To request localization strings for a particular request, take the base request url and append an underscore and the language code. For example, for English, append "_en".',
+                    )}
+                </p>
+                <p>
+                    {t(
+                        "Each API response includes a `translations` property containing a list of JSON path strings that can be used with a translation file to localize the base response into a given language.",
+                    )}
+                </p>
+            </div>
+            <h3>{t("Examples")}</h3>
+            <p>{t("Examples of using and localizing responses can be found in our code repositories:")}</p>
             <ul>
                 <li>
-                    <HashLink to="#browser-js">Browser JS</HashLink>
+                    <a
+                        href="https://github.com/the-hideout/stash/blob/main/modules/json-api.mjs"
+                        target="_blank"
+                        rel="noreferrer"
+                    >
+                        {t("Stash Discord Bot")}
+                    </a>
                 </li>
                 <li>
-                    <HashLink to="#node-js">Node JS</HashLink>
+                    <a
+                        href="https://github.com/the-hideout/tarkov-dev/blob/main/src/modules/api-request.mjs"
+                        target="_blank"
+                        rel="noreferrer"
+                    >
+                        {t("This website")}
+                    </a>
                 </li>
                 <li>
-                    <HashLink to="#python">Python</HashLink>
-                </li>
-                <li>
-                    <HashLink to="#ruby">Ruby</HashLink>
-                </li>
-                <li>
-                    <HashLink to="#cli">CLI</HashLink>
-                </li>
-                <li>
-                    <HashLink to="#php">PHP</HashLink>
-                </li>
-                <li>
-                    <HashLink to="#java-11">Java 11</HashLink>
-                </li>
-                <li>
-                    <HashLink to="#csharp">C#</HashLink>
-                </li>
-                <li>
-                    <HashLink to="#go">Golang</HashLink>
-                </li>
-                <li>
-                    <HashLink to="#luvit">Lua (Luvit)</HashLink>
+                    <a
+                        href="https://github.com/the-hideout/TarkovMonitor/blob/27ee738da2ef59410795791a9911ef985cefa67b/TarkovMonitor/TarkovDev.cs#L71"
+                        target="_blank"
+                        rel="noreferrer"
+                    >
+                        {t("TarkovMonitor")}
+                    </a>
                 </li>
             </ul>
-            <div className="example-wrapper">
-                <h3 id="browser-js">Browser JS {t("example")}</h3>
-                <SyntaxHighlighter language="javascript" style={atomOneDark}>
-                    {`fetch('https://api.tarkov.dev/graphql', {
-  method: 'POST',
-  headers: {
-    'Accept': 'application/json',
-  },
-  body: JSON.stringify({query: \`{
-    items {
-        id
-        name
-        shortName
-    }
-}\`})
-})
-  .then(r => r.json())
-  .then(data => console.log('data returned:', data));`}
-                </SyntaxHighlighter>
-            </div>
-            <div className="example-wrapper">
-                <h3 id="node-js">Node JS {t("example")}</h3>
-                <SyntaxHighlighter language="javascript" style={atomOneDark}>
-                    {`import { request, gql } from 'graphql-request'
-
-const query = gql\`
-{
-    items {
-        id
-        name
-        shortName
-    }
-}
-\`
-
-request('https://api.tarkov.dev/graphql', query).then((data) => console.log(data))`}
-                </SyntaxHighlighter>
-            </div>
-            <div className="example-wrapper">
-                <h3 id="python">Python {t("example")}</h3>
-                <SyntaxHighlighter language="python" style={atomOneDark}>
-                    {`import requests
-
-def run_query(query):
-    headers = {"Content-Type": "application/json"}
-    response = requests.post('https://api.tarkov.dev/graphql', headers=headers, json={'query': query})
-    if response.status_code == 200:
-        return response.json()
-    else:
-        raise Exception("Query failed to run by returning code of {}. {}".format(response.status_code, query))
-
-
-new_query = """
-{
-    items {
-        id
-        name
-        shortName
-    }
-}
-"""
-
-result = run_query(new_query)
-print(result)`}
-                </SyntaxHighlighter>
-            </div>
-            <div className="example-wrapper">
-                <h3 id="ruby">Ruby {t("example")}</h3>
-                <cite>
-                    <span>{t("Contributed by")} </span>
-                    <a href="https://github.com/GrantBirki" target="_blank" rel="noopener noreferrer">
-                        GrantBirki
-                    </a>
-                </cite>
-                <SyntaxHighlighter language="ruby" style={atomOneDark}>
-                    {`# frozen_string_literal: true
-
-require 'net/http'
-require 'uri'
-require 'json'
-
-uri = URI.parse("https://api.tarkov.dev/graphql")
-
-header = { "Content-Type": "application/json" }
-query = { "query": "{ items {id name shortName } }" }
-
-# Create the HTTP object
-http = Net::HTTP.new(uri.host, uri.port)
-http.use_ssl = true
-request = Net::HTTP::Post.new(uri.request_uri, header)
-request.body = query.to_json
-
-# Send the request
-response = http.request(request)
-
-# Display request results
-puts response.code
-puts response.message
-puts response.body`}
-                </SyntaxHighlighter>
-            </div>
-            <div className="example-wrapper">
-                <h3 id="cli">CLI {t("example")}</h3>
-                <SyntaxHighlighter language="bash" style={atomOneDark}>
-                    {`curl -X POST \
--H "Content-Type: application/json" \
--d '{"query": "{ items {id name shortName } }"}' \
-https://api.tarkov.dev/graphql`}
-                </SyntaxHighlighter>
-            </div>
-            <div className="example-wrapper">
-                <h3 id="php">PHP {t("example")}</h3>
-                <SyntaxHighlighter language="php" style={atomOneDark}>
-                    {`$headers = ['Content-Type: application/json'];
-
-$query = '{
-  items {
-    id
-    name
-    shortName
-  }
-}';
-$data = @file_get_contents('https://api.tarkov.dev/graphql', false, stream_context_create([
-  'http' => [
-    'method' => 'POST',
-    'header' => $headers,
-    'content' => json_encode(['query' => $query]),
-  ]
-]));
-return json_decode($data, true);`}
-                </SyntaxHighlighter>
-            </div>
-            <div className="example-wrapper">
-                <h3 id="java-11">
-                    <span>Java 11's HttpClient {t("example")}</span>
-                    <cite>
-                        <span>{t("Contributed by")} </span>
-                        <a href="https://github.com/HeyBanditoz" target="_blank" rel="noopener noreferrer">
-                            HeyBanditoz
-                        </a>
-                    </cite>
-                </h3>
-                <SyntaxHighlighter language="java" style={atomOneDark}>
-                    {`import java.io.IOException;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-
-class Scratch {
-    public static void main(String[] args) throws IOException, InterruptedException {
-        HttpClient client = HttpClient.newBuilder().build();
-        String query = "{\\"query\\": \\"{ items {id name shortName } }\\"}";
-        HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create("https://api.tarkov.dev/graphql"))
-                .header("Content-Type", "application/json")
-                .header("Accept", "application/json")
-                .POST(HttpRequest.BodyPublishers.ofString(query))
-                .build();
-        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-        String jsonString = response.body();
-        System.out.println(jsonString);
-    }
-}
-`}
-                </SyntaxHighlighter>
-            </div>
-            <div className="example-wrapper">
-                <h3 id="csharp">
-                    <span>C# {t("example")}</span>
-                    <cite>{t("Contributed by")} BambusBo</cite>
-                </h3>
-                <SyntaxHighlighter language="csharp" style={atomOneDark}>
-                    {`var data = new Dictionary<string, string>()
-{
-    {"query", "{items { id name shortName }}"}
-};
-
-using (var httpClient = new HttpClient())
-{
-
-    //Http response message
-    var httpResponse = await httpClient.PostAsJsonAsync("https://api.tarkov.dev/graphql", data);
-
-    //Response content
-    var responseContent = await httpResponse.Content.ReadAsStringAsync();
-
-    //Print response
-    Debug.WriteLine(responseContent);
-
-}`}
-                </SyntaxHighlighter>
-            </div>
-            <div className="example-wrapper">
-                <h3 id="go">
-                    <span>Go {t("example")}</span>
-                    <cite>
-                        <span>{t("Contributed by")} </span>
-                        <a href="https://github.com/HeyBanditoz" target="_blank" rel="noopener noreferrer">
-                            HeyBanditoz
-                        </a>
-                    </cite>
-                </h3>
-                <SyntaxHighlighter language="go" style={atomOneDark}>
-                    {`package main
-
-import (
-    "fmt"
-    "io"
-    "log"
-    "net/http"
-    "strings"
-)
-
-func main() {
-    body := strings.NewReader(\`{"query": "{ items {id name shortName } }"}\`)
-    req, err := http.NewRequest("POST", "https://api.tarkov.dev/graphql", body)
-    if err != nil {
-        log.Fatalln(err)
-    }
-    req.Header.Set("Content-Type", "application/json")
-    req.Header.Set("Accept", "application/json")
-
-    resp, err := http.DefaultClient.Do(req)
-    if err != nil {
-        log.Fatalln(err)
-    }
-    bodyBytes, err := io.ReadAll(resp.Body)
-    if err != nil {
-        log.Fatalln(err)
-    }
-    bodyString := string(bodyBytes)
-    fmt.Println(bodyString)
-
-    defer resp.Body.Close()
-}`}
-                </SyntaxHighlighter>
-            </div>
-            <div className="example-wrapper">
-                <h3 id="luvit">
-                    <span>Lua (Luvit) {t("example")}</span>
-                    <cite>
-                        <span>{t("Contributed by")} </span>
-                        <a href="https://github.com/AntwanR942" target="_blank" rel="noopener noreferrer">
-                            AntwanR942
-                        </a>
-                    </cite>
-                </h3>
-                <SyntaxHighlighter language="lua" style={atomOneDark}>
-                    {`local http = require "coro-http"
-
-coroutine.wrap(function()
-    local query = [[{"query": "{ items {id name shortName } }"}]]
-    local headers = {
-        { "Content-Type", "application/json" },
-        { "Accept", "application/json" }
-    }
-    local res, body = http.request("POST", "https://api.tarkov.dev/graphql", headers, query)
-    if res.code ~= 200 then
-        error(res.message)
-    end
-
-    print(body)
-end)()`}
-                </SyntaxHighlighter>
-            </div>
         </div>,
     ];
 }

--- a/src/pages/api-graphql/index.css
+++ b/src/pages/api-graphql/index.css
@@ -1,0 +1,8 @@
+.api-docs-page-wrapper {
+    margin: auto;
+    max-width: 900px;
+}
+
+.section-text-wrapper {
+    margin: 10px 0;
+}

--- a/src/pages/api-graphql/index.jsx
+++ b/src/pages/api-graphql/index.jsx
@@ -1,0 +1,417 @@
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { atomDark as atomOneDark } from "react-syntax-highlighter/dist/esm/styles/prism/index.js";
+import { Trans, useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
+import { HashLink } from "react-router-hash-link";
+
+import SEO from "../../components/SEO.jsx";
+//import ApiMetricsGraph from '../../components/api-metrics-graph/index.js';
+
+import "./index.css";
+
+function APIDocs() {
+    const { t } = useTranslation();
+    return [
+        <SEO
+            title={`${t("API Documentation")} - ${t("Tarkov.dev")}`}
+            description={t(
+                "api-docs-page-description",
+                "Escape from Tarkov's community made API and its documentation. Learn more about our free and easy to use GraphQL API for EFT.",
+            )}
+            key="seo-wrapper"
+        />,
+        <div className={"page-wrapper api-docs-page-wrapper"}>
+            <h1>{t("Tarkov.dev GraphQL Legacy API")}</h1>
+            <div className="section-text-wrapper">
+                {/* prettier-ignore */}
+                <Trans i18nKey={'api-graphql-maintenance'}>
+                    <p>The GraphQL API is now considered in maintenance mode. While it will continue to function in its current state, schema changes will not be made.</p>
+                </Trans>
+                {/* prettier-ignore */}
+                <Trans i18nKey={'api-graphql-json-api'}>
+                    <p>You ought to use the new <Link to="/api">JSON API</Link> going forward.</p>
+                </Trans>
+            </div>
+            <h2>{t("About")}</h2>
+            {/* prettier-ignore */}
+            <Trans i18nKey={'api-about-p'}>
+                <div className="section-text-wrapper">
+                    The API is written in GraphQL and we try our hardest to follow spec and not to make breaking changes. 
+                    To learn about what queries you can make and how the schema is structured, visit the playground and read the documentation by clicking the book icon in the upper left corner. 
+                    Once you're ready to try some queries, you can also test them out in the playground. To learn about GraphQL queries generally, the GraphQL Foundation has helpful resources.
+                    <ul>
+                        <li>
+                            <a href="https://api.tarkov.dev/" target="_blank" rel="noopener noreferrer">Tarkov.dev GraphQL playground</a>
+                        </li>
+                        <li>
+                            <a href="https://graphql.org/learn/" target="_blank" rel="noopener noreferrer">GraphQL Foundation resources</a>
+                        </li>
+                    </ul>
+                </div>
+                <div className="section-text-wrapper">
+                    Once you're ready to send API queries from outside the playground, the endpoint is: <a href="https://api.tarkov.dev/graphql" target="_blank" rel="noopener noreferrer">https://api.tarkov.dev/graphql</a>.
+                </div>
+            </Trans>
+            <h2>{t("FAQ")}</h2>
+            <div className="section-text-wrapper">
+                <h3>{t("Is it free?")}</h3>
+                {t("Yes")}
+            </div>
+            <div className="section-text-wrapper">
+                <h3>{t("Is it open source?")}</h3>
+                {/* prettier-ignore */}
+                <Trans i18nKey={'api-faq-open-source-p'}>
+                    Of course! Source code for the API can be found in its GitHub repo: <a href="https://github.com/the-hideout/tarkov-api" target="_blank" rel="noopener noreferrer">github.com/the-hideout/tarkov-api</a>.
+                </Trans>
+            </div>
+            <div className="section-text-wrapper">
+                <h3>{t("Is there a rate limit?")}</h3>
+                {/* prettier-ignore */}
+                <Trans i18nKey={'api-faq-rate-limit-p'}>
+                    We occasionally get hit with a lot of traffic from bad actors that require implementing rate limits.
+                    Price data is updated every 5 minutes, so there's really no need to query faster than that.
+                    Use common sense, and you should be fine.
+                </Trans>
+            </div>
+            <div className="section-text-wrapper">
+                <h3>{t("What about caching?")}</h3>
+                {/* prettier-ignore */}
+                <Trans i18nKey={'api-faq-caching-p'}>
+                    Since our data is updated every 5 minutes, we also cache all GraphQL queries for 5 minutes as well.
+                    This helps to greatly reduce the load on our servers while making your requests speedy quick!
+                </Trans>
+            </div>
+            <div className="section-text-wrapper">
+                <h3>{t("Where is the data from?")}</h3>
+                {t("We source data from multiple places to build an API as complete as possible. We use data from:")}
+                <ul>
+                    <li>
+                        <a href="https://tarkov-changes.com/" target="_blank" rel="noopener noreferrer">
+                            Tarkov Changes
+                        </a>
+                    </li>
+                    <li>
+                        <a
+                            href="https://escapefromtarkov.fandom.com/wiki/Escape_from_Tarkov_Wiki"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            Escape from Tarkov Wiki
+                        </a>
+                    </li>
+                    <li>
+                        <a
+                            href="https://github.com/TarkovTracker/tarkovdata/"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            TarkovTracker/tarkovdata
+                        </a>
+                    </li>
+                    <li>{t("Our network of scanners")}</li>
+                </ul>
+            </div>
+            <h2>{t("Examples")}</h2>
+            <ul>
+                <li>
+                    <HashLink to="#browser-js">Browser JS</HashLink>
+                </li>
+                <li>
+                    <HashLink to="#node-js">Node JS</HashLink>
+                </li>
+                <li>
+                    <HashLink to="#python">Python</HashLink>
+                </li>
+                <li>
+                    <HashLink to="#ruby">Ruby</HashLink>
+                </li>
+                <li>
+                    <HashLink to="#cli">CLI</HashLink>
+                </li>
+                <li>
+                    <HashLink to="#php">PHP</HashLink>
+                </li>
+                <li>
+                    <HashLink to="#java-11">Java 11</HashLink>
+                </li>
+                <li>
+                    <HashLink to="#csharp">C#</HashLink>
+                </li>
+                <li>
+                    <HashLink to="#go">Golang</HashLink>
+                </li>
+                <li>
+                    <HashLink to="#luvit">Lua (Luvit)</HashLink>
+                </li>
+            </ul>
+            <div className="example-wrapper">
+                <h3 id="browser-js">Browser JS {t("example")}</h3>
+                <SyntaxHighlighter language="javascript" style={atomOneDark}>
+                    {`fetch('https://api.tarkov.dev/graphql', {
+  method: 'POST',
+  headers: {
+    'Accept': 'application/json',
+  },
+  body: JSON.stringify({query: \`{
+    items {
+        id
+        name
+        shortName
+    }
+}\`})
+})
+  .then(r => r.json())
+  .then(data => console.log('data returned:', data));`}
+                </SyntaxHighlighter>
+            </div>
+            <div className="example-wrapper">
+                <h3 id="node-js">Node JS {t("example")}</h3>
+                <SyntaxHighlighter language="javascript" style={atomOneDark}>
+                    {`import { request, gql } from 'graphql-request'
+
+const query = gql\`
+{
+    items {
+        id
+        name
+        shortName
+    }
+}
+\`
+
+request('https://api.tarkov.dev/graphql', query).then((data) => console.log(data))`}
+                </SyntaxHighlighter>
+            </div>
+            <div className="example-wrapper">
+                <h3 id="python">Python {t("example")}</h3>
+                <SyntaxHighlighter language="python" style={atomOneDark}>
+                    {`import requests
+
+def run_query(query):
+    headers = {"Content-Type": "application/json"}
+    response = requests.post('https://api.tarkov.dev/graphql', headers=headers, json={'query': query})
+    if response.status_code == 200:
+        return response.json()
+    else:
+        raise Exception("Query failed to run by returning code of {}. {}".format(response.status_code, query))
+
+
+new_query = """
+{
+    items {
+        id
+        name
+        shortName
+    }
+}
+"""
+
+result = run_query(new_query)
+print(result)`}
+                </SyntaxHighlighter>
+            </div>
+            <div className="example-wrapper">
+                <h3 id="ruby">Ruby {t("example")}</h3>
+                <cite>
+                    <span>{t("Contributed by")} </span>
+                    <a href="https://github.com/GrantBirki" target="_blank" rel="noopener noreferrer">
+                        GrantBirki
+                    </a>
+                </cite>
+                <SyntaxHighlighter language="ruby" style={atomOneDark}>
+                    {`# frozen_string_literal: true
+
+require 'net/http'
+require 'uri'
+require 'json'
+
+uri = URI.parse("https://api.tarkov.dev/graphql")
+
+header = { "Content-Type": "application/json" }
+query = { "query": "{ items {id name shortName } }" }
+
+# Create the HTTP object
+http = Net::HTTP.new(uri.host, uri.port)
+http.use_ssl = true
+request = Net::HTTP::Post.new(uri.request_uri, header)
+request.body = query.to_json
+
+# Send the request
+response = http.request(request)
+
+# Display request results
+puts response.code
+puts response.message
+puts response.body`}
+                </SyntaxHighlighter>
+            </div>
+            <div className="example-wrapper">
+                <h3 id="cli">CLI {t("example")}</h3>
+                <SyntaxHighlighter language="bash" style={atomOneDark}>
+                    {`curl -X POST \
+-H "Content-Type: application/json" \
+-d '{"query": "{ items {id name shortName } }"}' \
+https://api.tarkov.dev/graphql`}
+                </SyntaxHighlighter>
+            </div>
+            <div className="example-wrapper">
+                <h3 id="php">PHP {t("example")}</h3>
+                <SyntaxHighlighter language="php" style={atomOneDark}>
+                    {`$headers = ['Content-Type: application/json'];
+
+$query = '{
+  items {
+    id
+    name
+    shortName
+  }
+}';
+$data = @file_get_contents('https://api.tarkov.dev/graphql', false, stream_context_create([
+  'http' => [
+    'method' => 'POST',
+    'header' => $headers,
+    'content' => json_encode(['query' => $query]),
+  ]
+]));
+return json_decode($data, true);`}
+                </SyntaxHighlighter>
+            </div>
+            <div className="example-wrapper">
+                <h3 id="java-11">
+                    <span>Java 11's HttpClient {t("example")}</span>
+                    <cite>
+                        <span>{t("Contributed by")} </span>
+                        <a href="https://github.com/HeyBanditoz" target="_blank" rel="noopener noreferrer">
+                            HeyBanditoz
+                        </a>
+                    </cite>
+                </h3>
+                <SyntaxHighlighter language="java" style={atomOneDark}>
+                    {`import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+class Scratch {
+    public static void main(String[] args) throws IOException, InterruptedException {
+        HttpClient client = HttpClient.newBuilder().build();
+        String query = "{\\"query\\": \\"{ items {id name shortName } }\\"}";
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("https://api.tarkov.dev/graphql"))
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(query))
+                .build();
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        String jsonString = response.body();
+        System.out.println(jsonString);
+    }
+}
+`}
+                </SyntaxHighlighter>
+            </div>
+            <div className="example-wrapper">
+                <h3 id="csharp">
+                    <span>C# {t("example")}</span>
+                    <cite>{t("Contributed by")} BambusBo</cite>
+                </h3>
+                <SyntaxHighlighter language="csharp" style={atomOneDark}>
+                    {`var data = new Dictionary<string, string>()
+{
+    {"query", "{items { id name shortName }}"}
+};
+
+using (var httpClient = new HttpClient())
+{
+
+    //Http response message
+    var httpResponse = await httpClient.PostAsJsonAsync("https://api.tarkov.dev/graphql", data);
+
+    //Response content
+    var responseContent = await httpResponse.Content.ReadAsStringAsync();
+
+    //Print response
+    Debug.WriteLine(responseContent);
+
+}`}
+                </SyntaxHighlighter>
+            </div>
+            <div className="example-wrapper">
+                <h3 id="go">
+                    <span>Go {t("example")}</span>
+                    <cite>
+                        <span>{t("Contributed by")} </span>
+                        <a href="https://github.com/HeyBanditoz" target="_blank" rel="noopener noreferrer">
+                            HeyBanditoz
+                        </a>
+                    </cite>
+                </h3>
+                <SyntaxHighlighter language="go" style={atomOneDark}>
+                    {`package main
+
+import (
+    "fmt"
+    "io"
+    "log"
+    "net/http"
+    "strings"
+)
+
+func main() {
+    body := strings.NewReader(\`{"query": "{ items {id name shortName } }"}\`)
+    req, err := http.NewRequest("POST", "https://api.tarkov.dev/graphql", body)
+    if err != nil {
+        log.Fatalln(err)
+    }
+    req.Header.Set("Content-Type", "application/json")
+    req.Header.Set("Accept", "application/json")
+
+    resp, err := http.DefaultClient.Do(req)
+    if err != nil {
+        log.Fatalln(err)
+    }
+    bodyBytes, err := io.ReadAll(resp.Body)
+    if err != nil {
+        log.Fatalln(err)
+    }
+    bodyString := string(bodyBytes)
+    fmt.Println(bodyString)
+
+    defer resp.Body.Close()
+}`}
+                </SyntaxHighlighter>
+            </div>
+            <div className="example-wrapper">
+                <h3 id="luvit">
+                    <span>Lua (Luvit) {t("example")}</span>
+                    <cite>
+                        <span>{t("Contributed by")} </span>
+                        <a href="https://github.com/AntwanR942" target="_blank" rel="noopener noreferrer">
+                            AntwanR942
+                        </a>
+                    </cite>
+                </h3>
+                <SyntaxHighlighter language="lua" style={atomOneDark}>
+                    {`local http = require "coro-http"
+
+coroutine.wrap(function()
+    local query = [[{"query": "{ items {id name shortName } }"}]]
+    local headers = {
+        { "Content-Type", "application/json" },
+        { "Accept", "application/json" }
+    }
+    local res, body = http.request("POST", "https://api.tarkov.dev/graphql", headers, query)
+    if res.code ~= 200 then
+        error(res.message)
+    end
+
+    print(body)
+end)()`}
+                </SyntaxHighlighter>
+            </div>
+        </div>,
+    ];
+}
+
+export default APIDocs;

--- a/src/pages/item/index.jsx
+++ b/src/pages/item/index.jsx
@@ -549,6 +549,7 @@ The max profitable price is impacted by the intel center and hideout management 
                             imageField={"image512pxLink"}
                             imageViewer={true}
                             nonFunctionalOverlay={true}
+                            autoDowngrade={true}
                         />
                     </div>
                 </div>

--- a/src/pages/map/index.jsx
+++ b/src/pages/map/index.jsx
@@ -577,6 +577,9 @@ function Map() {
         if (mapSettingsRef.current.alwaysShowSnipers ?? true) {
             map._container.classList.add("always-show-snipers");
         }
+        if (mapSettingsRef.current.alwaysShowExtracts ?? false) {
+            map._container.classList.add("always-show-extracts");
+        }
 
         map.raidInfoControl = L.control
             .raidInfo({

--- a/src/translations/de/translation.json
+++ b/src/translations/de/translation.json
@@ -738,5 +738,16 @@
   "PMC Kills": "PMC-Kills",
   "PMC K:D": "PMC K:D",
   "No hideout stations match filter settings.": "Keine Hideout-Stationen entsprechen den Filtereinstellungen.",
-  "Prestige is not available in {{gameMode}} mode.": "Prestige is not available in {{gameMode}} mode."
+  "Prestige is not available in {{gameMode}} mode.": "Prestige is not available in {{gameMode}} mode.",
+  "Tarkov.dev GraphQL Legacy API": "Tarkov.dev GraphQL Legacy API",
+  "api-graphql-maintenance": "<0>The GraphQL API is now considered in maintenance mode. While it will continue to function in its current state, schema changes will not be made.</1>",
+  "api-graphql-json-api": "<0>You ought to use the new <1>JSON API</1> going forward.</0>",
+  "api-json-about-p": "<0>The API serves JSON responses to simple GET requests.</0><1>A list of available endpoints can be found at: <1>https://json.tarkov.dev/endpoints</1>.</1>",
+  "api-json-faq-open-source-p": "The source code for the API can be found here: <1>github.com/the-hideout/tarkov-data-manager</1>.",
+  "api-json-faq-caching-p": "Data is cached until new data is available.",
+  "Localization": "Localization",
+  "Localizations (translations) are available for the languages listed in the languages property of the endpoint response. To request localization strings for a particular request, take the base request url and append an underscore and the language code. For example, for English, append \"_en\".": "Localizations (translations) are available for the languages listed in the languages property of the endpoint response. To request localization strings for a particular request, take the base request url and append an underscore and the language code. For example, for English, append \"_en\".",
+  "Each API response includes a `translations` property containing a list of JSON path strings that can be used with a translation file to localize the base response into a given language.": "Each API response includes a `translations` property containing a list of JSON path strings that can be used with a translation file to localize the base response into a given language.",
+  "Examples of using and localizing responses can be found in our code repositories:": "Examples of using and localizing responses can be found in our code repositories:",
+  "This website": "This website"
 }

--- a/src/translations/en/translation.json
+++ b/src/translations/en/translation.json
@@ -738,5 +738,16 @@
   "PMC Kills": "PMC Kills",
   "PMC K:D": "PMC K:D",
   "No hideout stations match filter settings.": "No hideout stations match filter settings.",
-  "Prestige is not available in {{gameMode}} mode.": "Prestige is not available in {{gameMode}} mode."
+  "Prestige is not available in {{gameMode}} mode.": "Prestige is not available in {{gameMode}} mode.",
+  "Tarkov.dev GraphQL Legacy API": "Tarkov.dev GraphQL Legacy API",
+  "api-graphql-maintenance": "<0>The GraphQL API is now considered in maintenance mode. While it will continue to function in its current state, schema changes will not be made.</1>",
+  "api-graphql-json-api": "<0>You ought to use the new <1>JSON API</1> going forward.</0>",
+  "api-json-about-p": "<0>The API serves JSON responses to simple GET requests.</0><1>A list of available endpoints can be found at: <1>https://json.tarkov.dev/endpoints</1>.</1>",
+  "api-json-faq-open-source-p": "The source code for the API can be found here: <1>github.com/the-hideout/tarkov-data-manager</1>.",
+  "api-json-faq-caching-p": "Data is cached until new data is available.",
+  "Localization": "Localization",
+  "Localizations (translations) are available for the languages listed in the languages property of the endpoint response. To request localization strings for a particular request, take the base request url and append an underscore and the language code. For example, for English, append \"_en\".": "Localizations (translations) are available for the languages listed in the languages property of the endpoint response. To request localization strings for a particular request, take the base request url and append an underscore and the language code. For example, for English, append \"_en\".",
+  "Each API response includes a `translations` property containing a list of JSON path strings that can be used with a translation file to localize the base response into a given language.": "Each API response includes a `translations` property containing a list of JSON path strings that can be used with a translation file to localize the base response into a given language.",
+  "Examples of using and localizing responses can be found in our code repositories:": "Examples of using and localizing responses can be found in our code repositories:",
+  "This website": "This website"
 }

--- a/src/translations/es/translation.json
+++ b/src/translations/es/translation.json
@@ -738,5 +738,16 @@
   "PMC Kills": "PMC Kills",
   "PMC K:D": "PMC K:D",
   "No hideout stations match filter settings.": "No hideout stations match filter settings.",
-  "Prestige is not available in {{gameMode}} mode.": "Prestige is not available in {{gameMode}} mode."
+  "Prestige is not available in {{gameMode}} mode.": "Prestige is not available in {{gameMode}} mode.",
+  "Tarkov.dev GraphQL Legacy API": "Tarkov.dev GraphQL Legacy API",
+  "api-graphql-maintenance": "<0>The GraphQL API is now considered in maintenance mode. While it will continue to function in its current state, schema changes will not be made.</1>",
+  "api-graphql-json-api": "<0>You ought to use the new <1>JSON API</1> going forward.</0>",
+  "api-json-about-p": "<0>The API serves JSON responses to simple GET requests.</0><1>A list of available endpoints can be found at: <1>https://json.tarkov.dev/endpoints</1>.</1>",
+  "api-json-faq-open-source-p": "The source code for the API can be found here: <1>github.com/the-hideout/tarkov-data-manager</1>.",
+  "api-json-faq-caching-p": "Data is cached until new data is available.",
+  "Localization": "Localization",
+  "Localizations (translations) are available for the languages listed in the languages property of the endpoint response. To request localization strings for a particular request, take the base request url and append an underscore and the language code. For example, for English, append \"_en\".": "Localizations (translations) are available for the languages listed in the languages property of the endpoint response. To request localization strings for a particular request, take the base request url and append an underscore and the language code. For example, for English, append \"_en\".",
+  "Each API response includes a `translations` property containing a list of JSON path strings that can be used with a translation file to localize the base response into a given language.": "Each API response includes a `translations` property containing a list of JSON path strings that can be used with a translation file to localize the base response into a given language.",
+  "Examples of using and localizing responses can be found in our code repositories:": "Examples of using and localizing responses can be found in our code repositories:",
+  "This website": "This website"
 }

--- a/src/translations/fr/translation.json
+++ b/src/translations/fr/translation.json
@@ -750,5 +750,16 @@
   "PMC Kills": "PMC Kills",
   "PMC K:D": "PMC K:D",
   "No hideout stations match filter settings.": "No hideout stations match filter settings.",
-  "Prestige is not available in {{gameMode}} mode.": "Prestige is not available in {{gameMode}} mode."
+  "Prestige is not available in {{gameMode}} mode.": "Prestige is not available in {{gameMode}} mode.",
+  "Tarkov.dev GraphQL Legacy API": "Tarkov.dev GraphQL Legacy API",
+  "api-graphql-maintenance": "<0>The GraphQL API is now considered in maintenance mode. While it will continue to function in its current state, schema changes will not be made.</1>",
+  "api-graphql-json-api": "<0>You ought to use the new <1>JSON API</1> going forward.</0>",
+  "api-json-about-p": "<0>The API serves JSON responses to simple GET requests.</0><1>A list of available endpoints can be found at: <1>https://json.tarkov.dev/endpoints</1>.</1>",
+  "api-json-faq-open-source-p": "The source code for the API can be found here: <1>github.com/the-hideout/tarkov-data-manager</1>.",
+  "api-json-faq-caching-p": "Data is cached until new data is available.",
+  "Localization": "Localization",
+  "Localizations (translations) are available for the languages listed in the languages property of the endpoint response. To request localization strings for a particular request, take the base request url and append an underscore and the language code. For example, for English, append \"_en\".": "Localizations (translations) are available for the languages listed in the languages property of the endpoint response. To request localization strings for a particular request, take the base request url and append an underscore and the language code. For example, for English, append \"_en\".",
+  "Each API response includes a `translations` property containing a list of JSON path strings that can be used with a translation file to localize the base response into a given language.": "Each API response includes a `translations` property containing a list of JSON path strings that can be used with a translation file to localize the base response into a given language.",
+  "Examples of using and localizing responses can be found in our code repositories:": "Examples of using and localizing responses can be found in our code repositories:",
+  "This website": "This website"
 }

--- a/src/translations/it/translation.json
+++ b/src/translations/it/translation.json
@@ -745,5 +745,16 @@
   "PMC Kills": "PMC Kills",
   "PMC K:D": "PMC K:D",
   "No hideout stations match filter settings.": "No hideout stations match filter settings.",
-  "Prestige is not available in {{gameMode}} mode.": "Prestige is not available in {{gameMode}} mode."
+  "Prestige is not available in {{gameMode}} mode.": "Prestige is not available in {{gameMode}} mode.",
+  "Tarkov.dev GraphQL Legacy API": "Tarkov.dev GraphQL Legacy API",
+  "api-graphql-maintenance": "<0>The GraphQL API is now considered in maintenance mode. While it will continue to function in its current state, schema changes will not be made.</1>",
+  "api-graphql-json-api": "<0>You ought to use the new <1>JSON API</1> going forward.</0>",
+  "api-json-about-p": "<0>The API serves JSON responses to simple GET requests.</0><1>A list of available endpoints can be found at: <1>https://json.tarkov.dev/endpoints</1>.</1>",
+  "api-json-faq-open-source-p": "The source code for the API can be found here: <1>github.com/the-hideout/tarkov-data-manager</1>.",
+  "api-json-faq-caching-p": "Data is cached until new data is available.",
+  "Localization": "Localization",
+  "Localizations (translations) are available for the languages listed in the languages property of the endpoint response. To request localization strings for a particular request, take the base request url and append an underscore and the language code. For example, for English, append \"_en\".": "Localizations (translations) are available for the languages listed in the languages property of the endpoint response. To request localization strings for a particular request, take the base request url and append an underscore and the language code. For example, for English, append \"_en\".",
+  "Each API response includes a `translations` property containing a list of JSON path strings that can be used with a translation file to localize the base response into a given language.": "Each API response includes a `translations` property containing a list of JSON path strings that can be used with a translation file to localize the base response into a given language.",
+  "Examples of using and localizing responses can be found in our code repositories:": "Examples of using and localizing responses can be found in our code repositories:",
+  "This website": "This website"
 }

--- a/src/translations/ja/translation.json
+++ b/src/translations/ja/translation.json
@@ -752,5 +752,16 @@
   "PMC Kills": "PMC Kills",
   "PMC K:D": "PMC K:D",
   "No hideout stations match filter settings.": "No hideout stations match filter settings.",
-  "Prestige is not available in {{gameMode}} mode.": "Prestige is not available in {{gameMode}} mode."
+  "Prestige is not available in {{gameMode}} mode.": "Prestige is not available in {{gameMode}} mode.",
+  "Tarkov.dev GraphQL Legacy API": "Tarkov.dev GraphQL Legacy API",
+  "api-graphql-maintenance": "<0>The GraphQL API is now considered in maintenance mode. While it will continue to function in its current state, schema changes will not be made.</1>",
+  "api-graphql-json-api": "<0>You ought to use the new <1>JSON API</1> going forward.</0>",
+  "api-json-about-p": "<0>The API serves JSON responses to simple GET requests.</0><1>A list of available endpoints can be found at: <1>https://json.tarkov.dev/endpoints</1>.</1>",
+  "api-json-faq-open-source-p": "The source code for the API can be found here: <1>github.com/the-hideout/tarkov-data-manager</1>.",
+  "api-json-faq-caching-p": "Data is cached until new data is available.",
+  "Localization": "Localization",
+  "Localizations (translations) are available for the languages listed in the languages property of the endpoint response. To request localization strings for a particular request, take the base request url and append an underscore and the language code. For example, for English, append \"_en\".": "Localizations (translations) are available for the languages listed in the languages property of the endpoint response. To request localization strings for a particular request, take the base request url and append an underscore and the language code. For example, for English, append \"_en\".",
+  "Each API response includes a `translations` property containing a list of JSON path strings that can be used with a translation file to localize the base response into a given language.": "Each API response includes a `translations` property containing a list of JSON path strings that can be used with a translation file to localize the base response into a given language.",
+  "Examples of using and localizing responses can be found in our code repositories:": "Examples of using and localizing responses can be found in our code repositories:",
+  "This website": "This website"
 }

--- a/src/translations/pl/translation.json
+++ b/src/translations/pl/translation.json
@@ -752,5 +752,16 @@
   "PMC Kills": "PMC Kills",
   "PMC K:D": "PMC K:D",
   "No hideout stations match filter settings.": "No hideout stations match filter settings.",
-  "Prestige is not available in {{gameMode}} mode.": "Prestige is not available in {{gameMode}} mode."
+  "Prestige is not available in {{gameMode}} mode.": "Prestige is not available in {{gameMode}} mode.",
+  "Tarkov.dev GraphQL Legacy API": "Tarkov.dev GraphQL Legacy API",
+  "api-graphql-maintenance": "<0>The GraphQL API is now considered in maintenance mode. While it will continue to function in its current state, schema changes will not be made.</1>",
+  "api-graphql-json-api": "<0>You ought to use the new <1>JSON API</1> going forward.</0>",
+  "api-json-about-p": "<0>The API serves JSON responses to simple GET requests.</0><1>A list of available endpoints can be found at: <1>https://json.tarkov.dev/endpoints</1>.</1>",
+  "api-json-faq-open-source-p": "The source code for the API can be found here: <1>github.com/the-hideout/tarkov-data-manager</1>.",
+  "api-json-faq-caching-p": "Data is cached until new data is available.",
+  "Localization": "Localization",
+  "Localizations (translations) are available for the languages listed in the languages property of the endpoint response. To request localization strings for a particular request, take the base request url and append an underscore and the language code. For example, for English, append \"_en\".": "Localizations (translations) are available for the languages listed in the languages property of the endpoint response. To request localization strings for a particular request, take the base request url and append an underscore and the language code. For example, for English, append \"_en\".",
+  "Each API response includes a `translations` property containing a list of JSON path strings that can be used with a translation file to localize the base response into a given language.": "Each API response includes a `translations` property containing a list of JSON path strings that can be used with a translation file to localize the base response into a given language.",
+  "Examples of using and localizing responses can be found in our code repositories:": "Examples of using and localizing responses can be found in our code repositories:",
+  "This website": "This website"
 }

--- a/src/translations/pt/translation.json
+++ b/src/translations/pt/translation.json
@@ -745,5 +745,16 @@
   "PMC Kills": "PMC Kills",
   "PMC K:D": "PMC K:D",
   "No hideout stations match filter settings.": "No hideout stations match filter settings.",
-  "Prestige is not available in {{gameMode}} mode.": "Prestige is not available in {{gameMode}} mode."
+  "Prestige is not available in {{gameMode}} mode.": "Prestige is not available in {{gameMode}} mode.",
+  "Tarkov.dev GraphQL Legacy API": "Tarkov.dev GraphQL Legacy API",
+  "api-graphql-maintenance": "<0>The GraphQL API is now considered in maintenance mode. While it will continue to function in its current state, schema changes will not be made.</1>",
+  "api-graphql-json-api": "<0>You ought to use the new <1>JSON API</1> going forward.</0>",
+  "api-json-about-p": "<0>The API serves JSON responses to simple GET requests.</0><1>A list of available endpoints can be found at: <1>https://json.tarkov.dev/endpoints</1>.</1>",
+  "api-json-faq-open-source-p": "The source code for the API can be found here: <1>github.com/the-hideout/tarkov-data-manager</1>.",
+  "api-json-faq-caching-p": "Data is cached until new data is available.",
+  "Localization": "Localization",
+  "Localizations (translations) are available for the languages listed in the languages property of the endpoint response. To request localization strings for a particular request, take the base request url and append an underscore and the language code. For example, for English, append \"_en\".": "Localizations (translations) are available for the languages listed in the languages property of the endpoint response. To request localization strings for a particular request, take the base request url and append an underscore and the language code. For example, for English, append \"_en\".",
+  "Each API response includes a `translations` property containing a list of JSON path strings that can be used with a translation file to localize the base response into a given language.": "Each API response includes a `translations` property containing a list of JSON path strings that can be used with a translation file to localize the base response into a given language.",
+  "Examples of using and localizing responses can be found in our code repositories:": "Examples of using and localizing responses can be found in our code repositories:",
+  "This website": "This website"
 }

--- a/src/translations/ru/translation.json
+++ b/src/translations/ru/translation.json
@@ -752,5 +752,16 @@
   "PMC Kills": "PMC Kills",
   "PMC K:D": "PMC K:D",
   "No hideout stations match filter settings.": "No hideout stations match filter settings.",
-  "Prestige is not available in {{gameMode}} mode.": "Prestige is not available in {{gameMode}} mode."
+  "Prestige is not available in {{gameMode}} mode.": "Prestige is not available in {{gameMode}} mode.",
+  "Tarkov.dev GraphQL Legacy API": "Tarkov.dev GraphQL Legacy API",
+  "api-graphql-maintenance": "<0>The GraphQL API is now considered in maintenance mode. While it will continue to function in its current state, schema changes will not be made.</1>",
+  "api-graphql-json-api": "<0>You ought to use the new <1>JSON API</1> going forward.</0>",
+  "api-json-about-p": "<0>The API serves JSON responses to simple GET requests.</0><1>A list of available endpoints can be found at: <1>https://json.tarkov.dev/endpoints</1>.</1>",
+  "api-json-faq-open-source-p": "The source code for the API can be found here: <1>github.com/the-hideout/tarkov-data-manager</1>.",
+  "api-json-faq-caching-p": "Data is cached until new data is available.",
+  "Localization": "Localization",
+  "Localizations (translations) are available for the languages listed in the languages property of the endpoint response. To request localization strings for a particular request, take the base request url and append an underscore and the language code. For example, for English, append \"_en\".": "Localizations (translations) are available for the languages listed in the languages property of the endpoint response. To request localization strings for a particular request, take the base request url and append an underscore and the language code. For example, for English, append \"_en\".",
+  "Each API response includes a `translations` property containing a list of JSON path strings that can be used with a translation file to localize the base response into a given language.": "Each API response includes a `translations` property containing a list of JSON path strings that can be used with a translation file to localize the base response into a given language.",
+  "Examples of using and localizing responses can be found in our code repositories:": "Examples of using and localizing responses can be found in our code repositories:",
+  "This website": "This website"
 }

--- a/src/translations/zh/translation.json
+++ b/src/translations/zh/translation.json
@@ -739,5 +739,16 @@
   "PMC Kills": "PMC Kills",
   "PMC K:D": "PMC K:D",
   "No hideout stations match filter settings.": "No hideout stations match filter settings.",
-  "Prestige is not available in {{gameMode}} mode.": "Prestige is not available in {{gameMode}} mode."
+  "Prestige is not available in {{gameMode}} mode.": "Prestige is not available in {{gameMode}} mode.",
+  "Tarkov.dev GraphQL Legacy API": "Tarkov.dev GraphQL Legacy API",
+  "api-graphql-maintenance": "<0>The GraphQL API is now considered in maintenance mode. While it will continue to function in its current state, schema changes will not be made.</1>",
+  "api-graphql-json-api": "<0>You ought to use the new <1>JSON API</1> going forward.</0>",
+  "api-json-about-p": "<0>The API serves JSON responses to simple GET requests.</0><1>A list of available endpoints can be found at: <1>https://json.tarkov.dev/endpoints</1>.</1>",
+  "api-json-faq-open-source-p": "The source code for the API can be found here: <1>github.com/the-hideout/tarkov-data-manager</1>.",
+  "api-json-faq-caching-p": "Data is cached until new data is available.",
+  "Localization": "Localization",
+  "Localizations (translations) are available for the languages listed in the languages property of the endpoint response. To request localization strings for a particular request, take the base request url and append an underscore and the language code. For example, for English, append \"_en\".": "Localizations (translations) are available for the languages listed in the languages property of the endpoint response. To request localization strings for a particular request, take the base request url and append an underscore and the language code. For example, for English, append \"_en\".",
+  "Each API response includes a `translations` property containing a list of JSON path strings that can be used with a translation file to localize the base response into a given language.": "Each API response includes a `translations` property containing a list of JSON path strings that can be used with a translation file to localize the base response into a given language.",
+  "Examples of using and localizing responses can be found in our code repositories:": "Examples of using and localizing responses can be found in our code repositories:",
+  "This website": "This website"
 }


### PR DESCRIPTION
Changes the API page to provide info about the JSON API. the information about the graphql API is still available at /api-graphql.