### PR TITLE
Benchmark and improve interactive map performance

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*.jsx]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+max_line_length = 120

--- a/.github/workflows/map-benchmark-comment.yml
+++ b/.github/workflows/map-benchmark-comment.yml
@@ -1,0 +1,63 @@
+name: Map benchmark PR comment
+
+on:
+    workflow_run:
+        workflows: [Map performance benchmark]
+        types: [completed]
+
+permissions:
+    actions: read
+    contents: read
+    pull-requests: write
+
+jobs:
+    comment:
+        if: >-
+            github.event.workflow_run.conclusion == 'success' &&
+            github.event.workflow_run.event == 'pull_request' &&
+            github.event.workflow_run.pull_requests[0]
+        runs-on: ubuntu-latest
+        steps:
+            - name: Download benchmark results
+              uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # pin@v5
+              with:
+                  github-token: ${{ github.token }}
+                  run-id: ${{ github.event.workflow_run.id }}
+                  pattern: map-benchmark-results-*
+                  merge-multiple: true
+                  path: benchmark-results
+
+            - name: Update pull request comment
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # pin@v8
+              env:
+                  PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+              with:
+                  script: |
+                      const fs = require('node:fs');
+                      const marker = '<!-- map-performance-benchmark -->';
+                      const body = fs.readFileSync('benchmark-results/map-benchmark-comment.md', 'utf8');
+                      const issue_number = Number(process.env.PR_NUMBER);
+                      const comments = await github.paginate(github.rest.issues.listComments, {
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number,
+                        per_page: 100,
+                      });
+                      const existing = comments.find((comment) =>
+                        comment.user.type === 'Bot' && comment.body.includes(marker)
+                      );
+                      if (existing) {
+                        await github.rest.issues.updateComment({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          comment_id: existing.id,
+                          body,
+                        });
+                      } else {
+                        await github.rest.issues.createComment({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          issue_number,
+                          body,
+                        });
+                      }

--- a/.github/workflows/map-benchmark.yml
+++ b/.github/workflows/map-benchmark.yml
@@ -4,17 +4,45 @@ on:
     pull_request:
         branches: [main]
         types: [opened, reopened, synchronize, ready_for_review]
+        paths:
+            - .github/workflows/map-benchmark*.yml
+            - package.json
+            - pnpm-lock.yaml
+            - rsbuild.config.ts
+            - scripts/benchmark-maps.mjs
+            - scripts/compare-map-benchmarks.mjs
+            - src/App.jsx
+            - src/store.js
+            - src/data/maps*.json
+            - src/features/items/**
+            - src/features/maps/**
+            - src/features/quests/**
+            - src/features/settings/**
+            - src/modules/api-*.mjs
+            - src/modules/leaflet-*
+            - src/pages/map/**
+            - src/styles/map*.css
+    workflow_dispatch:
+        inputs:
+            base-ref:
+                description: Git ref to use as the benchmark base
+                default: main
+                required: true
+            head-ref:
+                description: Git ref to benchmark against the base
+                default: main
+                required: true
 
 permissions:
     contents: read
 
 concurrency:
-    group: map-benchmark-${{ github.event.pull_request.number }}
+    group: map-benchmark-${{ github.event.pull_request.number || github.run_id }}
     cancel-in-progress: true
 
 jobs:
     benchmark:
-        if: github.event.pull_request.draft == false
+        if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
         runs-on: ubuntu-latest
         timeout-minutes: 45
 
@@ -23,6 +51,7 @@ jobs:
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # pin@v6
               with:
                   fetch-depth: 0
+                  ref: ${{ inputs.head-ref || github.event.pull_request.head.sha }}
 
             - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # pin@v6.0.9
 
@@ -39,9 +68,10 @@ jobs:
 
             - name: Create base worktree
               env:
-                  BASE_SHA: ${{ github.event.pull_request.base.sha }}
+                  BASE_SHA: ${{ inputs.base-ref || github.event.pull_request.base.sha }}
               run: |
-                  git worktree add "$RUNNER_TEMP/map-benchmark-base" "$BASE_SHA"
+                  git fetch origin "$BASE_SHA"
+                  git worktree add "$RUNNER_TEMP/map-benchmark-base" FETCH_HEAD
                   echo "BASE_DIR=$RUNNER_TEMP/map-benchmark-base" >> "$GITHUB_ENV"
 
             - name: Install base dependencies
@@ -80,7 +110,7 @@ jobs:
             - name: Upload benchmark results
               uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # pin@v4
               with:
-                  name: map-benchmark-results-${{ github.event.pull_request.number }}
+                  name: map-benchmark-results-${{ github.event.pull_request.number || github.run_id }}
                   path: |
                       ${{ runner.temp }}/map-benchmark.json
                       ${{ runner.temp }}/map-benchmark-comment.md

--- a/.github/workflows/map-benchmark.yml
+++ b/.github/workflows/map-benchmark.yml
@@ -1,0 +1,94 @@
+name: Map performance benchmark
+
+on:
+    pull_request:
+        branches: [main]
+        types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+    contents: read
+
+concurrency:
+    group: map-benchmark-${{ github.event.pull_request.number }}
+    cancel-in-progress: true
+
+jobs:
+    benchmark:
+        if: github.event.pull_request.draft == false
+        runs-on: ubuntu-latest
+        timeout-minutes: 45
+
+        steps:
+            - name: Checkout pull request
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # pin@v6
+              with:
+                  fetch-depth: 0
+
+            - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # pin@v6.0.9
+
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # pin@v6.4.0
+              with:
+                  node-version-file: .node-version
+                  cache: pnpm
+
+            - name: Install pull request dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Install Chromium
+              run: pnpm exec playwright install --with-deps chromium
+
+            - name: Create base worktree
+              env:
+                  BASE_SHA: ${{ github.event.pull_request.base.sha }}
+              run: |
+                  git worktree add "$RUNNER_TEMP/map-benchmark-base" "$BASE_SHA"
+                  echo "BASE_DIR=$RUNNER_TEMP/map-benchmark-base" >> "$GITHUB_ENV"
+
+            - name: Install base dependencies
+              run: pnpm --dir "$BASE_DIR" install --frozen-lockfile
+
+            - name: Build base
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+                  PUBLIC_URL: ""
+              run: |
+                  pnpm --dir "$BASE_DIR" run prebuild
+                  pnpm --dir "$BASE_DIR" exec rsbuild build
+
+            - name: Benchmark base
+              run: >-
+                  pnpm benchmark:maps --
+                  --build-dir "$BASE_DIR/build"
+                  --output "$RUNNER_TEMP/map-benchmark-base.json"
+
+            - name: Build pull request
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+                  PUBLIC_URL: ""
+              run: |
+                  pnpm run prebuild
+                  pnpm exec rsbuild build
+
+            - name: Benchmark pull request
+              run: >-
+                  pnpm benchmark:maps --
+                  --build-dir build
+                  --output "$RUNNER_TEMP/map-benchmark-head.json"
+
+            - name: Compare results
+              run: |
+                  node scripts/compare-map-benchmarks.mjs \
+                    --base "$RUNNER_TEMP/map-benchmark-base.json" \
+                    --head "$RUNNER_TEMP/map-benchmark-head.json" \
+                    --output "$RUNNER_TEMP/map-benchmark-comment.md"
+                  cat "$RUNNER_TEMP/map-benchmark-comment.md" >> "$GITHUB_STEP_SUMMARY"
+
+            - name: Upload benchmark results
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # pin@v4
+              with:
+                  name: map-benchmark-results-${{ github.event.pull_request.number }}
+                  path: |
+                      ${{ runner.temp }}/map-benchmark-base.json
+                      ${{ runner.temp }}/map-benchmark-head.json
+                      ${{ runner.temp }}/map-benchmark-comment.md
+                  retention-days: 7

--- a/.github/workflows/map-benchmark.yml
+++ b/.github/workflows/map-benchmark.yml
@@ -55,12 +55,6 @@ jobs:
                   pnpm --dir "$BASE_DIR" run prebuild
                   pnpm --dir "$BASE_DIR" exec rsbuild build
 
-            - name: Benchmark base
-              run: >-
-                  pnpm benchmark:maps --
-                  --build-dir "$BASE_DIR/build"
-                  --output "$RUNNER_TEMP/map-benchmark-base.json"
-
             - name: Build pull request
               env:
                   GITHUB_TOKEN: ${{ github.token }}
@@ -69,17 +63,17 @@ jobs:
                   pnpm run prebuild
                   pnpm exec rsbuild build
 
-            - name: Benchmark pull request
+            - name: Benchmark base and pull request
               run: >-
                   pnpm benchmark:maps --
-                  --build-dir build
-                  --output "$RUNNER_TEMP/map-benchmark-head.json"
+                  --base-build-dir "$BASE_DIR/build"
+                  --head-build-dir build
+                  --output "$RUNNER_TEMP/map-benchmark.json"
 
-            - name: Compare results
+            - name: Format results
               run: |
                   node scripts/compare-map-benchmarks.mjs \
-                    --base "$RUNNER_TEMP/map-benchmark-base.json" \
-                    --head "$RUNNER_TEMP/map-benchmark-head.json" \
+                    --input "$RUNNER_TEMP/map-benchmark.json" \
                     --output "$RUNNER_TEMP/map-benchmark-comment.md"
                   cat "$RUNNER_TEMP/map-benchmark-comment.md" >> "$GITHUB_STEP_SUMMARY"
 
@@ -88,7 +82,6 @@ jobs:
               with:
                   name: map-benchmark-results-${{ github.event.pull_request.number }}
                   path: |
-                      ${{ runner.temp }}/map-benchmark-base.json
-                      ${{ runner.temp }}/map-benchmark-head.json
+                      ${{ runner.temp }}/map-benchmark.json
                       ${{ runner.temp }}/map-benchmark-comment.md
                   retention-days: 7

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     },
     "scripts": {
         "analyze": "source-map-explorer 'build/static/js/*.js'",
+        "benchmark:maps": "node scripts/benchmark-maps.mjs",
         "prestart": "pnpm run prebuild",
         "start": "rsbuild dev --open",
         "build": "rsbuild build",
@@ -48,6 +49,7 @@
         "globals": "^17.6.0",
         "husky": "^9.1.7",
         "lint-staged": "^17.0.7",
+        "playwright": "1.62.1",
         "prettier": "^3.8.4",
         "sharp": "^0.35.2",
         "source-map-explorer": "^2.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,6 +195,9 @@ importers:
       lint-staged:
         specifier: ^17.0.7
         version: 17.0.7
+      playwright:
+        specifier: 1.62.1
+        version: 1.62.1
       prettier:
         specifier: ^3.8.4
         version: 3.8.4
@@ -2399,6 +2402,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
@@ -3221,6 +3229,16 @@ packages:
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   plugin-error@2.0.1:
     resolution: {integrity: sha512-zMakqvIDyY40xHOvzXka0kUvf40nYIuwRE8dWhti2WtjQZ31xAgBZBhxsK7vK3QbRXS1Xms/LO7B5cuAsfB2Gg==}
@@ -6644,6 +6662,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   function-bind@1.1.2: {}
 
   fuse.js@7.4.2: {}
@@ -7462,6 +7483,14 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.5: {}
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   plugin-error@2.0.1:
     dependencies:

--- a/scripts/benchmark-maps.mjs
+++ b/scripts/benchmark-maps.mjs
@@ -5,11 +5,12 @@ import process from "node:process";
 import { chromium } from "playwright";
 
 const defaults = {
-    buildDir: "build",
-    cpuThrottle: 4,
+    baseBuildDir: undefined,
+    cpuThrottle: 2,
     executablePath: undefined,
-    iterations: 7,
-    layerIterations: 10,
+    headBuildDir: undefined,
+    iterations: 15,
+    layerIterations: 30,
     map: "streets-of-tarkov",
     output: "map-benchmark.json",
     settleMs: 750,
@@ -18,6 +19,8 @@ const defaults = {
 };
 
 const layerGroups = ["Loose Loot", "Lootable Items", "Tasks"];
+const layerBlockSize = 5;
+const loadMetricKeys = ["mapReadyMs", "markerRenderMs", "longTaskTotalMs", "domNodes", "markerCount"];
 
 function parseArgs(argv) {
     if (argv[0] === "--") {
@@ -25,9 +28,10 @@ function parseArgs(argv) {
     }
     const options = { ...defaults };
     const optionNames = {
-        "--build-dir": "buildDir",
+        "--base-build-dir": "baseBuildDir",
         "--cpu-throttle": "cpuThrottle",
         "--executable-path": "executablePath",
+        "--head-build-dir": "headBuildDir",
         "--iterations": "iterations",
         "--layer-iterations": "layerIterations",
         "--map": "map",
@@ -55,6 +59,9 @@ function parseArgs(argv) {
         options[optionName] = numericOptions.has(optionName) ? Number(value) : value;
     }
 
+    if (!options.baseBuildDir || !options.headBuildDir) {
+        throw new Error("--base-build-dir and --head-build-dir are required");
+    }
     for (const optionName of numericOptions) {
         if (!Number.isFinite(options[optionName]) || options[optionName] < 0) {
             throw new Error(`Invalid numeric option: ${optionName}`);
@@ -107,7 +114,7 @@ async function startStaticServer(buildDir) {
 
             const content = await readFile(filePath);
             response.writeHead(200, {
-                "cache-control": "public, max-age=3600",
+                "cache-control": "no-store",
                 "content-type": mimeType(filePath),
             });
             response.end(content);
@@ -128,8 +135,61 @@ async function startStaticServer(buildDir) {
     };
 }
 
+function requestCacheKey(request) {
+    return [request.method(), request.url(), request.postData() ?? ""].join("\n");
+}
+
+function replayHeaders(headers) {
+    const excluded = new Set(["content-encoding", "content-length", "transfer-encoding"]);
+    return Object.fromEntries(Object.entries(headers).filter(([name]) => !excluded.has(name.toLowerCase())));
+}
+
+async function installNetworkReplay(context, localOrigins) {
+    const responses = new Map();
+    const stats = { recorded: 0, replayed: 0 };
+    let replayOnly = false;
+
+    await context.route("**/*", async (route) => {
+        const request = route.request();
+        if (localOrigins.has(new URL(request.url()).origin)) {
+            await route.continue();
+            return;
+        }
+
+        const key = requestCacheKey(request);
+        const cached = responses.get(key);
+        if (cached) {
+            stats.replayed += 1;
+            await route.fulfill(cached);
+            return;
+        }
+        if (replayOnly) {
+            throw new Error(`Unexpected external request during measured run: ${request.method()} ${request.url()}`);
+        }
+
+        const response = await route.fetch();
+        const body = await response.body();
+        const cachedResponse = {
+            body,
+            headers: replayHeaders(response.headers()),
+            status: response.status(),
+        };
+        responses.set(key, cachedResponse);
+        stats.recorded += 1;
+        await route.fulfill(cachedResponse);
+    });
+
+    return {
+        beginReplay: () => {
+            replayOnly = true;
+        },
+        stats,
+    };
+}
+
 async function installBrowserObservers(page) {
     await page.addInitScript(() => {
+        localStorage.clear();
         const state = {
             firstMarkerMutation: null,
             lastMarkerMutation: null,
@@ -197,33 +257,26 @@ async function waitForMapReady(page, options) {
     return page.evaluate(async () => {
         await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
         const readyAt = performance.now();
-        const navigation = performance.getEntriesByType("navigation")[0];
         const benchmark = window.__mapBenchmark;
         const longTasks = benchmark.longTasks.filter((entry) => entry.startTime <= readyAt);
         return {
-            domContentLoadedMs: navigation.domContentLoadedEventEnd,
             domNodes: document.getElementsByTagName("*").length,
-            longTaskCount: longTasks.length,
             longTaskTotalMs: longTasks.reduce((total, entry) => total + entry.duration, 0),
             mapReadyMs: readyAt,
             markerCount: document.querySelectorAll(".leaflet-marker-icon").length,
             markerRenderMs: benchmark.lastMarkerMutation - benchmark.firstMarkerMutation,
-            responseEndMs: navigation.responseEnd,
         };
     });
 }
 
 async function measureLoad(page, url, options) {
+    await page.bringToFront();
     await page.goto(url, { timeout: options.timeoutMs, waitUntil: "domcontentloaded" });
-    try {
-        await page.waitForLoadState("networkidle", { timeout: 30_000 });
-    } catch {
-        // Marker stability below is the authoritative readiness signal.
-    }
     return waitForMapReady(page, options);
 }
 
 async function measureLayerToggle(page, group) {
+    await page.bringToFront();
     return page.evaluate(async (groupKey) => {
         const input = [...document.querySelectorAll(".leaflet-control-layers-group-selector")].find(
             (element) => element.dataset.key === groupKey,
@@ -260,13 +313,29 @@ function summarize(values) {
 }
 
 function summarizeLoads(loads) {
-    const keys = ["mapReadyMs", "markerRenderMs", "longTaskTotalMs", "domNodes", "markerCount"];
-    return Object.fromEntries(keys.map((key) => [key, summarize(loads.map((load) => load[key]))]));
+    return Object.fromEntries(loadMetricKeys.map((key) => [key, summarize(loads.map((load) => load[key]))]));
+}
+
+function alternatingOrder(index) {
+    return index % 2 === 0 ? ["base", "head"] : ["head", "base"];
+}
+
+async function createMeasuredPage(context, cpuThrottle) {
+    const page = await context.newPage();
+    await installBrowserObservers(page);
+    if (cpuThrottle > 1) {
+        const session = await context.newCDPSession(page);
+        await session.send("Emulation.setCPUThrottlingRate", { rate: cpuThrottle });
+    }
+    return page;
 }
 
 async function main() {
     const options = parseArgs(process.argv.slice(2));
-    const server = await startStaticServer(options.buildDir);
+    const [baseServer, headServer] = await Promise.all([
+        startStaticServer(options.baseBuildDir),
+        startStaticServer(options.headBuildDir),
+    ]);
     const browser = await chromium.launch({
         executablePath: options.executablePath,
         headless: true,
@@ -274,66 +343,89 @@ async function main() {
 
     try {
         const context = await browser.newContext({ viewport: { height: 1000, width: 1440 } });
-        const page = await context.newPage();
-        await installBrowserObservers(page);
+        const page = await createMeasuredPage(context, options.cpuThrottle);
+        const versions = {
+            base: {
+                url: `${baseServer.url}/map/${options.map}`,
+            },
+            head: {
+                url: `${headServer.url}/map/${options.map}`,
+            },
+        };
+        const networkReplay = await installNetworkReplay(
+            context,
+            new Set([new URL(baseServer.url).origin, new URL(headServer.url).origin]),
+        );
 
-        if (options.cpuThrottle > 1) {
-            const session = await context.newCDPSession(page);
-            await session.send("Emulation.setCPUThrottlingRate", { rate: options.cpuThrottle });
+        const diagnosticFirstLoads = {};
+        for (const version of ["base", "head"]) {
+            diagnosticFirstLoads[version] = await measureLoad(page, versions[version].url, options);
         }
-
-        const url = `${server.url}/map/${options.map}`;
-        const coldLoad = await measureLoad(page, url, options);
-        for (let index = 0; index < options.warmups; index += 1) {
-            await measureLoad(page, url, options);
+        for (let index = 1; index < options.warmups; index += 1) {
+            for (const version of alternatingOrder(index)) {
+                await measureLoad(page, versions[version].url, options);
+            }
         }
+        networkReplay.beginReplay();
 
-        const warmLoads = [];
+        const warmLoads = { base: [], head: [] };
         for (let index = 0; index < options.iterations; index += 1) {
-            warmLoads.push(await measureLoad(page, url, options));
+            for (const version of alternatingOrder(index)) {
+                const target = versions[version];
+                warmLoads[version].push(await measureLoad(page, target.url, options));
+            }
         }
 
         const layerToggles = {};
         for (const group of layerGroups) {
-            const hide = [];
-            const show = [];
-            for (let index = 0; index < options.layerIterations; index += 1) {
-                const hidden = await measureLayerToggle(page, group);
-                const shown = await measureLayerToggle(page, group);
-                if (hidden.visible || !shown.visible) {
-                    throw new Error(`Unexpected toggle state for layer group: ${group}`);
-                }
-                hide.push(hidden);
-                show.push(shown);
-            }
             layerToggles[group] = {
-                hide,
-                hideSummary: summarize(hide.map((sample) => sample.durationMs)),
-                show,
-                showSummary: summarize(show.map((sample) => sample.durationMs)),
+                base: { hide: [], show: [] },
+                head: { hide: [], show: [] },
             };
+            for (let blockStart = 0; blockStart < options.layerIterations; blockStart += layerBlockSize) {
+                const blockIndex = blockStart / layerBlockSize;
+                const blockLength = Math.min(layerBlockSize, options.layerIterations - blockStart);
+                for (const version of alternatingOrder(blockIndex)) {
+                    await measureLoad(page, versions[version].url, options);
+                    const samples = layerToggles[group][version];
+                    for (let index = 0; index < blockLength; index += 1) {
+                        const hidden = await measureLayerToggle(page, group);
+                        const shown = await measureLayerToggle(page, group);
+                        if (hidden.visible || !shown.visible) {
+                            throw new Error(`Unexpected toggle state for ${version} ${group}`);
+                        }
+                        samples.hide.push(hidden);
+                        samples.show.push(shown);
+                    }
+                }
+            }
         }
 
         const result = {
-            coldLoad,
+            diagnosticFirstLoads,
             generatedAt: new Date().toISOString(),
             layerToggles,
             map: options.map,
+            networkReplay: networkReplay.stats,
             options: {
                 cpuThrottle: options.cpuThrottle,
                 iterations: options.iterations,
+                layerBlockSize,
                 layerIterations: options.layerIterations,
                 settleMs: options.settleMs,
                 warmups: options.warmups,
             },
-            warmLoadSummary: summarizeLoads(warmLoads),
+            warmLoadSummary: {
+                base: summarizeLoads(warmLoads.base),
+                head: summarizeLoads(warmLoads.head),
+            },
             warmLoads,
         };
         await writeFile(options.output, `${JSON.stringify(result, null, 2)}\n`);
         console.log(JSON.stringify(result, null, 2));
     } finally {
         await browser.close();
-        await server.close();
+        await Promise.all([baseServer.close(), headServer.close()]);
     }
 }
 

--- a/scripts/benchmark-maps.mjs
+++ b/scripts/benchmark-maps.mjs
@@ -144,9 +144,63 @@ function replayHeaders(headers) {
     return Object.fromEntries(Object.entries(headers).filter(([name]) => !excluded.has(name.toLowerCase())));
 }
 
+const delay = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+function createConcurrencyLimiter(limit) {
+    const waiting = [];
+    let active = 0;
+
+    const release = () => {
+        active -= 1;
+        waiting.shift()?.();
+    };
+    return async (operation) => {
+        if (active >= limit) {
+            await new Promise((resolve) => waiting.push(resolve));
+        }
+        active += 1;
+        try {
+            return await operation();
+        } finally {
+            release();
+        }
+    };
+}
+
+async function fetchExternalResponse(route) {
+    const request = route.request();
+    const attempts = request.resourceType() === "fetch" || request.resourceType() === "xhr" ? 3 : 1;
+    let response;
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+        try {
+            response = await route.fetch({ timeout: 60_000 });
+        } catch (error) {
+            console.error(
+                `External request error (${attempt}/${attempts}): ${request.method()} ${request.url()} (${error.message})`,
+            );
+            if (attempt === attempts) {
+                throw error;
+            }
+            await delay(attempt * 5_000);
+            continue;
+        }
+        if (response.status() < 400) {
+            return response;
+        }
+        console.error(
+            `External request failed (${attempt}/${attempts}): ${response.status()} ${request.method()} ${request.url()}`,
+        );
+        if (attempt < attempts) {
+            await delay(attempt * 5_000);
+        }
+    }
+    return response;
+}
+
 async function installNetworkReplay(context, localOrigins) {
     const responses = new Map();
     const stats = { recorded: 0, replayed: 0 };
+    const limitApiRequests = createConcurrencyLimiter(4);
     let replayOnly = false;
 
     await context.route("**/*", async (route) => {
@@ -167,14 +221,20 @@ async function installNetworkReplay(context, localOrigins) {
             throw new Error(`Unexpected external request during measured run: ${request.method()} ${request.url()}`);
         }
 
-        const response = await route.fetch();
+        const fetchResponse = () => fetchExternalResponse(route);
+        const response =
+            new URL(request.url()).hostname === "json.tarkov.dev"
+                ? await limitApiRequests(fetchResponse)
+                : await fetchResponse();
         const body = await response.body();
         const cachedResponse = {
             body,
             headers: replayHeaders(response.headers()),
             status: response.status(),
         };
-        responses.set(key, cachedResponse);
+        if (response.status() < 400) {
+            responses.set(key, cachedResponse);
+        }
         stats.recorded += 1;
         await route.fulfill(cachedResponse);
     });
@@ -275,6 +335,24 @@ async function measureLoad(page, url, options) {
     return waitForMapReady(page, options);
 }
 
+async function measureInitialLoad(page, url, options, label) {
+    const attempts = 3;
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+        try {
+            return await measureLoad(page, url, {
+                ...options,
+                timeoutMs: Math.min(options.timeoutMs, 45_000),
+            });
+        } catch (error) {
+            console.error(`Initial ${label} load failed (${attempt}/${attempts}): ${error.message}`);
+            if (attempt === attempts) {
+                throw error;
+            }
+            await delay(attempt * 5_000);
+        }
+    }
+}
+
 async function measureLayerToggle(page, group) {
     await page.bringToFront();
     return page.evaluate(async (groupKey) => {
@@ -322,6 +400,17 @@ function alternatingOrder(index) {
 
 async function createMeasuredPage(context, cpuThrottle) {
     const page = await context.newPage();
+    page.on("console", (message) => {
+        if (message.type() === "error") {
+            console.error(`Browser console: ${message.text()}`);
+        }
+    });
+    page.on("pageerror", (error) => {
+        console.error(`Browser page error: ${error.stack ?? error.message}`);
+    });
+    page.on("requestfailed", (request) => {
+        console.error(`Browser request failed: ${request.method()} ${request.url()} (${request.failure()?.errorText})`);
+    });
     await installBrowserObservers(page);
     if (cpuThrottle > 1) {
         const session = await context.newCDPSession(page);
@@ -359,7 +448,7 @@ async function main() {
 
         const diagnosticFirstLoads = {};
         for (const version of ["base", "head"]) {
-            diagnosticFirstLoads[version] = await measureLoad(page, versions[version].url, options);
+            diagnosticFirstLoads[version] = await measureInitialLoad(page, versions[version].url, options, version);
         }
         for (let index = 1; index < options.warmups; index += 1) {
             for (const version of alternatingOrder(index)) {

--- a/scripts/benchmark-maps.mjs
+++ b/scripts/benchmark-maps.mjs
@@ -1,0 +1,340 @@
+import { createServer } from "node:http";
+import { readFile, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { chromium } from "playwright";
+
+const defaults = {
+    buildDir: "build",
+    cpuThrottle: 4,
+    executablePath: undefined,
+    iterations: 7,
+    layerIterations: 10,
+    map: "streets-of-tarkov",
+    output: "map-benchmark.json",
+    settleMs: 750,
+    timeoutMs: 120_000,
+    warmups: 2,
+};
+
+const layerGroups = ["Loose Loot", "Lootable Items", "Tasks"];
+
+function parseArgs(argv) {
+    if (argv[0] === "--") {
+        argv = argv.slice(1);
+    }
+    const options = { ...defaults };
+    const optionNames = {
+        "--build-dir": "buildDir",
+        "--cpu-throttle": "cpuThrottle",
+        "--executable-path": "executablePath",
+        "--iterations": "iterations",
+        "--layer-iterations": "layerIterations",
+        "--map": "map",
+        "--output": "output",
+        "--settle-ms": "settleMs",
+        "--timeout-ms": "timeoutMs",
+        "--warmups": "warmups",
+    };
+    const numericOptions = new Set([
+        "cpuThrottle",
+        "iterations",
+        "layerIterations",
+        "settleMs",
+        "timeoutMs",
+        "warmups",
+    ]);
+
+    for (let index = 0; index < argv.length; index += 2) {
+        const argument = argv[index];
+        const optionName = optionNames[argument];
+        const value = argv[index + 1];
+        if (!optionName || value === undefined) {
+            throw new Error(`Unknown or incomplete argument: ${argument}`);
+        }
+        options[optionName] = numericOptions.has(optionName) ? Number(value) : value;
+    }
+
+    for (const optionName of numericOptions) {
+        if (!Number.isFinite(options[optionName]) || options[optionName] < 0) {
+            throw new Error(`Invalid numeric option: ${optionName}`);
+        }
+    }
+    return options;
+}
+
+function mimeType(filePath) {
+    const extension = path.extname(filePath);
+    return (
+        {
+            ".css": "text/css",
+            ".gif": "image/gif",
+            ".html": "text/html",
+            ".ico": "image/x-icon",
+            ".jpg": "image/jpeg",
+            ".js": "text/javascript",
+            ".json": "application/json",
+            ".map": "application/json",
+            ".png": "image/png",
+            ".svg": "image/svg+xml",
+            ".webp": "image/webp",
+        }[extension] ?? "application/octet-stream"
+    );
+}
+
+async function startStaticServer(buildDir) {
+    const root = path.resolve(buildDir);
+    const indexPath = path.join(root, "index.html");
+    await stat(indexPath);
+
+    const server = createServer(async (request, response) => {
+        try {
+            const requestPath = decodeURIComponent(new URL(request.url, "http://localhost").pathname);
+            const relativePath = requestPath.replace(/^\/+/, "");
+            let filePath = path.resolve(root, relativePath);
+            if (!filePath.startsWith(`${root}${path.sep}`) && filePath !== root) {
+                response.writeHead(403).end();
+                return;
+            }
+
+            try {
+                if ((await stat(filePath)).isDirectory()) {
+                    filePath = path.join(filePath, "index.html");
+                }
+            } catch {
+                filePath = indexPath;
+            }
+
+            const content = await readFile(filePath);
+            response.writeHead(200, {
+                "cache-control": "public, max-age=3600",
+                "content-type": mimeType(filePath),
+            });
+            response.end(content);
+        } catch (error) {
+            response.writeHead(500, { "content-type": "text/plain" });
+            response.end(error.message);
+        }
+    });
+
+    await new Promise((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    return {
+        close: () => new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve()))),
+        url: `http://127.0.0.1:${address.port}`,
+    };
+}
+
+async function installBrowserObservers(page) {
+    await page.addInitScript(() => {
+        const state = {
+            firstMarkerMutation: null,
+            lastMarkerMutation: null,
+            longTasks: [],
+        };
+        window.__mapBenchmark = state;
+
+        const containsMarker = (node) =>
+            node instanceof Element &&
+            (node.matches(".leaflet-marker-icon, .leaflet-marker-shadow") ||
+                node.querySelector(".leaflet-marker-icon, .leaflet-marker-shadow"));
+
+        const observeMarkers = () => {
+            const observer = new MutationObserver((records) => {
+                const changed = records.some((record) =>
+                    [...record.addedNodes, ...record.removedNodes].some(containsMarker),
+                );
+                if (!changed) {
+                    return;
+                }
+                const now = performance.now();
+                state.firstMarkerMutation ??= now;
+                state.lastMarkerMutation = now;
+            });
+            observer.observe(document.documentElement, { childList: true, subtree: true });
+        };
+
+        if (document.documentElement) {
+            observeMarkers();
+        } else {
+            document.addEventListener("DOMContentLoaded", observeMarkers, { once: true });
+        }
+
+        try {
+            const longTaskObserver = new PerformanceObserver((list) => {
+                state.longTasks.push(...list.getEntries().map(({ startTime, duration }) => ({ startTime, duration })));
+            });
+            longTaskObserver.observe({ type: "longtask", buffered: true });
+        } catch {
+            // Long-task entries are unavailable in some Chromium configurations.
+        }
+    });
+}
+
+async function waitForMapReady(page, options) {
+    await page.waitForSelector("#leaflet-map.leaflet-container", { timeout: options.timeoutMs });
+    await page.waitForFunction(
+        ({ groups, settleMs }) => {
+            const benchmark = window.__mapBenchmark;
+            const availableGroups = new Set(
+                [...document.querySelectorAll(".leaflet-control-layers-group-selector")].map(
+                    (element) => element.dataset.key,
+                ),
+            );
+            return (
+                benchmark?.lastMarkerMutation !== null &&
+                performance.now() - benchmark.lastMarkerMutation >= settleMs &&
+                groups.every((group) => availableGroups.has(group))
+            );
+        },
+        { groups: layerGroups, settleMs: options.settleMs },
+        { timeout: options.timeoutMs, polling: 100 },
+    );
+
+    return page.evaluate(async () => {
+        await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+        const readyAt = performance.now();
+        const navigation = performance.getEntriesByType("navigation")[0];
+        const benchmark = window.__mapBenchmark;
+        const longTasks = benchmark.longTasks.filter((entry) => entry.startTime <= readyAt);
+        return {
+            domContentLoadedMs: navigation.domContentLoadedEventEnd,
+            domNodes: document.getElementsByTagName("*").length,
+            longTaskCount: longTasks.length,
+            longTaskTotalMs: longTasks.reduce((total, entry) => total + entry.duration, 0),
+            mapReadyMs: readyAt,
+            markerCount: document.querySelectorAll(".leaflet-marker-icon").length,
+            markerRenderMs: benchmark.lastMarkerMutation - benchmark.firstMarkerMutation,
+            responseEndMs: navigation.responseEnd,
+        };
+    });
+}
+
+async function measureLoad(page, url, options) {
+    await page.goto(url, { timeout: options.timeoutMs, waitUntil: "domcontentloaded" });
+    try {
+        await page.waitForLoadState("networkidle", { timeout: 30_000 });
+    } catch {
+        // Marker stability below is the authoritative readiness signal.
+    }
+    return waitForMapReady(page, options);
+}
+
+async function measureLayerToggle(page, group) {
+    return page.evaluate(async (groupKey) => {
+        const input = [...document.querySelectorAll(".leaflet-control-layers-group-selector")].find(
+            (element) => element.dataset.key === groupKey,
+        );
+        if (!input) {
+            throw new Error(`Layer group not found: ${groupKey}`);
+        }
+
+        const markerCountBefore = document.querySelectorAll(".leaflet-marker-icon").length;
+        const startedAt = performance.now();
+        input.click();
+        await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+        return {
+            durationMs: performance.now() - startedAt,
+            markerDelta: document.querySelectorAll(".leaflet-marker-icon").length - markerCountBefore,
+            visible: input.checked,
+        };
+    }, group);
+}
+
+function percentile(values, percentileValue) {
+    if (values.length === 0) {
+        return 0;
+    }
+    const sorted = [...values].sort((left, right) => left - right);
+    return sorted[Math.ceil((percentileValue / 100) * sorted.length) - 1];
+}
+
+function summarize(values) {
+    return {
+        median: percentile(values, 50),
+        p95: percentile(values, 95),
+    };
+}
+
+function summarizeLoads(loads) {
+    const keys = ["mapReadyMs", "markerRenderMs", "longTaskTotalMs", "domNodes", "markerCount"];
+    return Object.fromEntries(keys.map((key) => [key, summarize(loads.map((load) => load[key]))]));
+}
+
+async function main() {
+    const options = parseArgs(process.argv.slice(2));
+    const server = await startStaticServer(options.buildDir);
+    const browser = await chromium.launch({
+        executablePath: options.executablePath,
+        headless: true,
+    });
+
+    try {
+        const context = await browser.newContext({ viewport: { height: 1000, width: 1440 } });
+        const page = await context.newPage();
+        await installBrowserObservers(page);
+
+        if (options.cpuThrottle > 1) {
+            const session = await context.newCDPSession(page);
+            await session.send("Emulation.setCPUThrottlingRate", { rate: options.cpuThrottle });
+        }
+
+        const url = `${server.url}/map/${options.map}`;
+        const coldLoad = await measureLoad(page, url, options);
+        for (let index = 0; index < options.warmups; index += 1) {
+            await measureLoad(page, url, options);
+        }
+
+        const warmLoads = [];
+        for (let index = 0; index < options.iterations; index += 1) {
+            warmLoads.push(await measureLoad(page, url, options));
+        }
+
+        const layerToggles = {};
+        for (const group of layerGroups) {
+            const hide = [];
+            const show = [];
+            for (let index = 0; index < options.layerIterations; index += 1) {
+                const hidden = await measureLayerToggle(page, group);
+                const shown = await measureLayerToggle(page, group);
+                if (hidden.visible || !shown.visible) {
+                    throw new Error(`Unexpected toggle state for layer group: ${group}`);
+                }
+                hide.push(hidden);
+                show.push(shown);
+            }
+            layerToggles[group] = {
+                hide,
+                hideSummary: summarize(hide.map((sample) => sample.durationMs)),
+                show,
+                showSummary: summarize(show.map((sample) => sample.durationMs)),
+            };
+        }
+
+        const result = {
+            coldLoad,
+            generatedAt: new Date().toISOString(),
+            layerToggles,
+            map: options.map,
+            options: {
+                cpuThrottle: options.cpuThrottle,
+                iterations: options.iterations,
+                layerIterations: options.layerIterations,
+                settleMs: options.settleMs,
+                warmups: options.warmups,
+            },
+            warmLoadSummary: summarizeLoads(warmLoads),
+            warmLoads,
+        };
+        await writeFile(options.output, `${JSON.stringify(result, null, 2)}\n`);
+        console.log(JSON.stringify(result, null, 2));
+    } finally {
+        await browser.close();
+        await server.close();
+    }
+}
+
+await main();

--- a/scripts/compare-map-benchmarks.mjs
+++ b/scripts/compare-map-benchmarks.mjs
@@ -1,15 +1,81 @@
 import { readFile, writeFile } from "node:fs/promises";
 import process from "node:process";
 
+const noiseBandPercent = 10;
+const bootstrapIterations = 10_000;
+const minimumIndependentSamples = 5;
+
 function parseArgs(argv) {
     const options = {};
     for (let index = 0; index < argv.length; index += 2) {
         options[argv[index].replace(/^--/, "")] = argv[index + 1];
     }
-    if (!options.base || !options.head || !options.output) {
-        throw new Error("Usage: compare-map-benchmarks.mjs --base BASE.json --head HEAD.json --output OUTPUT.md");
+    if (!options.input || !options.output) {
+        throw new Error("Usage: compare-map-benchmarks.mjs --input RESULTS.json --output OUTPUT.md");
     }
     return options;
+}
+
+function percentile(values, percentileValue) {
+    const sorted = [...values].sort((left, right) => left - right);
+    return sorted[Math.ceil((percentileValue / 100) * sorted.length) - 1];
+}
+
+function median(values) {
+    return percentile(values, 50);
+}
+
+function pairedDeltas(base, head) {
+    if (base.length !== head.length) {
+        throw new Error(`Paired sample counts differ: ${base.length} base, ${head.length} head`);
+    }
+    return base.map((baseValue, index) => ((head[index] - baseValue) / baseValue) * 100);
+}
+
+function createRandom(seed) {
+    return () => {
+        seed = (1664525 * seed + 1013904223) >>> 0;
+        return seed / 2 ** 32;
+    };
+}
+
+function bootstrapMedianConfidenceInterval(values) {
+    const random = createRandom(0x5eed1234);
+    const medians = [];
+    for (let iteration = 0; iteration < bootstrapIterations; iteration += 1) {
+        const sample = [];
+        for (let index = 0; index < values.length; index += 1) {
+            sample.push(values[Math.floor(random() * values.length)]);
+        }
+        medians.push(median(sample));
+    }
+    return [percentile(medians, 2.5), percentile(medians, 97.5)];
+}
+
+function pairedChange(base, head, blockSize = 1) {
+    const deltas = pairedDeltas(base, head);
+    const independentDeltas = [];
+    for (let index = 0; index < deltas.length; index += blockSize) {
+        independentDeltas.push(median(deltas.slice(index, index + blockSize)));
+    }
+    const medianDelta = median(independentDeltas);
+    const [low, high] = bootstrapMedianConfidenceInterval(independentDeltas);
+    let status = "within noise";
+    if (
+        independentDeltas.length >= minimumIndependentSamples &&
+        Math.abs(medianDelta) >= noiseBandPercent &&
+        high < 0
+    ) {
+        status = "faster";
+    } else if (
+        independentDeltas.length >= minimumIndependentSamples &&
+        Math.abs(medianDelta) >= noiseBandPercent &&
+        low > 0
+    ) {
+        status = "slower";
+    }
+    const sign = (value) => `${value >= 0 ? "+" : ""}${value.toFixed(1)}%`;
+    return `${status}: ${sign(medianDelta)} (95% CI ${sign(low)} to ${sign(high)})`;
 }
 
 function formatMilliseconds(value) {
@@ -20,58 +86,38 @@ function formatCount(value) {
     return Math.round(value).toLocaleString("en-US");
 }
 
-function change(base, head) {
-    const difference = head - base;
-    const percent = base === 0 ? 0 : (difference / base) * 100;
-    const direction = difference < 0 ? "faster" : difference > 0 ? "slower" : "unchanged";
-    return `${direction}: ${difference >= 0 ? "+" : ""}${difference.toFixed(1)} (${percent >= 0 ? "+" : ""}${percent.toFixed(1)}%)`;
-}
-
-function metricRow(name, base, head, formatter = formatMilliseconds) {
-    return `| ${name} | ${formatter(base)} | ${formatter(head)} | ${change(base, head)} |`;
+function metricRow(name, base, head, formatter = formatMilliseconds, blockSize = 1) {
+    return `| ${name} | ${formatter(median(base))} | ${formatter(median(head))} | ${pairedChange(base, head, blockSize)} |`;
 }
 
 const options = parseArgs(process.argv.slice(2));
-const base = JSON.parse(await readFile(options.base, "utf8"));
-const head = JSON.parse(await readFile(options.head, "utf8"));
+const result = JSON.parse(await readFile(options.input, "utf8"));
+const loadValues = (version, key) => result.warmLoads[version].map((sample) => sample[key]);
+const toggleValues = (group, version, action) =>
+    result.layerToggles[group][version][action].map((sample) => sample.durationMs);
 
 const rows = [
-    metricRow("Cold map ready", base.coldLoad.mapReadyMs, head.coldLoad.mapReadyMs),
-    metricRow(
-        "Warm map ready (median)",
-        base.warmLoadSummary.mapReadyMs.median,
-        head.warmLoadSummary.mapReadyMs.median,
-    ),
-    metricRow("Warm map ready (p95)", base.warmLoadSummary.mapReadyMs.p95, head.warmLoadSummary.mapReadyMs.p95),
-    metricRow(
-        "Marker render span (median)",
-        base.warmLoadSummary.markerRenderMs.median,
-        head.warmLoadSummary.markerRenderMs.median,
-    ),
-    metricRow(
-        "Long-task time (median)",
-        base.warmLoadSummary.longTaskTotalMs.median,
-        head.warmLoadSummary.longTaskTotalMs.median,
-    ),
-    metricRow(
-        "Rendered markers (median)",
-        base.warmLoadSummary.markerCount.median,
-        head.warmLoadSummary.markerCount.median,
-        formatCount,
-    ),
+    metricRow("Warm map ready", loadValues("base", "mapReadyMs"), loadValues("head", "mapReadyMs")),
+    metricRow("Marker render span", loadValues("base", "markerRenderMs"), loadValues("head", "markerRenderMs")),
+    metricRow("Long-task time", loadValues("base", "longTaskTotalMs"), loadValues("head", "longTaskTotalMs")),
+    metricRow("Rendered markers", loadValues("base", "markerCount"), loadValues("head", "markerCount"), formatCount),
 ];
 
-for (const group of Object.keys(head.layerToggles)) {
+for (const group of Object.keys(result.layerToggles)) {
     rows.push(
         metricRow(
-            `${group}: hide (median)`,
-            base.layerToggles[group].hideSummary.median,
-            head.layerToggles[group].hideSummary.median,
+            `${group}: hide`,
+            toggleValues(group, "base", "hide"),
+            toggleValues(group, "head", "hide"),
+            formatMilliseconds,
+            result.options.layerBlockSize,
         ),
         metricRow(
-            `${group}: show (median)`,
-            base.layerToggles[group].showSummary.median,
-            head.layerToggles[group].showSummary.median,
+            `${group}: show`,
+            toggleValues(group, "base", "show"),
+            toggleValues(group, "head", "show"),
+            formatMilliseconds,
+            result.options.layerBlockSize,
         ),
     );
 }
@@ -79,18 +125,26 @@ for (const group of Object.keys(head.layerToggles)) {
 const markdown = `<!-- map-performance-benchmark -->
 ## Streets of Tarkov map benchmark
 
-| Metric | Base | PR | Change |
-| --- | ---: | ---: | ---: |
+| Metric | Base median | PR median | Paired change |
+| --- | ---: | ---: | --- |
 ${rows.join("\n")}
+
+Changes are classified only when the paired median is at least ${noiseBandPercent}%, its 95% bootstrap confidence interval excludes zero, and at least ${minimumIndependentSamples} independent samples or blocks exist.
 
 <details>
 <summary>Methodology</summary>
 
-- Chromium with ${head.options.cpuThrottle}x CPU throttling at a 1440x1000 viewport
-- ${head.options.iterations} warm-load samples after ${head.options.warmups} warmups
-- ${head.options.layerIterations} hide/show samples per layer group
-- Map readiness requires marker mutations to settle for ${head.options.settleMs} ms, followed by two animation frames
-- Negative timing changes are improvements; results are diagnostic and do not fail the PR
+- Base and PR production builds run simultaneously in one Chromium process
+- External API and map responses are recorded during warmup, then replayed identically with unexpected network requests blocked
+- One foreground page is shared by both revisions to avoid background-tab throttling
+- Load samples alternate base/PR order; layer samples alternate in blocks of ${result.options.layerBlockSize} to distribute runner drift
+- Chromium uses ${result.options.cpuThrottle}x CPU throttling at a 1440x1000 viewport
+- ${result.options.iterations} paired warm-load samples after ${result.options.warmups} warmups
+- ${result.options.layerIterations} paired hide/show samples per layer group
+- Layer confidence intervals resample block medians so correlated toggles are not treated as independent observations
+- Map readiness requires marker mutations to settle for ${result.options.settleMs} ms, followed by two animation frames
+- First-load timings remain in the downloadable artifact for diagnostics but are not compared
+- Results are diagnostic and do not fail the PR
 
 </details>
 `;

--- a/scripts/compare-map-benchmarks.mjs
+++ b/scripts/compare-map-benchmarks.mjs
@@ -1,0 +1,99 @@
+import { readFile, writeFile } from "node:fs/promises";
+import process from "node:process";
+
+function parseArgs(argv) {
+    const options = {};
+    for (let index = 0; index < argv.length; index += 2) {
+        options[argv[index].replace(/^--/, "")] = argv[index + 1];
+    }
+    if (!options.base || !options.head || !options.output) {
+        throw new Error("Usage: compare-map-benchmarks.mjs --base BASE.json --head HEAD.json --output OUTPUT.md");
+    }
+    return options;
+}
+
+function formatMilliseconds(value) {
+    return `${value.toFixed(1)} ms`;
+}
+
+function formatCount(value) {
+    return Math.round(value).toLocaleString("en-US");
+}
+
+function change(base, head) {
+    const difference = head - base;
+    const percent = base === 0 ? 0 : (difference / base) * 100;
+    const direction = difference < 0 ? "faster" : difference > 0 ? "slower" : "unchanged";
+    return `${direction}: ${difference >= 0 ? "+" : ""}${difference.toFixed(1)} (${percent >= 0 ? "+" : ""}${percent.toFixed(1)}%)`;
+}
+
+function metricRow(name, base, head, formatter = formatMilliseconds) {
+    return `| ${name} | ${formatter(base)} | ${formatter(head)} | ${change(base, head)} |`;
+}
+
+const options = parseArgs(process.argv.slice(2));
+const base = JSON.parse(await readFile(options.base, "utf8"));
+const head = JSON.parse(await readFile(options.head, "utf8"));
+
+const rows = [
+    metricRow("Cold map ready", base.coldLoad.mapReadyMs, head.coldLoad.mapReadyMs),
+    metricRow(
+        "Warm map ready (median)",
+        base.warmLoadSummary.mapReadyMs.median,
+        head.warmLoadSummary.mapReadyMs.median,
+    ),
+    metricRow("Warm map ready (p95)", base.warmLoadSummary.mapReadyMs.p95, head.warmLoadSummary.mapReadyMs.p95),
+    metricRow(
+        "Marker render span (median)",
+        base.warmLoadSummary.markerRenderMs.median,
+        head.warmLoadSummary.markerRenderMs.median,
+    ),
+    metricRow(
+        "Long-task time (median)",
+        base.warmLoadSummary.longTaskTotalMs.median,
+        head.warmLoadSummary.longTaskTotalMs.median,
+    ),
+    metricRow(
+        "Rendered markers (median)",
+        base.warmLoadSummary.markerCount.median,
+        head.warmLoadSummary.markerCount.median,
+        formatCount,
+    ),
+];
+
+for (const group of Object.keys(head.layerToggles)) {
+    rows.push(
+        metricRow(
+            `${group}: hide (median)`,
+            base.layerToggles[group].hideSummary.median,
+            head.layerToggles[group].hideSummary.median,
+        ),
+        metricRow(
+            `${group}: show (median)`,
+            base.layerToggles[group].showSummary.median,
+            head.layerToggles[group].showSummary.median,
+        ),
+    );
+}
+
+const markdown = `<!-- map-performance-benchmark -->
+## Streets of Tarkov map benchmark
+
+| Metric | Base | PR | Change |
+| --- | ---: | ---: | ---: |
+${rows.join("\n")}
+
+<details>
+<summary>Methodology</summary>
+
+- Chromium with ${head.options.cpuThrottle}x CPU throttling at a 1440x1000 viewport
+- ${head.options.iterations} warm-load samples after ${head.options.warmups} warmups
+- ${head.options.layerIterations} hide/show samples per layer group
+- Map readiness requires marker mutations to settle for ${head.options.settleMs} ms, followed by two animation frames
+- Negative timing changes are improvements; results are diagnostic and do not fail the PR
+
+</details>
+`;
+
+await writeFile(options.output, markdown);
+console.log(markdown);

--- a/src/pages/map/index.jsx
+++ b/src/pages/map/index.jsx
@@ -278,7 +278,7 @@ function addElevation(item, popup) {
     }
 }
 
-function Map() {
+function TarkovMap() {
     let { currentMap } = useParams();
     const [searchParams] = useSearchParams();
 
@@ -384,6 +384,14 @@ function Map() {
     const { data: items } = useItemsData();
     const { data: quests } = useQuestsData();
     const { data: handbook } = useHandbookData();
+    const indexedItemsById = useMemo(
+        () => new Map(items.map((item, order) => [item.id, { item, order }])),
+        [items],
+    );
+    const handbookCategoriesById = useMemo(
+        () => new Map(handbook.handbookCategories.map((category) => [category.id, category])),
+        [handbook.handbookCategories],
+    );
 
     let allMaps = useMapImages();
 
@@ -1971,7 +1979,7 @@ function Map() {
         if (mapData.locks.length > 0) {
             const locks = L.layerGroup();
             for (const lock of mapData.locks) {
-                const key = items.find((i) => i.id === lock.key.id);
+                const key = indexedItemsById.get(lock.key.id)?.item;
                 if (!key) {
                     continue;
                 }
@@ -2036,7 +2044,11 @@ function Map() {
                 if (!positionIsInBounds(looseLoot.position)) {
                     continue;
                 }
-                const lootItems = items.filter((item) => looseLoot.items.some((lootItem) => item.id === lootItem.id));
+                const lootItems = [...new Set(looseLoot.items.map((lootItem) => lootItem.id))]
+                    .map((itemId) => indexedItemsById.get(itemId))
+                    .filter(Boolean)
+                    .sort((left, right) => left.order - right.order)
+                    .map(({ item }) => item);
                 if (lootItems.length === 0) {
                     continue;
                 }
@@ -2045,7 +2057,7 @@ function Map() {
                 let markerTitle = t("Loose Loot");
                 let className = "";
                 const markerCategories = lootItems.reduce((markerCategories, item) => {
-                    const category = handbook.handbookCategories.find((c) => c.id === item.handbookCategories[0]?.id);
+                    const category = handbookCategoriesById.get(item.handbookCategories[0]?.id);
                     if (category) {
                         markerCategories.add(category);
                     }
@@ -2066,9 +2078,7 @@ function Map() {
                         iconSize = [pixelWidth * scale, 24];
                     }
                 } else if (markerCategories.size === 1) {
-                    const category = handbook.handbookCategories.find(
-                        (c) => c.id === markerCategories.values().next().value.id,
-                    );
+                    const category = handbookCategoriesById.get(markerCategories.values().next().value.id);
                     iconUrl = category.imageLink;
                     markerTitle = category.name;
                     //className = 'loot-outline';
@@ -2102,9 +2112,7 @@ function Map() {
                         lootLink.append(`${lootItem.name}`);
                     }
                     popupContent.append(lootLink);
-                    const category = handbook.handbookCategories.find(
-                        (c) => c.id === lootItem.handbookCategories[0]?.id,
-                    );
+                    const category = handbookCategoriesById.get(lootItem.handbookCategories[0]?.id);
                     if (!category) {
                         continue;
                     }
@@ -2144,7 +2152,7 @@ function Map() {
             }
         }
         refreshMapSearch();
-    }, [mapData, items, handbook, addLayer, t, tMaps, getPoiLinkElement]);
+    }, [mapData, indexedItemsById, handbookCategoriesById, addLayer, t, tMaps, getPoiLinkElement]);
 
     useEffect(() => {
         if (!mapData || mapData.projection !== "interactive") {
@@ -2259,4 +2267,4 @@ function Map() {
         </div>,
     ];
 }
-export default Map;
+export default TarkovMap;


### PR DESCRIPTION
## Summary
- add a [reproducible Streets of Tarkov browser benchmark](https://github.com/troynt/tarkov-dev/pull/3#issuecomment-5294342074) for map readiness, marker rendering, long tasks, and layer hide/show performance
- index item and handbook-category data by ID to avoid repeated linear scans while constructing lock and loose-loot markers
- preserve existing loose-loot deduplication and item display ordering
- restrict the benchmark workflow to map-sensitive changes and publish a single diagnostic PR comment

## Benchmark methodology
- build the base and PR revisions in production mode
- run both revisions in one Chromium process with 2x CPU throttling and a fixed 1440x1000 viewport
- record external API and map responses during warmup, then replay identical responses with unexpected requests blocked
- alternate base/PR sample order to reduce runner drift
- collect 15 paired warm-load samples and 30 paired hide/show samples for Loose Loot, Lootable Items, and Tasks
- report median paired changes with bootstrap confidence intervals; results are diagnostic and do not fail the PR

## Workflow security
The pull request workflow has read-only permissions and uploads benchmark results as an artifact. A separate `workflow_run` workflow with pull-request write permission downloads only that artifact and updates the benchmark comment, so code from forked pull requests never receives a write token.
